### PR TITLE
Remove flow animation dependency on absolute flux value level

### DIFF
--- a/visualizations/map/src/cell.js
+++ b/visualizations/map/src/cell.js
@@ -58,6 +58,9 @@ export class Cell {
         return this._flux
     }
 
+    /**
+     * @returns {float} - maximum speed (in normal coordinates) within the cell
+     */
     get maxNormalSpeed() {
         const normalCornerSpeeds = []
         const corners = [[0, 0], [0, 1], [1, 0], [1, 1]]

--- a/visualizations/map/src/cell.js
+++ b/visualizations/map/src/cell.js
@@ -60,7 +60,7 @@ export class Cell {
 
     get maxNormalSpeed() {
         const normalCornerSpeeds = []
-        const corners = new Array([0, 0], [0, 1], [1, 0], [1, 1])
+        const corners = [[0, 0], [0, 1], [1, 0], [1, 1]]
         corners.forEach(corner => {
             const position = new Vector(corner[0], corner[1])
             const speed = this.normalVelocity(position).magnitude

--- a/visualizations/map/src/cell.js
+++ b/visualizations/map/src/cell.js
@@ -58,6 +58,17 @@ export class Cell {
         return this._flux
     }
 
+    get maxNormalSpeed() {
+        const normalCornerSpeeds = []
+        const corners = new Array([0, 0], [0, 1], [1, 0], [1, 1])
+        corners.forEach(corner => {
+            const position = new Vector(corner[0], corner[1])
+            const speed = this.normalVelocity(position).magnitude
+            normalCornerSpeeds.push(speed)
+        })
+        return Math.max(...normalCornerSpeeds.map(x => x || 0))
+    }
+
     /**
      * @returns - the jacobian of the transformation to normalized coordinates at
      *  the given coordinate.
@@ -101,7 +112,7 @@ export class Cell {
     }
 
     /**
-     * @returns {Vector} position - Normal position.
+     * @param {Vector} position - Normal position.
      * @returns {Vector} - velocity of flux, in normal coordinates.
      */
     normalVelocity(position) {

--- a/visualizations/map/src/flow_map.js
+++ b/visualizations/map/src/flow_map.js
@@ -21,6 +21,8 @@ export default class FlowMap extends Map2D {
             this._canvasNode = this._canvas.node()
         }
 
+        this.maxNormalSpeedPerLayer = this._getMaxNormalSpeed()
+
         this._setLayer(0)
         this._flowAnimation = new FlowAnimation(
             this._canvasNode,
@@ -32,7 +34,20 @@ export default class FlowMap extends Map2D {
         )
     }
 
-    _setLayer(i) {
+    _getMaxNormalSpeed() {
+        const self = this
+        const maxNormalSpeedPerLayer = []
+        this.layers.forEach(function(_, i) {
+            const cells = self._createCells(i)
+            const maxNormalSpeeds = []
+            cells.forEach(cell => {maxNormalSpeeds.push(cell.maxNormalSpeed)})
+            maxNormalSpeedPerLayer.push(Math.max(...maxNormalSpeeds))
+        })
+
+        return maxNormalSpeedPerLayer
+    }
+
+    _createCells(i) {
         const cells = []
         const self = this
         this.layers[i].forEach(cell => {
@@ -46,7 +61,12 @@ export default class FlowMap extends Map2D {
                 cell['FLOWJ+'],
             ))
         })
-        const grid = new Grid(cells)
+
+        return cells
+    }
+    _setLayer(i) {
+        const self = this
+        const grid = new Grid(this._createCells(i))
         const field = new Field(grid)
         this._particleGenerator = new ParticleGenerator(field)
     }

--- a/visualizations/map/src/linear_algebra.js
+++ b/visualizations/map/src/linear_algebra.js
@@ -73,6 +73,13 @@ export class Vector {
         return this._length
     }
 
+    /**
+     * @type {float}
+     * Magnitude of the vector (L2 norm)
+     */
+    get magnitude() {
+        return Math.sqrt(this._data.map(x => x * 2).reduce((a, b) => a + b))
+    }
 
     /**
      * @param {number} i - Index of value to get.

--- a/visualizations/map/src/linear_algebra.js
+++ b/visualizations/map/src/linear_algebra.js
@@ -78,7 +78,7 @@ export class Vector {
      * Magnitude of the vector (L2 norm)
      */
     get magnitude() {
-        return Math.sqrt(this._data.map(x => x * 2).reduce((a, b) => a + b))
+        return Math.sqrt(this._data.map(x => x ** 2).reduce((a, b) => a + b))
     }
 
     /**

--- a/visualizations/map/src/linear_algebra.spec.js
+++ b/visualizations/map/src/linear_algebra.spec.js
@@ -25,6 +25,23 @@ describe('Vector', () => {
     )
 
     jsc.property(
+        'magnitude is calculated correctly',
+        jsc.number,
+        jsc.number,
+        (_x, _y) => {
+            const vector = new Vector(_x, _y)
+            console.log("Hei")
+            console.log(_x)
+            console.log(_y)
+            console.log(vector.value(0))
+            console.log(vector.value(1))
+            console.log(Math.sqrt(_x**2 + _y**2))
+            console.log(vector.magnitude)
+            return Math.sqrt(_x**2 + _y**2) === vector.magnitude
+        },
+    )
+
+    jsc.property(
         'multiply is mapping multiplication on values',
         jsc.array(jsc.nat),
         jsc.array(jsc.nat),

--- a/visualizations/map/src/linear_algebra.spec.js
+++ b/visualizations/map/src/linear_algebra.spec.js
@@ -30,13 +30,6 @@ describe('Vector', () => {
         jsc.number,
         (_x, _y) => {
             const vector = new Vector(_x, _y)
-            console.log("Hei")
-            console.log(_x)
-            console.log(_y)
-            console.log(vector.value(0))
-            console.log(vector.value(1))
-            console.log(Math.sqrt(_x**2 + _y**2))
-            console.log(vector.magnitude)
             return Math.sqrt(_x**2 + _y**2) === vector.magnitude
         },
     )

--- a/visualizations/map/src/linear_algebra.spec.js
+++ b/visualizations/map/src/linear_algebra.spec.js
@@ -30,7 +30,7 @@ describe('Vector', () => {
         jsc.number,
         (_x, _y) => {
             const vector = new Vector(_x, _y)
-            return Math.sqrt(_x**2 + _y**2) === vector.magnitude
+            return Math.sqrt(_x * _x + _y * _y) === vector.magnitude
         },
     )
 


### PR DESCRIPTION
##### Description of Change

Resolves #102.

- Finds maximum speed (in normal coordinates) for each layer.
  - _We can then easily later let there be an independent flux normalization scale per layer when that feature is requested. This option, together with e.g. interactive setting of cut-off value, could be future enhancement of the map GUI, enabling more data exploration._
- Fluxes are normalized based on global maximum non-normalized speed in input data.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and it is linked to an issue
- [x] `make test` and `make lint` passes
- [x] tests are changed or added