### PR TITLE
Hardcode most variables in config.py instead of using environment

### DIFF
--- a/backend/src/fastapi_app/config.py
+++ b/backend/src/fastapi_app/config.py
@@ -1,25 +1,36 @@
 import os
 from dotenv import load_dotenv
 
+# Import these from sumo wrapper package in order to grab the resource scopes
+from sumo.wrapper.config import APP_REGISTRATION as sumo_app_reg
+
 # Load environment variables from .env file
 # Note that values set in the system environment will override those in the .env file
 load_dotenv()
 
-TENANT_ID = os.environ["WEBVIZ_TENANT_ID"]
-CLIENT_ID = os.environ["WEBVIZ_CLIENT_ID"]
+
+TENANT_ID = "3aa4a235-b6e2-48d5-9195-7fcf05b459b0"
+CLIENT_ID = "900ed417-a860-4970-bd37-73b059ca6f0d"
+
 CLIENT_SECRET = os.environ["WEBVIZ_CLIENT_SECRET"]
-SUMO_RESOURCE_SCOPE = os.environ["WEBVIZ_SUMO_RESOURCE_SCOPE"]
-SMDA_RESOURCE_SCOPE = os.environ["WEBVIZ_SMDA_RESOURCE_SCOPE"]
+
+
+GRAPH_SCOPES = ["User.Read"]
+
+RESOURCE_SCOPES_DICT = {
+    "sumo": [f"api://{sumo_app_reg['prod']['RESOURCE_ID']}/access_as_user"],
+}
+
+# Since we are not using SMDA yet, leave it as optional
+SMDA_RESOURCE_SCOPE = os.environ.get("WEBVIZ_SMDA_RESOURCE_SCOPE")
+if SMDA_RESOURCE_SCOPE is not None:
+    RESOURCE_SCOPES_DICT["smda"] = [SMDA_RESOURCE_SCOPE]
+
+print(f"{RESOURCE_SCOPES_DICT=}")
+
 
 # Allow None her for now, since we don't always run with redis and a password
 # REDIS_PASSWORD: str = os.environ.get("WEBVIZ_REDIS_PASSWORD")
-
-GRAPH_SCOPES = ["User.Read"]
-RESOURCE_SCOPES_DICT = {
-    "sumo": [SUMO_RESOURCE_SCOPE],
-    "smda": [SMDA_RESOURCE_SCOPE],
-}
-
 
 # Format: redis://[[username]:[password]]@localhost:6379/0
 # REDIS_URL = "redis://localhost"

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -20,8 +20,5 @@ services:
       - 5000:5000
     environment:
       - UVICORN_WORKERS=4
-      - WEBVIZ_TENANT_ID
-      - WEBVIZ_CLIENT_ID
       - WEBVIZ_CLIENT_SECRET
-      - WEBVIZ_SUMO_RESOURCE_SCOPE
       - WEBVIZ_SMDA_RESOURCE_SCOPE

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,10 +24,7 @@ services:
       - 5000:5000
     environment:
       - UVICORN_RELOAD=true
-      - WEBVIZ_TENANT_ID
-      - WEBVIZ_CLIENT_ID
       - WEBVIZ_CLIENT_SECRET
-      - WEBVIZ_SUMO_RESOURCE_SCOPE
       - WEBVIZ_SMDA_RESOURCE_SCOPE
     volumes:
       - ./backend/src:/home/appuser/backend/src

--- a/radixconfig.yml
+++ b/radixconfig.yml
@@ -27,14 +27,8 @@ spec:
         azureKeyVaults:
           - name: webviz
             items:
-              - name: WEBVIZ-TENANT-ID
-                envVar: WEBVIZ_TENANT_ID
-              - name: WEBVIZ-CLIENT-ID
-                envVar: WEBVIZ_CLIENT_ID
               - name: WEBVIZ-CLIENT-SECRET
                 envVar: WEBVIZ_CLIENT_SECRET
-              - name: WEBVIZ-SUMO-RESOURCE-SCOPE
-                envVar: WEBVIZ_SUMO_RESOURCE_SCOPE
               - name: WEBVIZ-SMDA-RESOURCE-SCOPE
                 envVar: WEBVIZ_SMDA_RESOURCE_SCOPE
       environmentConfig:


### PR DESCRIPTION
Hardcode most variables in config.py instead of using environment variables.
Done in preparation for testing against new SUMO data and new sumo explorer where we will have to temporarily switch to SUMO dev service.
Also, there should be no need for keeping `TENANT_ID` and `CLIENT_ID` secret.
Not so clear on the scope resouce IDs, but for now, work around it by grabbing the SUMO resource ID from sumo wrapper package. The SMDA resource ID is still read from the environment, but note that it is currently not being used.