### PR TITLE
Incorporate new version of Sumo Explorer for SMRy data

### DIFF
--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -641,7 +641,7 @@ test = ["anyio[trio] (>=3.2.1,<4.0.0)", "black (==22.10.0)", "coverage[toml] (>=
 
 [[package]]
 name = "fmu-sumo"
-version = "0.2.5.dev6+gf84a32c"
+version = "0.2.5.dev15+ge6f26a6"
 description = "Python package for interacting with Sumo in an FMU setting"
 category = "main"
 optional = false
@@ -666,8 +666,8 @@ tests = ["pytest (>=6.1.1)"]
 [package.source]
 type = "git"
 url = "https://github.com/equinor/fmu-sumo.git"
-reference = "f84a32cddfa624550615311d91d829f28ec9877e"
-resolved_reference = "f84a32cddfa624550615311d91d829f28ec9877e"
+reference = "e6f26a6466ba33139522b49f1456c4c561f349ad"
+resolved_reference = "e6f26a6466ba33139522b49f1456c4c561f349ad"
 
 [[package]]
 name = "fonttools"
@@ -2333,4 +2333,4 @@ tests = ["hypothesis", "pytest", "pytest-benchmark", "pytest-mock", "pytest-snap
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "071949cd0e7d94021572d7aa32ebeb4146fc489d92ff579a2d330ac6c3053dae"
+content-hash = "248478baadb3800914c1740852ecca543f26ccdd9abd5b184b8cc29858db0b36"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -19,7 +19,7 @@ pyjwt = "^2.6.0"
 pydantic = "^1.10.4"
 numpy = "^1.24.1"
 sumo-wrapper-python = {git = "https://github.com/equinor/sumo-wrapper-python.git", rev = "master"}
-fmu-sumo = {git = "https://github.com/equinor/fmu-sumo.git", rev = "f84a32cddfa624550615311d91d829f28ec9877e"}
+fmu-sumo = {git = "https://github.com/equinor/fmu-sumo.git", rev = "e6f26a6466ba33139522b49f1456c4c561f349ad"}
 
 
 [tool.poetry.group.dev.dependencies]

--- a/backend/src/fastapi_app/config.py
+++ b/backend/src/fastapi_app/config.py
@@ -18,7 +18,10 @@ CLIENT_SECRET = os.environ["WEBVIZ_CLIENT_SECRET"]
 GRAPH_SCOPES = ["User.Read"]
 
 RESOURCE_SCOPES_DICT = {
-    "sumo": [f"api://{sumo_app_reg['prod']['RESOURCE_ID']}/access_as_user"],
+    #"sumo": [f"api://{sumo_app_reg['prod']['RESOURCE_ID']}/access_as_user"],
+
+    # Note that when switching back to prod, SUMO env in create_sumo_client_instance() must also be changed
+    "sumo": [f"api://{sumo_app_reg['dev']['RESOURCE_ID']}/access_as_user"],
 }
 
 # Since we are not using SMDA yet, leave it as optional

--- a/backend/src/fastapi_app/routers/explore.py
+++ b/backend/src/fastapi_app/routers/explore.py
@@ -34,11 +34,14 @@ async def get_cases(
     print(case_info_arr)
 
     # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-    # Note hard-coded to a single (working) sumo case on DROGON for now
+    # Sumo Explorer + Drogon + SMRY data is still a work in progress!
+    # Present the single DROGON case that we know to be good as the first item, also prefixing it with "GOOD"
     ret_arr: List[Case] = []
     if field_identifier == "DROGON":
         for ci in case_info_arr:
-            if ci.uuid == "0db5f2dd-aa62-407f-9ac4-0dbbe30371a2":
+            if ci.uuid == "10f41041-2c17-4374-a735-bb0de62e29dc":
+                ret_arr.insert(0, Case(uuid=ci.uuid, name=f"GOOD -- {ci.name}"))
+            else:
                 ret_arr.append(Case(uuid=ci.uuid, name=ci.name))
     else:
         ret_arr = [Case(uuid=ci.uuid, name=ci.name) for ci in case_info_arr]

--- a/backend/src/fastapi_app/routers/timeseries/converters.py
+++ b/backend/src/fastapi_app/routers/timeseries/converters.py
@@ -1,6 +1,7 @@
 from typing import List, Optional, Sequence
 
 from ....services.summary_vector_statistics import StatisticFunction, VectorStatistics
+from ....services.sumo_access.summary_access import VectorMetadata
 from . import schemas
 
 
@@ -23,7 +24,7 @@ def to_service_statistic_functions(
     return service_stat_funcs
 
 
-def to_api_vector_statistic_data(vector_statistics: VectorStatistics) -> schemas.VectorStatisticData:
+def to_api_vector_statistic_data(vector_statistics: VectorStatistics, vector_metadata: VectorMetadata) -> schemas.VectorStatisticData:
     """
     Create API VectorStatisticData from service layer VectorStatistics
     """
@@ -39,6 +40,8 @@ def to_api_vector_statistic_data(vector_statistics: VectorStatistics) -> schemas
         realizations=vector_statistics.realizations,
         timestamps=vector_statistics.timestamps,
         value_objects=value_objects,
+        unit=vector_metadata.unit,
+        is_rate=vector_metadata.is_rate,
     )
 
     return ret_data

--- a/backend/src/fastapi_app/routers/timeseries/router.py
+++ b/backend/src/fastapi_app/routers/timeseries/router.py
@@ -56,7 +56,7 @@ async def get_realizations_vector_data(
 
     ret_arr: List[schemas.VectorRealizationData] = []
     for vec in sumo_vec_arr:
-        ret_arr.append(schemas.VectorRealizationData(realization=vec.realization, timestamps=vec.timestamps, values=vec.values))
+        ret_arr.append(schemas.VectorRealizationData(realization=vec.realization, timestamps=vec.timestamps, values=vec.values, unit=vec.metadata.unit, is_rate=vec.metadata.is_rate))
 
     return ret_arr
 
@@ -123,12 +123,13 @@ async def get_statistical_vector_data(
     service_freq = Frequency.from_string_value(resampling_frequency.value)
     service_stat_funcs_to_compute = converters.to_service_statistic_functions(statistic_functions)
 
-    vector_table = access.get_vector_table(vector_name=vector_name, resampling_frequency=service_freq, realizations=realizations)
+    vector_table, vector_metadata = access.get_vector_table(vector_name=vector_name, resampling_frequency=service_freq, realizations=realizations)
+
     statistics = compute_vector_statistics(vector_table, vector_name, service_stat_funcs_to_compute)
     if not statistics:
         raise HTTPException(status_code=404, detail="Could not compute statistics")
 
-    ret_data: schemas.VectorStatisticData = converters.to_api_vector_statistic_data(statistics)
+    ret_data: schemas.VectorStatisticData = converters.to_api_vector_statistic_data(statistics, vector_metadata)
 
     return ret_data
 

--- a/backend/src/fastapi_app/routers/timeseries/schemas.py
+++ b/backend/src/fastapi_app/routers/timeseries/schemas.py
@@ -53,8 +53,8 @@ class VectorRealizationData(BaseModel):
     realization: int
     timestamps: List[datetime.datetime]
     values: List[float]
-    # unit: str
-    # is_rate: bool
+    unit: str
+    is_rate: bool
 
 
 class StatisticValueObject(BaseModel):
@@ -66,8 +66,8 @@ class VectorStatisticData(BaseModel):
     realizations: List[int]
     timestamps: List[datetime.datetime]
     value_objects: List[StatisticValueObject]
-    # unit: str
-    # is_rate: bool
+    unit: str
+    is_rate: bool
 
 
 class VectorExpressionInfo(BaseModel):

--- a/backend/src/services/summary_vector_statistics.py
+++ b/backend/src/services/summary_vector_statistics.py
@@ -31,7 +31,6 @@ class VectorStatistics(BaseModel):
     realizations: List[int]
     timestamps: List[datetime.datetime]
     values_dict: Dict[StatisticFunction, List[float]]
-    metadata: Optional[VectorMetadata]  # Must be optional until SUMO delivers arrow tables with metadata
 
 
 def compute_vector_statistics_table(

--- a/backend/src/services/sumo_access/_arrow_helpers.py
+++ b/backend/src/services/sumo_access/_arrow_helpers.py
@@ -1,5 +1,10 @@
 import pyarrow as pa
 
+
+def sort_table_on_real_then_date(table: pa.Table) -> pa.Table:
+    return table.sort_by([("REAL", "ascending"), ("DATE", "ascending")])
+
+
 def create_float_downcasting_schema(schema: pa.Schema) -> pa.Schema:
     dt_float64 = pa.float64()
     dt_float32 = pa.float32()

--- a/backend/src/services/sumo_access/_helpers.py
+++ b/backend/src/services/sumo_access/_helpers.py
@@ -1,26 +1,8 @@
-from dataclasses import dataclass
-from typing import Optional, List
 from sumo.wrapper import SumoClient
 
-SUMO_ENV="prod"
+#SUMO_ENV="prod"
+SUMO_ENV="dev"
 
 def create_sumo_client_instance(access_token: str) -> SumoClient:
     sumo_client = SumoClient(env=SUMO_ENV, token=access_token, interactive=False)
     return sumo_client
-
-
-@dataclass(frozen=True)
-class IterSpec:
-    case_uuid: str
-    iteration_id: int
-    iteration_name: str
-
-def encode_iteration_pseudo_uuid(iter_spec: IterSpec) -> str:
-    return f"{iter_spec.iteration_id}~{iter_spec.iteration_name}~{iter_spec.case_uuid}"
-
-def decode_iteration_pseudo_uuid(iteration_pseudo_uuid: str) -> Optional[IterSpec]:
-    str_arr: List[str] = iteration_pseudo_uuid.split("~")
-    if len(str_arr) != 3:
-        return None
-
-    return IterSpec(iteration_id=int(str_arr[0]), iteration_name=str_arr[1], case_uuid=str_arr[2])

--- a/backend/src/services/sumo_access/dev_sumo_access_test_driver.py
+++ b/backend/src/services/sumo_access/dev_sumo_access_test_driver.py
@@ -14,14 +14,16 @@ def main() -> None:
     print("## Running dev_sumo_access_test_driver")
     print("## =================================================")
 
-    dummy_sumo_client = SumoClient("prod")
+    #dummy_sumo_client = SumoClient("prod")
+    dummy_sumo_client = SumoClient("dev")
     access_token = dummy_sumo_client._retrieve_token()
 
     explore = SumoExplore(access_token=access_token)
     cases = explore.get_cases(field_identifier="DROGON")
     print(cases)
 
-    sumo_case_id = "0db5f2dd-aa62-407f-9ac4-0dbbe30371a2"
+    #sumo_case_id = "0db5f2dd-aa62-407f-9ac4-0dbbe30371a2"
+    sumo_case_id = "10f41041-2c17-4374-a735-bb0de62e29dc"
     sumo_case_name = None
     for case_info in cases:
         if case_info.uuid == sumo_case_id:
@@ -43,21 +45,21 @@ def main() -> None:
     print("\n\n")
     print(vector_names)
 
-    vector_table = summary_access.get_vector_table(vector_name="FOPT", resampling_frequency=None, realizations=None)
+    vector_table, vector_meta = summary_access.get_vector_table(vector_name="FOPT", resampling_frequency=None, realizations=None)
     print("\n\nRAW")
     print(vector_table.shape)
 
-    vector_table = summary_access.get_vector_table(vector_name="FOPT", resampling_frequency=Frequency.DAILY, realizations=None)
+    vector_table, vector_meta = summary_access.get_vector_table(vector_name="FOPT", resampling_frequency=Frequency.DAILY, realizations=None)
     print("\n\nDAILY")
     print(vector_table.shape)
 
-    vector_table = summary_access.get_vector_table(vector_name="FOPT", resampling_frequency=Frequency.YEARLY, realizations=None)
+    vector_table, vector_meta = summary_access.get_vector_table(vector_name="FOPT", resampling_frequency=Frequency.YEARLY, realizations=None)
     print("\n\nYEARLY")
     print(vector_table)
     print(vector_table.shape)
 
     print("\n\nYEARLY - only real 0")
-    vector_table = summary_access.get_vector_table(vector_name="FOPT", resampling_frequency=Frequency.YEARLY, realizations=[0])
+    vector_table, vector_meta = summary_access.get_vector_table(vector_name="FOPT", resampling_frequency=Frequency.YEARLY, realizations=[0])
     vector_table = vector_table.filter(pa.compute.equal(vector_table["REAL"], 0))
     print(vector_table)
     print(vector_table.shape)
@@ -70,7 +72,7 @@ def main() -> None:
 
 
     print("\n\nYEARLY")
-    vector_table = summary_access.get_vector_table(vector_name="FOPT", resampling_frequency=Frequency.YEARLY, realizations=None)
+    vector_table, vector_meta = summary_access.get_vector_table(vector_name="FOPT", resampling_frequency=Frequency.YEARLY, realizations=None)
     print(vector_table)
 
     print("\n\nSTATS table")

--- a/backend/src/services/sumo_access/sumo_explore.py
+++ b/backend/src/services/sumo_access/sumo_explore.py
@@ -4,7 +4,6 @@ from pydantic import BaseModel
 from fmu.sumo.explorer.explorer import CaseCollection, SumoClient
 
 from ._helpers import create_sumo_client_instance
-from ._helpers import encode_iteration_pseudo_uuid, IterSpec
 
 
 class CaseInfo(BaseModel):
@@ -12,7 +11,6 @@ class CaseInfo(BaseModel):
     name: str
 
 class IterationInfo(BaseModel):
-    pseudo_uuid: str
     name: str
 
 
@@ -25,23 +23,21 @@ class SumoExplore:
 
         case_info_arr: List[CaseInfo] = []
         for case in case_collection:
-            case_info_arr.append(CaseInfo(uuid=case.id, name=case.name))
+            case_info_arr.append(CaseInfo(uuid=case.uuid, name=case.name))
 
         return case_info_arr
 
     def get_iterations(self, case_uuid: str) -> List[IterationInfo]:
-        case_collection = CaseCollection(self._sumo_client).filter(id=case_uuid)
+        case_collection = CaseCollection(self._sumo_client).filter(uuid=case_uuid)
         if len(case_collection) != 1:
             raise ValueError(f"Sumo case not found {case_uuid=}")
 
         case = case_collection[0]
+
         iterations = case.iterations
         iter_info_arr: List[IterationInfo] = []
         for it in iterations:
-            iteration_id = it.get("id")
             iteration_name = it.get("name")
-            iteration_addr = IterSpec(case_uuid=case_uuid, iteration_id=iteration_id, iteration_name=iteration_name)
-            pseudo_iteration_uuid = encode_iteration_pseudo_uuid(iteration_addr)
-            iter_info_arr.append(IterationInfo(pseudo_uuid=pseudo_iteration_uuid, name=iteration_name))
+            iter_info_arr.append(IterationInfo(name=iteration_name))
 
         return iter_info_arr

--- a/backend/src/services/sumo_access/types.py
+++ b/backend/src/services/sumo_access/types.py
@@ -33,10 +33,10 @@ class RealizationVector(BaseModel):
     realization: int
     timestamps: List[datetime.datetime]
     values: List[float]
-    metadata: Optional[VectorMetadata]  # Must be optional until SUMO delivers arrow tables with metadata
+    metadata: VectorMetadata
 
 
 class HistoricalVector(BaseModel):
     timestamps: List[datetime.datetime]
     values: List[float]
-    metadata: Optional[VectorMetadata]  # Must be optional until SUMO delivers arrow tables with metadata
+    metadata: VectorMetadata

--- a/frontend/src/api/models/VectorRealizationData.ts
+++ b/frontend/src/api/models/VectorRealizationData.ts
@@ -6,5 +6,7 @@ export type VectorRealizationData = {
     realization: number;
     timestamps: Array<string>;
     values: Array<number>;
+    unit: string;
+    is_rate: boolean;
 };
 

--- a/frontend/src/api/models/VectorStatisticData.ts
+++ b/frontend/src/api/models/VectorStatisticData.ts
@@ -8,5 +8,7 @@ export type VectorStatisticData = {
     realizations: Array<number>;
     timestamps: Array<string>;
     value_objects: Array<StatisticValueObject>;
+    unit: string;
+    is_rate: boolean;
 };
 


### PR DESCRIPTION
First try at using new Sumo Explorer that supports split tables for SMRY data.
Hard-coded new Drogon test case that plays nice with the new  Sumo Explorer.
Note that the new test case is only available in Sumo's dev environment!