### PR TITLE
Add tags when mounting routers

### DIFF
--- a/backend/src/fastapi_app/main.py
+++ b/backend/src/fastapi_app/main.py
@@ -6,12 +6,12 @@ from fastapi.routing import APIRoute
 from starsessions import SessionMiddleware
 from starsessions.stores.redis import RedisStore
 
-from .routers.explore import router as explore_router
-from .routers.timeseries.router import router as timeseries_router
-from .routers.general import router as general_router
+from . import config
 from .auth.auth_helper import AuthHelper
 from .auth.enforce_logged_in_middleware import EnforceLoggedInMiddleware
-from . import config
+from .routers.explore import router as explore_router
+from .routers.general import router as general_router
+from .routers.timeseries.router import router as timeseries_router
 
 logging.basicConfig(
     level=logging.WARNING, format="%(asctime)s %(levelname)-3s [%(name)s]: %(message)s", datefmt="%H:%M:%S"
@@ -25,8 +25,10 @@ def custom_generate_unique_id(route: APIRoute):
 
 app = FastAPI(generate_unique_id_function=custom_generate_unique_id, root_path="/api")
 
-app.include_router(explore_router)
-app.include_router(timeseries_router, prefix="/timeseries")
+# The tags we add here will determine the name of the frontend api service for our endpoints as well as
+# providing some grouping when viewing the openapi documentation.
+app.include_router(explore_router, tags=["explore"])
+app.include_router(timeseries_router, prefix="/timeseries", tags=["timeseries"])
 
 authHelper = AuthHelper()
 app.include_router(authHelper.router)

--- a/backend/src/fastapi_app/routers/explore.py
+++ b/backend/src/fastapi_app/routers/explore.py
@@ -1,14 +1,11 @@
 from typing import List
 
-from fastapi import APIRouter, Query, Path, Depends
+from fastapi import APIRouter, Depends, Path, Query
 from pydantic import BaseModel
 
 from ...services.sumo_access.sumo_explore import SumoExplore
 from ...services.utils.authenticated_user import AuthenticatedUser
-from ...services.utils.perf_timer import PerfTimer
-
 from ..auth.auth_helper import AuthHelper
-
 
 router = APIRouter()
 
@@ -22,7 +19,7 @@ class Ensemble(BaseModel):
     name: str
 
 
-@router.get("/cases", tags=["explore"])
+@router.get("/cases")
 async def get_cases(
     authenticated_user: AuthenticatedUser = Depends(AuthHelper.get_authenticated_user),
     field_identifier: str = Query(description="Field identifier"),
@@ -49,7 +46,7 @@ async def get_cases(
     return ret_arr
 
 
-@router.get("/cases/{case_uuid}/ensembles", tags=["explore"])
+@router.get("/cases/{case_uuid}/ensembles")
 async def get_ensembles(
     authenticated_user: AuthenticatedUser = Depends(AuthHelper.get_authenticated_user),
     case_uuid: str = Path(description="Sumo case uuid"),

--- a/backend/src/fastapi_app/routers/timeseries/router.py
+++ b/backend/src/fastapi_app/routers/timeseries/router.py
@@ -17,7 +17,7 @@ LOGGER = logging.getLogger(__name__)
 router = APIRouter()
 
 
-@router.get("/vector_names_and_description/", tags=["timeseries"])
+@router.get("/vector_names_and_description/")
 async def get_vector_names_and_descriptions(
     # fmt:off
     authenticated_user: AuthenticatedUser = Depends(AuthHelper.get_authenticated_user),
@@ -39,7 +39,7 @@ async def get_vector_names_and_descriptions(
     return ret_arr
 
 
-@router.get("/realizations_vector_data/", tags=["timeseries"])
+@router.get("/realizations_vector_data/")
 async def get_realizations_vector_data(
     # fmt:off
     authenticated_user: AuthenticatedUser = Depends(AuthHelper.get_authenticated_user),
@@ -65,7 +65,7 @@ async def get_realizations_vector_data(
     return ret_arr
 
 
-@router.get("/vector_metadata/", tags=["timeseries"])
+@router.get("/vector_metadata/")
 async def get_vector_metadata(
     authenticated_user: AuthenticatedUser = Depends(AuthHelper.get_authenticated_user),
     case_uuid: str = Query(description="Sumo case uuid"),
@@ -78,7 +78,7 @@ async def get_vector_metadata(
     ...
 
 
-@router.get("/timestamps/", tags=["timeseries"])
+@router.get("/timestamps/")
 async def get_timestamps(
     authenticated_user: AuthenticatedUser = Depends(AuthHelper.get_authenticated_user),
     case_uuid: str = Query(description="Sumo case uuid"),
@@ -96,7 +96,7 @@ async def get_timestamps(
     ...
 
 
-@router.get("/historical_vector_data/", tags=["timeseries"])
+@router.get("/historical_vector_data/")
 async def get_historical_vector_data(
     authenticated_user: AuthenticatedUser = Depends(AuthHelper.get_authenticated_user),
     case_uuid: str = Query(description="Sumo case uuid"),
@@ -107,7 +107,7 @@ async def get_historical_vector_data(
     ...
 
 
-@router.get("/statistical_vector_data/", tags=["timeseries"])
+@router.get("/statistical_vector_data/")
 async def get_statistical_vector_data(
     # fmt:off
     authenticated_user: AuthenticatedUser = Depends(AuthHelper.get_authenticated_user),
@@ -138,7 +138,7 @@ async def get_statistical_vector_data(
     return ret_data
 
 
-@router.get("/realizations_calculated_vector_data/", tags=["timeseries"])
+@router.get("/realizations_calculated_vector_data/")
 async def get_realizations_calculated_vector_data(
     authenticated_user: AuthenticatedUser = Depends(AuthHelper.get_authenticated_user),
     case_uuid: str = Query(description="Sumo case uuid"),
@@ -153,7 +153,7 @@ async def get_realizations_calculated_vector_data(
     return "hei"
 
 
-# @router.get("/statistical_calculated_vector_data/", tags=["timeseries"])
+# @router.get("/statistical_calculated_vector_data/")
 # async def get_statistical_calculated_vector_data(
 #     authenticated_user: AuthenticatedUser = Depends(AuthHelper.get_authenticated_user),
 #     sumo_case_id: str = Query(None, description="Sumo case id"),


### PR DESCRIPTION
For now, add tags when mounting routers instead of specifying it per endpoint.
Makes sense since we're only using them on a per router basis anyway
