### PR TITLE
Removed async keyword from fastapi routes

### DIFF
--- a/backend/src/fastapi_app/routers/explore.py
+++ b/backend/src/fastapi_app/routers/explore.py
@@ -24,12 +24,15 @@ class Ensemble(BaseModel):
 
 
 @router.get("/fields")
-def get_fields(
-    authenticated_user: AuthenticatedUser = Depends(AuthHelper.get_authenticated_user)
-) -> List[Field]:
-    """Get list of fields"""
-
-    ret_arr = [Field(field_identifier="DROGON"), Field(field_identifier="JOHAN SVERDRUP"), Field(field_identifier="DUMMY_FIELD")]
+def get_fields(authenticated_user: AuthenticatedUser = Depends(AuthHelper.get_authenticated_user)) -> List[Field]:
+    """
+    Get list of fields
+    """
+    ret_arr = [
+        Field(field_identifier="DROGON"),
+        Field(field_identifier="JOHAN SVERDRUP"),
+        Field(field_identifier="DUMMY_FIELD"),
+    ]
     return ret_arr
 
 

--- a/backend/src/fastapi_app/routers/explore.py
+++ b/backend/src/fastapi_app/routers/explore.py
@@ -10,6 +10,10 @@ from ..auth.auth_helper import AuthHelper
 router = APIRouter()
 
 
+class Field(BaseModel):
+    field_identifier: str
+
+
 class Case(BaseModel):
     uuid: str
     name: str
@@ -19,8 +23,18 @@ class Ensemble(BaseModel):
     name: str
 
 
+@router.get("/fields")
+def get_fields(
+    authenticated_user: AuthenticatedUser = Depends(AuthHelper.get_authenticated_user)
+) -> List[Field]:
+    """Get list of fields"""
+
+    ret_arr = [Field(field_identifier="DROGON"), Field(field_identifier="JOHAN SVERDRUP"), Field(field_identifier="DUMMY_FIELD")]
+    return ret_arr
+
+
 @router.get("/cases")
-async def get_cases(
+def get_cases(
     authenticated_user: AuthenticatedUser = Depends(AuthHelper.get_authenticated_user),
     field_identifier: str = Query(description="Field identifier"),
 ) -> List[Case]:
@@ -48,7 +62,7 @@ async def get_cases(
 
 
 @router.get("/cases/{case_uuid}/ensembles")
-async def get_ensembles(
+def get_ensembles(
     authenticated_user: AuthenticatedUser = Depends(AuthHelper.get_authenticated_user),
     case_uuid: str = Path(description="Sumo case uuid"),
 ) -> List[Ensemble]:

--- a/backend/src/fastapi_app/routers/general.py
+++ b/backend/src/fastapi_app/routers/general.py
@@ -1,9 +1,9 @@
 import datetime
 import logging
 
-from pydantic import BaseModel
-from fastapi import APIRouter, HTTPException, Request, status
 import starsessions
+from fastapi import APIRouter, HTTPException, Request, status
+from pydantic import BaseModel
 
 from ..auth.auth_helper import AuthHelper
 

--- a/backend/src/fastapi_app/routers/inplace_volumetrics/router.py
+++ b/backend/src/fastapi_app/routers/inplace_volumetrics/router.py
@@ -18,7 +18,7 @@ router = APIRouter()
 
 
 @router.get("/table_names_and_descriptions/", tags=["inplace_volumetrics"])
-async def get_table_names_and_descriptions(
+def get_table_names_and_descriptions(
     # fmt:off
     authenticated_user: AuthenticatedUser = Depends(AuthHelper.get_authenticated_user),
     case_uuid: str = Query(description="Sumo case uuid"),
@@ -33,7 +33,7 @@ async def get_table_names_and_descriptions(
 
 
 @router.post("/realizations_response/", tags=["inplace_volumetrics"])
-async def get_realizations_response(
+def get_realizations_response(
     # fmt:off
     authenticated_user: AuthenticatedUser = Depends(AuthHelper.get_authenticated_user),
     case_uuid: str = Query(description="Sumo case uuid"),
@@ -75,7 +75,7 @@ async def get_realizations_response(
 
 
 # @router.get("/statistic_response/", tags=["inplace_volumetrics"])
-# async def get_statistic_response(
+# def get_statistic_response(
 #     # fmt:off
 #     authenticated_user: AuthenticatedUser = Depends(AuthHelper.get_authenticated_user),
 #     case_uuid: str = Query(description="Sumo case uuid"),

--- a/backend/src/fastapi_app/routers/timeseries/router.py
+++ b/backend/src/fastapi_app/routers/timeseries/router.py
@@ -18,7 +18,7 @@ router = APIRouter()
 
 
 @router.get("/vector_names_and_description/")
-async def get_vector_names_and_descriptions(
+def get_vector_names_and_descriptions(
     # fmt:off
     authenticated_user: AuthenticatedUser = Depends(AuthHelper.get_authenticated_user),
     case_uuid: str = Query(description="Sumo case uuid"),
@@ -40,7 +40,7 @@ async def get_vector_names_and_descriptions(
 
 
 @router.get("/realizations_vector_data/")
-async def get_realizations_vector_data(
+def get_realizations_vector_data(
     # fmt:off
     authenticated_user: AuthenticatedUser = Depends(AuthHelper.get_authenticated_user),
     case_uuid: str = Query(description="Sumo case uuid"),
@@ -66,7 +66,7 @@ async def get_realizations_vector_data(
 
 
 @router.get("/vector_metadata/")
-async def get_vector_metadata(
+def get_vector_metadata(
     authenticated_user: AuthenticatedUser = Depends(AuthHelper.get_authenticated_user),
     case_uuid: str = Query(description="Sumo case uuid"),
     ensemble_name: str = Query(description="Ensemble name"),
@@ -79,7 +79,7 @@ async def get_vector_metadata(
 
 
 @router.get("/timestamps/")
-async def get_timestamps(
+def get_timestamps(
     authenticated_user: AuthenticatedUser = Depends(AuthHelper.get_authenticated_user),
     case_uuid: str = Query(description="Sumo case uuid"),
     ensemble_name: str = Query(description="Ensemble name"),
@@ -97,7 +97,7 @@ async def get_timestamps(
 
 
 @router.get("/historical_vector_data/")
-async def get_historical_vector_data(
+def get_historical_vector_data(
     authenticated_user: AuthenticatedUser = Depends(AuthHelper.get_authenticated_user),
     case_uuid: str = Query(description="Sumo case uuid"),
     non_historical_vector_name: str = Query(description="Name of the non-historical vector"),
@@ -108,7 +108,7 @@ async def get_historical_vector_data(
 
 
 @router.get("/statistical_vector_data/")
-async def get_statistical_vector_data(
+def get_statistical_vector_data(
     # fmt:off
     authenticated_user: AuthenticatedUser = Depends(AuthHelper.get_authenticated_user),
     case_uuid: str = Query(description="Sumo case uuid"),
@@ -139,7 +139,7 @@ async def get_statistical_vector_data(
 
 
 @router.get("/realizations_calculated_vector_data/")
-async def get_realizations_calculated_vector_data(
+def get_realizations_calculated_vector_data(
     authenticated_user: AuthenticatedUser = Depends(AuthHelper.get_authenticated_user),
     case_uuid: str = Query(description="Sumo case uuid"),
     ensemble_name: str = Query(description="Ensemble name"),
@@ -154,7 +154,7 @@ async def get_realizations_calculated_vector_data(
 
 
 # @router.get("/statistical_calculated_vector_data/")
-# async def get_statistical_calculated_vector_data(
+# def get_statistical_calculated_vector_data(
 #     authenticated_user: AuthenticatedUser = Depends(AuthHelper.get_authenticated_user),
 #     sumo_case_id: str = Query(None, description="Sumo case id"),
 #     sumo_iteration_id: str = Query(None, description="Sumo iteration id"),

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -12,6 +12,7 @@ export type { OpenAPIConfig } from './core/OpenAPI';
 export type { Body_get_realizations_response } from './models/Body_get_realizations_response';
 export type { Case } from './models/Case';
 export type { Ensemble } from './models/Ensemble';
+export type { Field } from './models/Field';
 export { Frequency } from './models/Frequency';
 export type { HTTPValidationError } from './models/HTTPValidationError';
 export type { InplaceVolumetricsCategoricalMetaData } from './models/InplaceVolumetricsCategoricalMetaData';

--- a/frontend/src/api/models/Field.ts
+++ b/frontend/src/api/models/Field.ts
@@ -1,0 +1,8 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type Field = {
+    field_identifier: string;
+};
+

--- a/frontend/src/api/services/ExploreService.ts
+++ b/frontend/src/api/services/ExploreService.ts
@@ -3,6 +3,7 @@
 /* eslint-disable */
 import type { Case } from '../models/Case';
 import type { Ensemble } from '../models/Ensemble';
+import type { Field } from '../models/Field';
 
 import type { CancelablePromise } from '../core/CancelablePromise';
 import type { BaseHttpRequest } from '../core/BaseHttpRequest';
@@ -10,6 +11,19 @@ import type { BaseHttpRequest } from '../core/BaseHttpRequest';
 export class ExploreService {
 
     constructor(public readonly httpRequest: BaseHttpRequest) {}
+
+    /**
+     * Get Fields
+     * Get list of fields
+     * @returns Field Successful Response
+     * @throws ApiError
+     */
+    public getFields(): CancelablePromise<Array<Field>> {
+        return this.httpRequest.request({
+            method: 'GET',
+            url: '/fields',
+        });
+    }
 
     /**
      * Get Cases


### PR DESCRIPTION
Removed async keyword from routes until we're actually using async functions.
Added mocked /fields route