### PR TITLE
Allow selection of ensemble in top nav bar

### DIFF
--- a/frontend/src/framework/Workbench.ts
+++ b/frontend/src/framework/Workbench.ts
@@ -173,8 +173,11 @@ export class Workbench {
         this._workbenchServices.publishNavigatorData("navigator.fieldName", fieldName);
     }
 
-    // Temporary, for testing
     public setNavigatorCaseId(caseId: string) {
         this._workbenchServices.publishNavigatorData("navigator.caseId", caseId);
+    }
+
+    public setNavigatorEnsembles(ensemblesArr: { caseUuid: string; caseName: string; ensembleName: string }[]) {
+        this._workbenchServices.publishNavigatorData("navigator.ensembles", ensemblesArr);
     }
 }

--- a/frontend/src/framework/WorkbenchServices.ts
+++ b/frontend/src/framework/WorkbenchServices.ts
@@ -7,6 +7,7 @@ import { Workbench } from "./Workbench";
 export type NavigatorTopicDefinitions = {
     "navigator.fieldName": string;
     "navigator.caseId": string;
+    "navigator.ensembles": { caseUuid: string; caseName: string; ensembleName: string }[];
 };
 
 export type GlobalTopicDefinitions = {

--- a/frontend/src/framework/components/TopNavBar/topNavBar.tsx
+++ b/frontend/src/framework/components/TopNavBar/topNavBar.tsx
@@ -19,9 +19,9 @@ type TopNavBarProps = {
 
 export const TopNavBar: React.FC<TopNavBarProps> = (props) => {
     const activeModuleName = ""; // useWorkbenchActiveModuleName();
-    const [selectedField, setSelectedField] = React.useState<string>("");
-    const [selectedCaseId, setSelectedCaseId] = React.useState<string>("");
-    const [selectedEnsembleName, setSelectedEnsembleName] = React.useState<string>("");
+    const [userSelectedField, setSelectedField] = React.useState<string>("");
+    const [userSelectedCaseId, setSelectedCaseId] = React.useState<string>("");
+    const [userSelectedEnsembleName, setSelectedEnsembleName] = React.useState<string>("");
     const [modulesListOpen, setModulesListOpen] = useStoreState(props.workbench.getStateStore(), "modulesListOpen");
 
     const renderCount = React.useRef(0);
@@ -36,7 +36,7 @@ export const TopNavBar: React.FC<TopNavBarProps> = (props) => {
         },
     });
 
-    const computedFieldIdentifier = fixupFieldIdentifier(selectedField, fieldsQuery.data);
+    const computedFieldIdentifier = fixupFieldIdentifier(userSelectedField, fieldsQuery.data);
 
     const casesQuery = useQuery({
         queryKey: ["getCases", computedFieldIdentifier],
@@ -49,7 +49,7 @@ export const TopNavBar: React.FC<TopNavBarProps> = (props) => {
         enabled: fieldsQuery.isSuccess,
     });
 
-    const computedCaseUuid = fixupCaseUuid(selectedCaseId, casesQuery.data);
+    const computedCaseUuid = fixupCaseUuid(userSelectedCaseId, casesQuery.data);
 
     const ensemblesQuery = useQuery({
         queryKey: ["getEnsembles", computedCaseUuid],
@@ -62,7 +62,7 @@ export const TopNavBar: React.FC<TopNavBarProps> = (props) => {
         enabled: casesQuery.isSuccess,
     });
 
-    const computedEnsembleName = fixupEnsembleName(selectedEnsembleName, ensemblesQuery.data);
+    const computedEnsembleName = fixupEnsembleName(userSelectedEnsembleName, ensemblesQuery.data);
 
     console.log(
         `TopNavBar renderCount=${renderCount.current}` + makeQueriesDbgString(fieldsQuery, casesQuery, ensemblesQuery)
@@ -110,17 +110,28 @@ export const TopNavBar: React.FC<TopNavBarProps> = (props) => {
         <div className="bg-slate-100 p-4">
             <div className="flex flex-row gap-4 items-center">
                 <h1 className="flex-grow">{activeModuleName}</h1>
-                <Dropdown options={fieldOpts} value={computedFieldIdentifier} onChange={handleFieldChanged} />
+                <ApiStateWrapper
+                    apiResult={fieldsQuery}
+                    errorComponent={<div className="text-red-500">Error loading fields</div>}
+                    loadingComponent={<CircularProgress />}
+                >
+                    <Dropdown
+                        options={fieldOpts}
+                        value={computedFieldIdentifier}
+                        onChange={handleFieldChanged}
+                        disabled={fieldOpts.length === 0}
+                    />
+                </ApiStateWrapper>
                 <ApiStateWrapper
                     apiResult={casesQuery}
                     errorComponent={<div className="text-red-500">Error loading cases</div>}
                     loadingComponent={<CircularProgress />}
                 >
                     <Dropdown
-                        disabled={caseOpts.length === 0}
                         options={caseOpts}
                         value={computedCaseUuid}
                         onChange={handleCaseChanged}
+                        disabled={caseOpts.length === 0}
                     />
                 </ApiStateWrapper>
                 <ApiStateWrapper
@@ -129,10 +140,10 @@ export const TopNavBar: React.FC<TopNavBarProps> = (props) => {
                     loadingComponent={<CircularProgress />}
                 >
                     <Dropdown
-                        disabled={ensembleOpts.length === 0}
                         options={ensembleOpts}
                         value={computedEnsembleName}
                         onChange={handleEnsembleChanged}
+                        disabled={ensembleOpts.length === 0}
                     />
                 </ApiStateWrapper>
                 <ToggleButton active={modulesListOpen} onToggle={(active: boolean) => handleToggleModulesList(active)}>

--- a/frontend/src/framework/components/TopNavBar/topNavBar.tsx
+++ b/frontend/src/framework/components/TopNavBar/topNavBar.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 
+import { Case, Ensemble, Field } from "@api";
 import { apiService } from "@framework/ApiService";
 import { useStoreState } from "@framework/StateStore";
 import { Workbench } from "@framework/Workbench";
@@ -8,7 +9,7 @@ import { CircularProgress } from "@lib/components/CircularProgress";
 import { Dropdown } from "@lib/components/Dropdown";
 // import { useWorkbenchActiveModuleName } from "@framework/hooks/useWorkbenchActiveModuleName";
 import { ToggleButton } from "@lib/components/ToggleButton";
-import { useQuery } from "@tanstack/react-query";
+import { UseQueryResult, useQuery } from "@tanstack/react-query";
 
 import { LoginButton } from "../LoginButton";
 
@@ -20,73 +21,173 @@ export const TopNavBar: React.FC<TopNavBarProps> = (props) => {
     const activeModuleName = ""; // useWorkbenchActiveModuleName();
     const [selectedField, setSelectedField] = React.useState<string>("");
     const [selectedCaseId, setSelectedCaseId] = React.useState<string>("");
+    const [selectedEnsembleName, setSelectedEnsembleName] = React.useState<string>("");
     const [modulesListOpen, setModulesListOpen] = useStoreState(props.workbench.getStateStore(), "modulesListOpen");
 
-    const casesQueryRes = useQuery({
-        queryKey: ["getCases", selectedField],
+    const renderCount = React.useRef(0);
+    React.useEffect(function incrementRenderCount() {
+        renderCount.current = renderCount.current + 1;
+    });
+
+    const fieldsQuery = useQuery({
+        queryKey: ["getFields"],
         queryFn: () => {
-            if (selectedField !== "") {
-                return apiService.explore.getCases(selectedField);
-            }
-            return null;
-        },
-        onSuccess: function selectFirstCase(caseArray) {
-            if (caseArray === null) {
-                return;
-            }
-            if (caseArray.length > 0) {
-                setSelectedCaseId(caseArray[0].uuid);
-                props.workbench.setNavigatorCaseId(caseArray[0].uuid);
-            }
+            return apiService.explore.getFields();
         },
     });
 
-    const handleFieldChange = (fieldName: string) => {
-        setSelectedField(fieldName);
-        props.workbench.setNavigatorFieldName(fieldName);
-    };
+    const computedFieldIdentifier = fixupFieldIdentifier(selectedField, fieldsQuery.data);
 
-    const handleCaseChange = (caseId: string) => {
-        setSelectedCaseId(caseId);
-        props.workbench.setNavigatorCaseId(caseId);
-    };
+    const casesQuery = useQuery({
+        queryKey: ["getCases", computedFieldIdentifier],
+        queryFn: () => {
+            if (!computedFieldIdentifier) {
+                return Promise.resolve<Case[]>([]);
+            }
+            return apiService.explore.getCases(computedFieldIdentifier);
+        },
+        enabled: fieldsQuery.isSuccess,
+    });
+
+    const computedCaseUuid = fixupCaseUuid(selectedCaseId, casesQuery.data);
+
+    const ensemblesQuery = useQuery({
+        queryKey: ["getEnsembles", computedCaseUuid],
+        queryFn: () => {
+            if (!computedCaseUuid) {
+                return Promise.resolve<Ensemble[]>([]);
+            }
+            return apiService.explore.getEnsembles(computedCaseUuid);
+        },
+        enabled: casesQuery.isSuccess,
+    });
+
+    const computedEnsembleName = fixupEnsembleName(selectedEnsembleName, ensemblesQuery.data);
+
+    console.log(
+        `TopNavBar renderCount=${renderCount.current}` + makeQueriesDbgString(fieldsQuery, casesQuery, ensemblesQuery)
+    );
+
+    React.useEffect(
+        function publishSelectionViaWorkbench() {
+            props.workbench.setNavigatorFieldName(computedFieldIdentifier);
+            props.workbench.setNavigatorCaseId(computedCaseUuid);
+            if (computedCaseUuid && computedEnsembleName) {
+                const caseName = casesQuery.data?.find((c) => c.uuid === computedCaseUuid)?.name ?? "UNKNOWN";
+                const ensArr = [{ caseUuid: computedCaseUuid, caseName: caseName, ensembleName: computedEnsembleName }];
+                props.workbench.setNavigatorEnsembles(ensArr);
+            } else {
+                props.workbench.setNavigatorEnsembles([]);
+            }
+        },
+        [computedFieldIdentifier, computedCaseUuid, computedEnsembleName]
+    );
+
+    function handleFieldChanged(fieldIdentifier: string) {
+        setSelectedField(fieldIdentifier);
+    }
+
+    function handleCaseChanged(caseUuid: string) {
+        setSelectedField(computedFieldIdentifier);
+        setSelectedCaseId(caseUuid);
+    }
+
+    function handleEnsembleChanged(ensembleName: string) {
+        setSelectedField(computedFieldIdentifier);
+        setSelectedCaseId(computedCaseUuid);
+        setSelectedEnsembleName(ensembleName);
+    }
 
     const handleToggleModulesList = (value: boolean) => {
         setModulesListOpen(value);
     };
 
-    const fields = [
-        {
-            value: "DROGON",
-            label: "Drogon",
-        },
-    ];
+    const fieldOpts = fieldsQuery.data?.map((f) => ({ value: f.field_identifier, label: f.field_identifier })) ?? [];
+    const caseOpts = casesQuery.data?.map((c) => ({ value: c.uuid, label: c.name })) ?? [];
+    const ensembleOpts = ensemblesQuery.data?.map((e) => ({ value: e.name, label: e.name })) ?? [];
 
     return (
         <div className="bg-slate-100 p-4">
             <div className="flex flex-row gap-4 items-center">
                 <h1 className="flex-grow">{activeModuleName}</h1>
-                <Dropdown options={fields} value={selectedField} onChange={handleFieldChange} />
+                <Dropdown options={fieldOpts} value={computedFieldIdentifier} onChange={handleFieldChanged} />
                 <ApiStateWrapper
-                    apiResult={casesQueryRes}
+                    apiResult={casesQuery}
                     errorComponent={<div className="text-red-500">Error loading cases</div>}
                     loadingComponent={<CircularProgress />}
                 >
                     <Dropdown
-                        options={
-                            casesQueryRes.isSuccess
-                                ? casesQueryRes.data?.map((aCase) => ({ value: aCase.uuid, label: aCase.name })) || []
-                                : []
-                        }
-                        value={selectedCaseId}
-                        onChange={handleCaseChange}
+                        disabled={caseOpts.length === 0}
+                        options={caseOpts}
+                        value={computedCaseUuid}
+                        onChange={handleCaseChanged}
+                    />
+                </ApiStateWrapper>
+                <ApiStateWrapper
+                    apiResult={ensemblesQuery}
+                    errorComponent={<div className="text-red-500">Error loading ensembles</div>}
+                    loadingComponent={<CircularProgress />}
+                >
+                    <Dropdown
+                        disabled={ensembleOpts.length === 0}
+                        options={ensembleOpts}
+                        value={computedEnsembleName}
+                        onChange={handleEnsembleChanged}
                     />
                 </ApiStateWrapper>
                 <ToggleButton active={modulesListOpen} onToggle={(active: boolean) => handleToggleModulesList(active)}>
                     Add modules
                 </ToggleButton>
                 <LoginButton />
+                <div>({renderCount.current})</div>
             </div>
         </div>
     );
 };
+
+function fixupFieldIdentifier(currFieldIdentifier: string, fieldArr: Field[] | undefined): string {
+    const fieldIdentifiers = fieldArr ? fieldArr.map((item) => item.field_identifier) : [];
+    if (currFieldIdentifier && fieldIdentifiers.includes(currFieldIdentifier)) {
+        return currFieldIdentifier;
+    }
+
+    if (fieldIdentifiers.length > 0) {
+        return fieldIdentifiers[0];
+    }
+
+    return "";
+}
+
+function fixupCaseUuid(currCaseUuid: string, caseArr: Case[] | undefined): string {
+    const caseIds = caseArr ? caseArr.map((item) => item.uuid) : [];
+    if (currCaseUuid && caseIds.includes(currCaseUuid)) {
+        return currCaseUuid;
+    }
+
+    if (caseIds.length > 0) {
+        return caseIds[0];
+    }
+
+    return "";
+}
+
+function fixupEnsembleName(currEnsembleName: string, ensembleArr: Ensemble[] | undefined): string {
+    const ensembleNames = ensembleArr ? ensembleArr.map((item) => item.name) : [];
+    if (currEnsembleName && ensembleNames.includes(currEnsembleName)) {
+        return currEnsembleName;
+    }
+
+    if (ensembleNames.length > 0) {
+        return ensembleNames[0];
+    }
+
+    return "";
+}
+
+function makeQueriesDbgString(fields: UseQueryResult, cases: UseQueryResult, ens: UseQueryResult): string {
+    let s = "";
+    s += `  fields: ${fields.status.slice(0, 4)}/${fields.fetchStatus.slice(0, 4)} - data=${fields.data ? "Y" : "N"}`;
+    s += `  cases: ${cases.status.slice(0, 4)}/${cases.fetchStatus.slice(0, 4)} - data=${cases.data ? "Y" : "N"}`;
+    s += `  ensembles: ${ens.status.slice(0, 4)}/${ens.fetchStatus.slice(0, 4)} - data=${ens.data ? "Y" : "N"}`;
+    return s;
+}

--- a/frontend/src/framework/components/TopNavBar/topNavBar.tsx
+++ b/frontend/src/framework/components/TopNavBar/topNavBar.tsx
@@ -19,9 +19,9 @@ type TopNavBarProps = {
 
 export const TopNavBar: React.FC<TopNavBarProps> = (props) => {
     const activeModuleName = ""; // useWorkbenchActiveModuleName();
-    const [userSelectedField, setSelectedField] = React.useState<string>("");
-    const [userSelectedCaseId, setSelectedCaseId] = React.useState<string>("");
-    const [userSelectedEnsembleName, setSelectedEnsembleName] = React.useState<string>("");
+    const [selectedField, setSelectedField] = React.useState<string>("");
+    const [selectedCaseId, setSelectedCaseId] = React.useState<string>("");
+    const [selectedEnsembleName, setSelectedEnsembleName] = React.useState<string>("");
     const [modulesListOpen, setModulesListOpen] = useStoreState(props.workbench.getStateStore(), "modulesListOpen");
 
     const renderCount = React.useRef(0);
@@ -36,7 +36,7 @@ export const TopNavBar: React.FC<TopNavBarProps> = (props) => {
         },
     });
 
-    const computedFieldIdentifier = fixupFieldIdentifier(userSelectedField, fieldsQuery.data);
+    const computedFieldIdentifier = fixupFieldIdentifier(selectedField, fieldsQuery.data);
 
     const casesQuery = useQuery({
         queryKey: ["getCases", computedFieldIdentifier],
@@ -49,7 +49,7 @@ export const TopNavBar: React.FC<TopNavBarProps> = (props) => {
         enabled: fieldsQuery.isSuccess,
     });
 
-    const computedCaseUuid = fixupCaseUuid(userSelectedCaseId, casesQuery.data);
+    const computedCaseUuid = fixupCaseUuid(selectedCaseId, casesQuery.data);
 
     const ensemblesQuery = useQuery({
         queryKey: ["getEnsembles", computedCaseUuid],
@@ -62,11 +62,21 @@ export const TopNavBar: React.FC<TopNavBarProps> = (props) => {
         enabled: casesQuery.isSuccess,
     });
 
-    const computedEnsembleName = fixupEnsembleName(userSelectedEnsembleName, ensemblesQuery.data);
+    const computedEnsembleName = fixupEnsembleName(selectedEnsembleName, ensemblesQuery.data);
 
     console.log(
         `TopNavBar renderCount=${renderCount.current}` + makeQueriesDbgString(fieldsQuery, casesQuery, ensemblesQuery)
     );
+
+    if (computedFieldIdentifier && computedFieldIdentifier !== selectedField) {
+        setSelectedField(computedFieldIdentifier);
+    }
+    if (computedCaseUuid && computedCaseUuid !== selectedCaseId) {
+        setSelectedCaseId(computedCaseUuid);
+    }
+    if (computedEnsembleName && computedEnsembleName !== selectedEnsembleName) {
+        setSelectedEnsembleName(computedEnsembleName);
+    }
 
     React.useEffect(
         function publishSelectionViaWorkbench() {
@@ -88,13 +98,10 @@ export const TopNavBar: React.FC<TopNavBarProps> = (props) => {
     }
 
     function handleCaseChanged(caseUuid: string) {
-        setSelectedField(computedFieldIdentifier);
         setSelectedCaseId(caseUuid);
     }
 
     function handleEnsembleChanged(ensembleName: string) {
-        setSelectedField(computedFieldIdentifier);
-        setSelectedCaseId(computedCaseUuid);
         setSelectedEnsembleName(ensembleName);
     }
 
@@ -150,7 +157,6 @@ export const TopNavBar: React.FC<TopNavBarProps> = (props) => {
                     Add modules
                 </ToggleButton>
                 <LoginButton />
-                <div>({renderCount.current})</div>
             </div>
         </div>
     );

--- a/frontend/src/modules/DbgWorkbenchSpy/implementation.tsx
+++ b/frontend/src/modules/DbgWorkbenchSpy/implementation.tsx
@@ -22,6 +22,7 @@ export function WorkbenchSpySettings({ moduleContext, workbenchServices }: Modul
 export function WorkbenchSpyView({ moduleContext, workbenchServices }: ModuleFCProps<SharedState>) {
     const [fieldName, fieldName_TS] = useServiceValueWithTS("navigator.fieldName", workbenchServices);
     const [caseUuid, caseUuid_TS] = useServiceValueWithTS("navigator.caseId", workbenchServices);
+    const [ensembles, ensembles_TS] = useServiceValueWithTS("navigator.ensembles", workbenchServices);
     const [hoverRealization, hoverRealization_TS] = useServiceValueWithTS("global.hoverRealization", workbenchServices);
     const [hoverTimestamp, hoverTimestamp_TS] = useServiceValueWithTS("global.hoverTimestamp", workbenchServices);
     const triggeredRefreshCounter = moduleContext.useStoreValue("triggeredRefreshCounter");
@@ -33,6 +34,16 @@ export function WorkbenchSpyView({ moduleContext, workbenchServices }: ModuleFCP
 
     const componentLastRenderTS = getTimestampString();
 
+    let ensembleSpecAsString: string | undefined;
+    if (ensembles) {
+        if (ensembles.length > 0) {
+            ensembleSpecAsString = `${ensembles[0].ensembleName}  (${ensembles[0].caseUuid})`;
+        }
+        else {
+            ensembleSpecAsString = "empty array";
+        }
+    }
+
     return (
         <code>
             Navigator topics:
@@ -40,6 +51,7 @@ export function WorkbenchSpyView({ moduleContext, workbenchServices }: ModuleFCP
                 <tbody>
                     {makeTableRow("fieldName", fieldName, fieldName_TS)}
                     {makeTableRow("caseUuid", caseUuid, caseUuid_TS)}
+                    {makeTableRow("ensembles", ensembleSpecAsString, ensembles_TS)}
                 </tbody>
             </table>
             <br />

--- a/frontend/src/modules/SimulationTimeSeries/loadModule.tsx
+++ b/frontend/src/modules/SimulationTimeSeries/loadModule.tsx
@@ -6,8 +6,7 @@ import { State } from "./state";
 import { view } from "./view";
 
 const initialState: State = {
-    ensembleName: null,
-    vectorName: null,
+    vectorSpec: null,
     resamplingFrequency: Frequency.MONTHLY,
     showStatistics: true,
     realizationsToInclude: null

--- a/frontend/src/modules/SimulationTimeSeries/queryHooks.tsx
+++ b/frontend/src/modules/SimulationTimeSeries/queryHooks.tsx
@@ -1,15 +1,28 @@
-import { UseQueryResult, useQuery } from "@tanstack/react-query";
-
-import { Frequency, VectorRealizationData, VectorStatisticData } from "@api";
+import { Frequency, VectorDescription } from "@api";
+import { VectorRealizationData, VectorStatisticData } from "@api";
 import { apiService } from "@framework/ApiService";
+import { UseQueryResult, useQuery } from "@tanstack/react-query";
 
 const STALE_TIME = 60 * 1000;
 const CACHE_TIME = 60 * 1000;
 
+export function useVectorsQuery(
+    caseUuid: string | undefined,
+    ensembleName: string | undefined
+): UseQueryResult<Array<VectorDescription>> {
+    return useQuery({
+        queryKey: ["getVectorNamesAndDescriptions", caseUuid, ensembleName],
+        queryFn: () => apiService.timeseries.getVectorNamesAndDescriptions(caseUuid ?? "", ensembleName ?? ""),
+        staleTime: STALE_TIME,
+        cacheTime: CACHE_TIME,
+        enabled: caseUuid && ensembleName ? true : false,
+    });
+}
+
 export function useVectorDataQuery(
-    caseUuid: string | null,
-    ensembleName: string | null,
-    vectorName: string | null,
+    caseUuid: string | undefined,
+    ensembleName: string | undefined,
+    vectorName: string | undefined,
     resampleFrequency: Frequency | null,
     realizationsToInclude: number[] | null
 ): UseQueryResult<Array<VectorRealizationData>> {
@@ -37,9 +50,9 @@ export function useVectorDataQuery(
 }
 
 export function useStatisticalVectorDataQuery(
-    caseUuid: string | null,
-    ensembleName: string | null,
-    vectorName: string | null,
+    caseUuid: string | undefined,
+    ensembleName: string | undefined,
+    vectorName: string | undefined,
     resampleFrequency: Frequency | null,
     realizationsToInclude: number[] | null,
     allowEnable: boolean

--- a/frontend/src/modules/SimulationTimeSeries/settings.tsx
+++ b/frontend/src/modules/SimulationTimeSeries/settings.tsx
@@ -4,81 +4,53 @@ import { Frequency, VectorDescription } from "@api";
 import { apiService } from "@framework/ApiService";
 import { ModuleFCProps } from "@framework/Module";
 import { useSubscribedValue } from "@framework/WorkbenchServices";
+import { ApiStateWrapper } from "@lib/components/ApiStateWrapper";
 import { Checkbox } from "@lib/components/Checkbox";
-import { Dropdown } from "@lib/components/Dropdown";
+import { CircularProgress } from "@lib/components/CircularProgress";
+import { Dropdown, DropdownOption } from "@lib/components/Dropdown";
 import { Input } from "@lib/components/Input";
 import { Label } from "@lib/components/Label";
-import { UseQueryResult, useQuery } from "@tanstack/react-query";
+import { Select, SelectOption } from "@lib/components/Select";
 
 import { sortBy, sortedUniq } from "lodash";
 
+import { useVectorsQuery } from "./queryHooks";
 import { State } from "./state";
-
-import { DropdownProps } from "../../lib/components/Dropdown/dropdown";
 
 //-----------------------------------------------------------------------------------------------------------
 export function settings({ moduleContext, workbenchServices }: ModuleFCProps<State>) {
-    console.log("render Settings");
+    console.log("render SimulationTimeSeries settings");
 
-    const caseUuid = useSubscribedValue("navigator.caseId", workbenchServices);
-    const [ensembleName, setEnsembleName] = moduleContext.useStoreState("ensembleName");
-    const [vectorName, setVectorName] = moduleContext.useStoreState("vectorName");
+    const ensembles = useSubscribedValue("navigator.ensembles", workbenchServices);
+    const [userSelectedVectorName, setUserSelectedVectorName] = React.useState("");
     const [resampleFrequency, setResamplingFrequency] = moduleContext.useStoreState("resamplingFrequency");
     const [showStatistics, setShowStatistics] = moduleContext.useStoreState("showStatistics");
 
-    const ensemblesQuery = useQuery({
-        queryKey: ["getEnsembles", caseUuid],
-        queryFn: () => apiService.explore.getEnsembles(caseUuid || ""),
-        enabled: caseUuid ? true : false,
-        onSuccess: function selectDefaultEnsemble(ensembleArr) {
-            if (ensembleArr.length > 0) {
-                setEnsembleName(ensembleArr[0].name);
+    const firstEnsemble = ensembles && ensembles.length > 0 ? ensembles[0] : null;
+    const vectorsQuery = useVectorsQuery(firstEnsemble?.caseUuid, firstEnsemble?.ensembleName);
+
+    const renderVectorName = fixupVectorName(userSelectedVectorName, vectorsQuery.data);
+
+    React.useEffect(
+        function propagateVectorSpecToView() {
+            if (firstEnsemble && renderVectorName) {
+                moduleContext.stateStore.setValue("vectorSpec", {
+                    caseUuid: firstEnsemble.caseUuid,
+                    caseName: firstEnsemble.caseName,
+                    ensembleName: firstEnsemble.ensembleName,
+                    vectorName: renderVectorName,
+                });
+            } else {
+                moduleContext.stateStore.setValue("vectorSpec", null);
             }
         },
-    });
+        [firstEnsemble?.caseUuid, firstEnsemble?.ensembleName, renderVectorName]
+    );
 
-    const vectorsQuery = useQuery({
-        queryKey: ["getVectorNamesAndDescriptions", caseUuid, ensembleName],
-        queryFn: () => apiService.timeseries.getVectorNamesAndDescriptions(caseUuid ?? "", ensembleName ?? ""),
-        enabled: caseUuid && ensembleName ? true : false,
-        onSuccess: function selectDefaultVector(vectorArr) {
-            console.log("selectDefaultVector()");
-            if (vectorArr.length > 0) {
-                setVectorName(vectorArr[vectorArr.length - 1].name);
-            }
-        },
-        select: function capVectorArrayTo50Entries(vectorArr) {
-            console.log("capVectorArrayTo50Entries()");
-            return vectorArr.slice(0, 50);
-        },
-    });
-
-    function makeVectorListItems(vectorsQuery: UseQueryResult<VectorDescription[]>): DropdownProps["options"] {
-        const itemArr: DropdownProps["options"] = [];
-        if (vectorsQuery.isSuccess && vectorsQuery.data.length > 0) {
-            for (const vec of vectorsQuery.data) {
-                itemArr.push({ value: vec.name, label: vec.descriptive_name });
-            }
-        } else {
-            // itemArr.push({ value: "", label: `${vectorsQuery.status.toString()}...`, disabled: true });
-        }
-        return itemArr;
-    }
-
-    function handleVectorSelectionChange(vecName: string) {
+    function handleVectorSelectionChange(selectedVecNames: string[]) {
         console.log("handleVectorSelectionChange()");
-        setVectorName(vecName);
-    }
-
-    function makeFrequencyListItems(): { label: string; value: string }[] {
-        const itemArr: { label: string; value: string }[] = [
-            { value: Frequency.DAILY, label: "Daily" },
-            { value: Frequency.MONTHLY, label: "Monthly" },
-            { value: Frequency.QUARTERLY, label: "Quarterly" },
-            { value: Frequency.YEARLY, label: "Yearly" },
-            { value: "RAW", label: "None (raw)" },
-        ];
-        return itemArr;
+        const newName = selectedVecNames.length > 0 ? selectedVecNames[0] : "";
+        setUserSelectedVectorName(newName);
     }
 
     function handleFrequencySelectionChange(newFreqStr: string) {
@@ -105,16 +77,24 @@ export function settings({ moduleContext, workbenchServices }: ModuleFCProps<Sta
 
     return (
         <>
-            <Label text="Vector">
-                <Dropdown
-                    options={makeVectorListItems(vectorsQuery)}
-                    value={vectorName ?? ""}
-                    onChange={handleVectorSelectionChange}
-                />
-            </Label>
+            <ApiStateWrapper
+                apiResult={vectorsQuery}
+                errorComponent={"Error loading vector names"}
+                loadingComponent={<CircularProgress />}
+            >
+                <Label text="Vector">
+                    <Select
+                        options={makeVectorOptionItems(vectorsQuery.data)}
+                        value={renderVectorName ? [renderVectorName] : []}
+                        onChange={handleVectorSelectionChange}
+                        filter={true}
+                        size={5}
+                    />
+                </Label>
+            </ApiStateWrapper>
             <Label text="Frequency">
                 <Dropdown
-                    options={makeFrequencyListItems()}
+                    options={makeFrequencyOptionItems()}
                     value={resampleFrequency ?? "RAW"}
                     onChange={handleFrequencySelectionChange}
                 />
@@ -129,6 +109,39 @@ export function settings({ moduleContext, workbenchServices }: ModuleFCProps<Sta
 
 //-----------------------------------------------------------------------------------------------------------
 //-----------------------------------------------------------------------------------------------------------
+
+function fixupVectorName(currVectorName: string, vectorDescriptionsArr: VectorDescription[] | undefined): string {
+    if (!vectorDescriptionsArr || vectorDescriptionsArr.length === 0) {
+        return "";
+    }
+
+    if (vectorDescriptionsArr.find((item) => item.name === currVectorName)) {
+        return currVectorName;
+    }
+
+    return vectorDescriptionsArr[0].name;
+}
+
+function makeVectorOptionItems(vectorDescriptionsArr: VectorDescription[] | undefined): SelectOption[] {
+    const itemArr: SelectOption[] = [];
+    if (vectorDescriptionsArr) {
+        for (const vec of vectorDescriptionsArr) {
+            itemArr.push({ value: vec.name, label: vec.descriptive_name });
+        }
+    }
+    return itemArr;
+}
+
+function makeFrequencyOptionItems(): DropdownOption[] {
+    const itemArr: DropdownOption[] = [
+        { value: Frequency.DAILY, label: "Daily" },
+        { value: Frequency.MONTHLY, label: "Monthly" },
+        { value: Frequency.QUARTERLY, label: "Quarterly" },
+        { value: Frequency.YEARLY, label: "Yearly" },
+        { value: "RAW", label: "None (raw)" },
+    ];
+    return itemArr;
+}
 
 // Parse page ranges into array of numbers
 function parseRealizationRangeString(realRangeStr: string, maxLegalReal: number): number[] {

--- a/frontend/src/modules/SimulationTimeSeries/state.ts
+++ b/frontend/src/modules/SimulationTimeSeries/state.ts
@@ -1,8 +1,14 @@
 import { Frequency } from "@api";
 
+export interface VectorSpec {
+    caseUuid: string;
+    caseName: string;
+    ensembleName: string;
+    vectorName: string;
+}
+
 export interface State {
-    ensembleName: string | null;
-    vectorName: string | null;
+    vectorSpec: VectorSpec | null;
     resamplingFrequency: Frequency | null;
     showStatistics: boolean;
     realizationsToInclude: number[] | null;

--- a/frontend/src/modules/SimulationTimeSeries/view.tsx
+++ b/frontend/src/modules/SimulationTimeSeries/view.tsx
@@ -20,26 +20,24 @@ interface MyPlotData extends Partial<PlotData> {
 export const view = ({ moduleContext, workbenchServices }: ModuleFCProps<State>) => {
     const wrapperDivRef = React.useRef<HTMLDivElement>(null);
     const wrapperDivSize = useElementSize(wrapperDivRef);
-    const caseUuid = useSubscribedValue("navigator.caseId", workbenchServices);
-    const ensembleName = moduleContext.useStoreValue("ensembleName");
-    const vectorName = moduleContext.useStoreValue("vectorName");
+    const vectorSpec = moduleContext.useStoreValue("vectorSpec");
     const resampleFrequency = moduleContext.useStoreValue("resamplingFrequency");
     const showStatistics = moduleContext.useStoreValue("showStatistics");
     const realizationsToInclude = moduleContext.useStoreValue("realizationsToInclude");
     const [highlightRealization, setHighlightRealization] = React.useState(-1);
 
     const vectorQuery = useVectorDataQuery(
-        caseUuid,
-        ensembleName,
-        vectorName,
+        vectorSpec?.caseUuid,
+        vectorSpec?.ensembleName,
+        vectorSpec?.vectorName,
         resampleFrequency,
         realizationsToInclude
     );
 
     const statisticsQuery = useStatisticalVectorDataQuery(
-        caseUuid,
-        ensembleName,
-        vectorName,
+        vectorSpec?.caseUuid,
+        vectorSpec?.ensembleName,
+        vectorSpec?.vectorName,
         resampleFrequency,
         realizationsToInclude,
         showStatistics
@@ -126,11 +124,19 @@ export const view = ({ moduleContext, workbenchServices }: ModuleFCProps<State>)
             tracesDataArr.push(trace);
         }
     }
+
+    let title = "N/A";
+    const hasGotAnyRequestedData = vectorQuery.data || (showStatistics && statisticsQuery.data);
+    if (vectorSpec && hasGotAnyRequestedData) {
+        title = `${vectorSpec.vectorName} [${unitString}] - ${vectorSpec.ensembleName}, ${vectorSpec.caseName}`;
+    }
+
     const layout: Partial<Layout> = {
         width: wrapperDivSize.width,
         height: wrapperDivSize.height,
-        title: `${vectorName ? vectorName.toUpperCase() : "N/A"} - ${unitString}`,
+        title: title,
     };
+
     if (subscribedPlotlyTimeStamp) {
         layout["shapes"] = [
             {


### PR DESCRIPTION
Added ensemble selection in nav bar, for now just immediate selection of a single ensemble.
Selected ensemble is communicated through `WorkbenchServices` on the `navigator.ensembles` topic.
Communication is through an array of ensembles, but currently only an empty array or an array with a single item will be communicated.
Adapted `SimulationTimeSeries` to use the ensemble selection from the nav bar.