### PR TITLE
Limit relative import to same folder

### DIFF
--- a/backend/src/fastapi_app/auth/auth_helper.py
+++ b/backend/src/fastapi_app/auth/auth_helper.py
@@ -8,9 +8,9 @@ import starsessions
 from fastapi import APIRouter, Request, Response
 from fastapi.responses import RedirectResponse
 
-from ...services.utils.authenticated_user import AuthenticatedUser
-from ...services.utils.perf_timer import PerfTimer
-from .. import config
+from src.services.utils.authenticated_user import AuthenticatedUser
+from src.services.utils.perf_timer import PerfTimer
+from src.fastapi_app import config
 
 
 class AuthHelper:

--- a/backend/src/fastapi_app/routers/explore.py
+++ b/backend/src/fastapi_app/routers/explore.py
@@ -3,9 +3,9 @@ from typing import List
 from fastapi import APIRouter, Depends, Path, Query
 from pydantic import BaseModel
 
-from ...services.sumo_access.sumo_explore import SumoExplore
-from ...services.utils.authenticated_user import AuthenticatedUser
-from ..auth.auth_helper import AuthHelper
+from src.services.sumo_access.sumo_explore import SumoExplore
+from src.services.utils.authenticated_user import AuthenticatedUser
+from src.fastapi_app.auth.auth_helper import AuthHelper
 
 router = APIRouter()
 

--- a/backend/src/fastapi_app/routers/general.py
+++ b/backend/src/fastapi_app/routers/general.py
@@ -5,7 +5,7 @@ import starsessions
 from fastapi import APIRouter, HTTPException, Request, status
 from pydantic import BaseModel
 
-from ..auth.auth_helper import AuthHelper
+from src.fastapi_app.auth.auth_helper import AuthHelper
 
 LOGGER = logging.getLogger(__name__)
 

--- a/backend/src/fastapi_app/routers/inplace_volumetrics/router.py
+++ b/backend/src/fastapi_app/routers/inplace_volumetrics/router.py
@@ -3,15 +3,15 @@ from enum import Enum
 from pydantic import BaseModel
 from fastapi import APIRouter, Depends, HTTPException, Query, Body
 
-from ....services.sumo_access.inplace_volumetrics_access import (
+from src.services.sumo_access.inplace_volumetrics_access import (
     InplaceVolumetricsAccess,
     InplaceVolumetricsTableMetaData,
     InplaceVolumetricsRealizationsResponse,
     InplaceVolumetricsCategoricalMetaData,
 )
-from ....services.utils.authenticated_user import AuthenticatedUser
+from src.services.utils.authenticated_user import AuthenticatedUser
 
-from ...auth.auth_helper import AuthHelper
+from src.fastapi_app.auth.auth_helper import AuthHelper
 
 
 router = APIRouter()

--- a/backend/src/fastapi_app/routers/parameters/router.py
+++ b/backend/src/fastapi_app/routers/parameters/router.py
@@ -5,10 +5,10 @@ from typing import List, Optional, Literal
 from pydantic import BaseModel
 from fastapi import APIRouter, Depends, HTTPException, Query
 
-from ....services.sumo_access.parameter_access import ParameterAccess, EnsembleParameter, EnsembleSensitivity
-from ....services.utils.authenticated_user import AuthenticatedUser
-from ....services.utils.perf_timer import PerfTimer
-from ...auth.auth_helper import AuthHelper
+from src.services.sumo_access.parameter_access import ParameterAccess, EnsembleParameter, EnsembleSensitivity
+from src.services.utils.authenticated_user import AuthenticatedUser
+from src.services.utils.perf_timer import PerfTimer
+from src.fastapi_app.auth.auth_helper import AuthHelper
 from . import schemas
 
 LOGGER = logging.getLogger(__name__)

--- a/backend/src/fastapi_app/routers/surface/converters.py
+++ b/backend/src/fastapi_app/routers/surface/converters.py
@@ -2,8 +2,8 @@ import base64
 
 import xtgeo
 
-from ....services.utils.surface_to_png import surface_to_png_bytes_optimized
-from ....services.utils.surface_orientation import calc_surface_orientation_for_colormap_layer
+from src.services.utils.surface_to_png import surface_to_png_bytes_optimized
+from src.services.utils.surface_orientation import calc_surface_orientation_for_colormap_layer
 from . import schemas
 
 

--- a/backend/src/fastapi_app/routers/surface/router.py
+++ b/backend/src/fastapi_app/routers/surface/router.py
@@ -3,11 +3,11 @@ from typing import List
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 
-from ....services.sumo_access.surface_access import SurfaceAccess
-from ....services.sumo_access.surface_types import StatisticFunction
-from ....services.utils.authenticated_user import AuthenticatedUser
-from ....services.utils.perf_timer import PerfTimer
-from ...auth.auth_helper import AuthHelper
+from src.services.sumo_access.surface_access import SurfaceAccess
+from src.services.sumo_access.surface_types import StatisticFunction
+from src.services.utils.authenticated_user import AuthenticatedUser
+from src.services.utils.perf_timer import PerfTimer
+from src.fastapi_app.auth.auth_helper import AuthHelper
 from . import converters
 from . import schemas
 

--- a/backend/src/fastapi_app/routers/timeseries/converters.py
+++ b/backend/src/fastapi_app/routers/timeseries/converters.py
@@ -1,8 +1,8 @@
 from typing import List, Optional, Sequence
 
-from ....services.summary_vector_statistics import VectorStatistics
-from ....services.sumo_access.summary_access import VectorMetadata
-from ....services.utils.statistic_function import StatisticFunction
+from src.services.summary_vector_statistics import VectorStatistics
+from src.services.sumo_access.summary_access import VectorMetadata
+from src.services.utils.statistic_function import StatisticFunction
 from . import schemas
 
 

--- a/backend/src/fastapi_app/routers/timeseries/router.py
+++ b/backend/src/fastapi_app/routers/timeseries/router.py
@@ -4,11 +4,11 @@ from typing import List, Optional, Sequence, Union
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 
-from ....services.summary_vector_statistics import compute_vector_statistics
-from ....services.sumo_access.summary_access import Frequency, SummaryAccess
-from ....services.utils.authenticated_user import AuthenticatedUser
-from ....services.utils.perf_timer import PerfTimer
-from ...auth.auth_helper import AuthHelper
+from src.services.summary_vector_statistics import compute_vector_statistics
+from src.services.sumo_access.summary_access import Frequency, SummaryAccess
+from src.services.utils.authenticated_user import AuthenticatedUser
+from src.services.utils.perf_timer import PerfTimer
+from src.fastapi_app.auth.auth_helper import AuthHelper
 from . import converters
 from . import schemas
 

--- a/backend/src/services/sumo_access/dev_sumo_access_test_driver.py
+++ b/backend/src/services/sumo_access/dev_sumo_access_test_driver.py
@@ -6,11 +6,11 @@ import pyarrow as pa
 
 from fmu.sumo.explorer.explorer import SumoClient
 
+from src.services.summary_vector_statistics import compute_vector_statistics_table, compute_vector_statistics
+from src.services.utils.statistic_function import StatisticFunction
 from .summary_access import SummaryAccess, RealizationVector, Frequency
 from .surface_access import SurfaceAccess, DynamicSurfaceDirectory
 from .sumo_explore import SumoExplore
-from ..summary_vector_statistics import compute_vector_statistics_table, compute_vector_statistics
-from ..utils.statistic_function import StatisticFunction
 
 
 def test_summary_access(summary_access: SummaryAccess) -> None:

--- a/backend/src/services/sumo_access/inplace_volumetrics_access.py
+++ b/backend/src/services/sumo_access/inplace_volumetrics_access.py
@@ -13,7 +13,7 @@ from fmu.sumo.explorer.objects import TableCollection
 
 # from fmu.sumo.explorer.objects.table import AggregatedTable
 
-from ..utils.perf_timer import PerfTimer
+from src.services.utils.perf_timer import PerfTimer
 from ._field_metadata import create_vector_metadata_from_field_meta
 from ._helpers import create_sumo_client_instance
 from ._resampling import resample_segmented_multi_real_table

--- a/backend/src/services/sumo_access/parameter_access.py
+++ b/backend/src/services/sumo_access/parameter_access.py
@@ -11,7 +11,7 @@ from fmu.sumo.explorer import AggregatedTable
 
 # from fmu.sumo.explorer.objects.table import AggregatedTable
 
-from ..utils.perf_timer import PerfTimer
+from src.services.utils.perf_timer import PerfTimer
 from ._helpers import create_sumo_client_instance
 
 LOGGER = logging.getLogger(__name__)

--- a/backend/src/services/sumo_access/summary_access.py
+++ b/backend/src/services/sumo_access/summary_access.py
@@ -10,8 +10,8 @@ import pyarrow.compute as pc
 from fmu.sumo.explorer.objects import CaseCollection
 from sumo.wrapper import SumoClient
 
-from ..utils.arrow_helpers import sort_table_on_real_then_date
-from ..utils.perf_timer import PerfTimer
+from src.services.utils.arrow_helpers import sort_table_on_real_then_date
+from src.services.utils.perf_timer import PerfTimer
 from ._field_metadata import create_vector_metadata_from_field_meta
 from ._helpers import create_sumo_client_instance
 from ._resampling import resample_segmented_multi_real_table

--- a/backend/src/services/sumo_access/surface_access.py
+++ b/backend/src/services/sumo_access/surface_access.py
@@ -8,8 +8,8 @@ from fmu.sumo.explorer.objects import Case, CaseCollection, Surface, SurfaceColl
 from pydantic import BaseModel
 from sumo.wrapper import SumoClient
 
-from ..utils.perf_timer import PerfTimer
-from ..utils.statistic_function import StatisticFunction
+from src.services.utils.perf_timer import PerfTimer
+from src.services.utils.statistic_function import StatisticFunction
 from .surface_types import StatisticFunction, DynamicSurfaceDirectory, StaticSurfaceDirectory
 from ._helpers import create_sumo_client_instance
 


### PR DESCRIPTION
I think this reduces mental load when we are to understand where a file is located in the backend.

Basically `from .something.something` is fine, but changed `from ..something`, `from ...something`, `from ....something` etc. to non-relative imports.