### PR TITLE
Convert ModuleContext into a class

### DIFF
--- a/frontend/src/framework/Module.tsx
+++ b/frontend/src/framework/Module.tsx
@@ -2,7 +2,8 @@ import React from "react";
 
 import { cloneDeep } from "lodash";
 
-import { ModuleContext, ModuleInstance } from "./ModuleInstance";
+import { ModuleContext } from "./ModuleContext";
+import { ModuleInstance } from "./ModuleInstance";
 import { StateBaseType, StateOptions } from "./StateStore";
 import { Workbench } from "./Workbench";
 import { WorkbenchServices } from "./WorkbenchServices";

--- a/frontend/src/framework/ModuleContext.ts
+++ b/frontend/src/framework/ModuleContext.ts
@@ -14,20 +14,19 @@ export class ModuleContext<S extends StateBaseType> {
         return this._moduleInstance.getId();
     }
 
-    // Make this an ordinary method instead, stateStore()?
-    get stateStore(): StateStore<S> {
+    getStateStore(): StateStore<S> {
         return this._stateStore;
     }
 
     useStoreState<K extends keyof S>(key: K): [S[K], (value: S[K] | ((prev: S[K]) => S[K])) => void] {
-        return useStoreState(this.stateStore, key);
+        return useStoreState(this._stateStore, key);
     }
 
     useStoreValue<K extends keyof S>(key: K): S[K] {
-        return useStoreValue(this.stateStore, key);
+        return useStoreValue(this._stateStore, key);
     }
 
     useSetStoreValue<K extends keyof S>(key: K): (newValue: S[K] | ((prev: S[K]) => S[K])) => void {
-        return useSetStoreValue(this.stateStore, key);
+        return useSetStoreValue(this._stateStore, key);
     }
 }

--- a/frontend/src/framework/ModuleContext.ts
+++ b/frontend/src/framework/ModuleContext.ts
@@ -10,7 +10,7 @@ export class ModuleContext<S extends StateBaseType> {
         this._stateStore = stateStore;
     }
 
-    instanceIdString(): string {
+    getInstanceIdString(): string {
         return this._moduleInstance.getId();
     }
 

--- a/frontend/src/framework/ModuleContext.ts
+++ b/frontend/src/framework/ModuleContext.ts
@@ -1,0 +1,33 @@
+import { ModuleInstance } from "./ModuleInstance";
+import { StateBaseType, StateStore, useSetStoreValue, useStoreState, useStoreValue } from "./StateStore";
+
+export class ModuleContext<S extends StateBaseType> {
+    private _moduleInstance: ModuleInstance<S>;
+    private _stateStore: StateStore<S>;
+
+    constructor(moduleInstance: ModuleInstance<S>, stateStore: StateStore<S>) {
+        this._moduleInstance = moduleInstance;
+        this._stateStore = stateStore;
+    }
+
+    instanceIdString(): string {
+        return this._moduleInstance.getId();
+    }
+
+    // Make this an ordinary method instead, stateStore()?
+    get stateStore(): StateStore<S> {
+        return this._stateStore;
+    }
+
+    useStoreState<K extends keyof S>(key: K): [S[K], (value: S[K] | ((prev: S[K]) => S[K])) => void] {
+        return useStoreState(this.stateStore, key);
+    }
+
+    useStoreValue<K extends keyof S>(key: K): S[K] {
+        return useStoreValue(this.stateStore, key);
+    }
+
+    useSetStoreValue<K extends keyof S>(key: K): (newValue: S[K] | ((prev: S[K]) => S[K])) => void {
+        return useSetStoreValue(this.stateStore, key);
+    }
+}

--- a/frontend/src/framework/ModuleInstance.ts
+++ b/frontend/src/framework/ModuleInstance.ts
@@ -1,12 +1,6 @@
 import { ImportState, Module, ModuleFC } from "./Module";
+import { ModuleContext } from "./ModuleContext";
 import { StateBaseType, StateOptions, StateStore, useSetStoreValue, useStoreState, useStoreValue } from "./StateStore";
-
-export type ModuleContext<S extends StateBaseType> = {
-    useStoreState: <K extends keyof S>(key: K) => [S[K], (value: S[K] | ((prev: S[K]) => S[K])) => void];
-    useStoreValue: <K extends keyof S>(key: K) => S[K];
-    useSetStoreValue: <K extends keyof S>(key: K) => (newValue: S[K] | ((prev: S[K]) => S[K])) => void;
-    stateStore: StateStore<S>;
-};
 
 export class ModuleInstance<StateType extends StateBaseType> {
     private id: string;
@@ -29,21 +23,7 @@ export class ModuleInstance<StateType extends StateBaseType> {
 
     public setInitialState(initialState: StateType, options?: StateOptions<StateType>): void {
         this.stateStore = new StateStore<StateType>(initialState, options);
-
-        this.context = {
-            useStoreState: <K extends keyof StateType>(
-                key: K
-            ): [StateType[K], (value: StateType[K] | ((prev: StateType[K]) => StateType[K])) => void] =>
-                useStoreState(this.stateStore as Exclude<typeof this.stateStore, null>, key),
-            useStoreValue: <K extends keyof StateType>(key: K): StateType[K] =>
-                useStoreValue(this.stateStore as Exclude<typeof this.stateStore, null>, key),
-            useSetStoreValue: <K extends keyof StateType>(
-                key: K
-            ): ((newValue: StateType[K] | ((prev: StateType[K]) => StateType[K])) => void) =>
-                useSetStoreValue(this.stateStore as Exclude<typeof this.stateStore, null>, key),
-            stateStore: this.stateStore,
-        };
-
+        this.context = new ModuleContext<StateType>(this, this.stateStore);
         this.initialised = true;
     }
 

--- a/frontend/src/modules/Map/MapSettings.tsx
+++ b/frontend/src/modules/Map/MapSettings.tsx
@@ -99,7 +99,7 @@ export function MapSettings({ moduleContext, workbenchServices }: ModuleFCProps<
         }
 
         console.log(`propagateSurfaceSelectionToView() => ${surfAddr ? "valid surfAddr" : "NULL surfAddr"}`);
-        moduleContext.stateStore.setValue("surfaceAddress", surfAddr);
+        moduleContext.getStateStore().setValue("surfaceAddress", surfAddr);
     });
 
     function handleStaticSurfacesCheckboxChanged(event: React.ChangeEvent<HTMLInputElement>, staticChecked: boolean) {

--- a/frontend/src/modules/SimulationTimeSeries/settings.tsx
+++ b/frontend/src/modules/SimulationTimeSeries/settings.tsx
@@ -37,14 +37,14 @@ export function settings({ moduleContext, workbenchServices }: ModuleFCProps<Sta
     React.useEffect(
         function propagateVectorSpecToView() {
             if (firstEnsemble && computedVectorName) {
-                moduleContext.stateStore.setValue("vectorSpec", {
+                moduleContext.getStateStore().setValue("vectorSpec", {
                     caseUuid: firstEnsemble.caseUuid,
                     caseName: firstEnsemble.caseName,
                     ensembleName: firstEnsemble.ensembleName,
                     vectorName: computedVectorName,
                 });
             } else {
-                moduleContext.stateStore.setValue("vectorSpec", null);
+                moduleContext.getStateStore().setValue("vectorSpec", null);
             }
         },
         [firstEnsemble, computedVectorName]
@@ -75,7 +75,7 @@ export function settings({ moduleContext, workbenchServices }: ModuleFCProps<Sta
         console.log("handleRealizationRangeTextChanged() " + event.target.value);
         const rangeArr = parseRealizationRangeString(event.target.value, 200);
         console.log(rangeArr);
-        moduleContext.stateStore.setValue("realizationsToInclude", rangeArr.length > 0 ? rangeArr : null);
+        moduleContext.getStateStore().setValue("realizationsToInclude", rangeArr.length > 0 ? rangeArr : null);
     }
 
     return (


### PR DESCRIPTION
Converted ModuleContext into a class and changed the `ModuleContext.stateStore` property into a regular method  `ModuleContext.getStateStore()`