### PR TITLE
Introduced optional state store persistency

### DIFF
--- a/frontend/src/framework/ModuleInstance.ts
+++ b/frontend/src/framework/ModuleInstance.ts
@@ -28,7 +28,7 @@ export class ModuleInstance<StateType extends StateBaseType> {
     }
 
     public setInitialState(initialState: StateType, options?: StateOptions<StateType>): void {
-        this.stateStore = new StateStore<StateType>(initialState, options);
+        this.stateStore = new StateStore<StateType>(this.id, initialState, options);
 
         this.context = {
             useStoreState: <K extends keyof StateType>(

--- a/frontend/src/framework/Workbench.ts
+++ b/frontend/src/framework/Workbench.ts
@@ -28,6 +28,7 @@ export type WorkbenchDataState = {
 
 export type WorkbenchGuiState = {
     modulesListOpen: boolean;
+    syncSettingsActive: boolean;
 };
 
 export class Workbench {
@@ -42,12 +43,21 @@ export class Workbench {
     constructor() {
         this.moduleInstances = [];
         this._activeModuleId = "";
-        this.guiStateStore = new StateStore<WorkbenchGuiState>({
+        this.guiStateStore = new StateStore<WorkbenchGuiState>("workbenchGuiState", {
             modulesListOpen: false,
+            syncSettingsActive: false,
         });
-        this.dataStateStore = new StateStore<WorkbenchDataState>({
-            selectedEnsembles: [],
-        });
+        this.dataStateStore = new StateStore<WorkbenchDataState>(
+            "workbenchDataState",
+            {
+                selectedEnsembles: [],
+            },
+            {
+                selectedEnsembles: {
+                    persistent: true,
+                },
+            }
+        );
         this._workbenchServices = new PrivateWorkbenchServices(this);
         this._subscribersMap = {};
         this.layout = [];


### PR DESCRIPTION
Implemented option for storing state store states in local storage. Main use case: Ensemble selection, but other states can also be stored if wanted.