### PR TITLE
Use `orjson` as default encoder

### DIFF
--- a/backend/src/backend/primary/main.py
+++ b/backend/src/backend/primary/main.py
@@ -3,6 +3,7 @@ import logging
 
 from fastapi import FastAPI
 from fastapi.routing import APIRoute
+from fastapi.responses import ORJSONResponse
 from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 
 from src.backend.shared_middleware import add_shared_middlewares
@@ -27,7 +28,11 @@ def custom_generate_unique_id(route: APIRoute) -> str:
     return f"{route.name}"
 
 
-app = FastAPI(generate_unique_id_function=custom_generate_unique_id, root_path="/api")
+app = FastAPI(
+    generate_unique_id_function=custom_generate_unique_id,
+    root_path="/api",
+    default_response_class=ORJSONResponse,
+)
 
 # The tags we add here will determine the name of the frontend api service for our endpoints as well as
 # providing some grouping when viewing the openapi documentation.

--- a/backend/src/backend/user_session/main.py
+++ b/backend/src/backend/user_session/main.py
@@ -1,10 +1,11 @@
 from fastapi import FastAPI
+from fastapi.responses import ORJSONResponse
 
 from src.backend.shared_middleware import add_shared_middlewares
 from .inactivity_shutdown import InactivityShutdown
 from .routers.general import router as general_router
 
-app = FastAPI()
+app = FastAPI(default_response_class=ORJSONResponse)
 
 app.include_router(general_router)
 


### PR DESCRIPTION
`orjson` is significantly faster than `json` from std.lib. The difference is significant for lager JSON objects (which often is the case in FMU). Use this as default encoder.

Closes #118.