### PR TITLE
Give `console` level information

### DIFF
--- a/frontend/.eslintrc.cjs
+++ b/frontend/.eslintrc.cjs
@@ -9,6 +9,7 @@ module.exports = {
         "react/jsx-uses-react": "off", // Import of React is not required anymore in React 17
         "react/react-in-jsx-scope": "off", // Import of React is not required anymore in React 17
         "react/destructuring-assignment": ["error", "never"],
+        "no-console": ["error", { allow: ["debug", "info", "warn", "error"] }],
     },
     parser: "@typescript-eslint/parser",
     parserOptions: {

--- a/frontend/compress_static.cjs
+++ b/frontend/compress_static.cjs
@@ -27,7 +27,7 @@ const compressFile = (filePath) => {
 
       const reduction = (100 * (origSize - compSize)) / origSize;
 
-      console.log(
+      console.info(
         `${filePath} → ${compFilePath} (${reduction.toFixed(1)} % reduction)`
       );
 

--- a/frontend/src/modules/InplaceVolumetrics/settings.tsx
+++ b/frontend/src/modules/InplaceVolumetrics/settings.tsx
@@ -154,7 +154,7 @@ export function settings({ moduleContext, workbenchServices }: ModuleFCProps<Sta
 
     React.useEffect(
         function selectDefaultTable() {
-            console.log("selectDefaultTable()");
+            console.debug("selectDefaultTable()");
             if (tableDescriptionsQuery.data) {
                 setTableName(tableDescriptionsQuery.data[0].name);
                 const responses = tableDescriptionsQuery.data[0].numerical_column_names;
@@ -168,7 +168,7 @@ export function settings({ moduleContext, workbenchServices }: ModuleFCProps<Sta
     );
 
     function handleEnsembleSelectionChange(ensembleString: string) {
-        console.log("handleEnsembleSelectionChange()");
+        console.debug("handleEnsembleSelectionChange()");
         const [caseUuid, ensembleName] = ensembleString.split("::");
         const matchingEnsemble = selectedEnsembles?.find(
             (el) => el.caseUuid === caseUuid && el.ensembleName === ensembleName
@@ -176,16 +176,16 @@ export function settings({ moduleContext, workbenchServices }: ModuleFCProps<Sta
         setEnsemble(matchingEnsemble ?? null);
     }
     function handleTableChange(tableName: string) {
-        console.log("handleTableChange()");
+        console.debug("handleTableChange()");
         setTableName(tableName);
     }
     function handleResponseChange(responseName: string) {
-        console.log("handleResponseChange()");
+        console.debug("handleResponseChange()");
         setResponseName(responseName);
     }
 
     const handleSelectionChange = React.useCallback((categoryName: string, categoryValues: string[]) => {
-        console.log("handleSelectionChange()");
+        console.debug("handleSelectionChange()");
         let currentCategoryFilter = categoricalFilter;
         if (currentCategoryFilter) {
             const categoryIndex = currentCategoryFilter.findIndex((category) => category.name === categoryName);

--- a/frontend/src/modules/Map/MapSettings.tsx
+++ b/frontend/src/modules/Map/MapSettings.tsx
@@ -22,7 +22,7 @@ import { AggregationDropdown } from "./UiComponents";
 //-----------------------------------------------------------------------------------------------------------
 export function MapSettings(props: ModuleFCProps<MapState>) {
     const myInstanceIdStr = props.moduleContext.getInstanceIdString();
-    console.log(`${myInstanceIdStr} -- render MapSettings`);
+    console.debug(`${myInstanceIdStr} -- render MapSettings`);
 
     const availableEnsembles = useSubscribedValue("navigator.ensembles", props.workbenchServices);
     const [selectedEnsemble, setSelectedEnsemble] = React.useState<Ensemble | null>(null);
@@ -119,15 +119,15 @@ export function MapSettings(props: ModuleFCProps<MapState>) {
     }
 
     React.useEffect(function propagateSurfaceSelectionToView() {
-        // console.log("propagateSurfaceSelectionToView()");
-        // console.log(`  caseUuid=${caseUuid}`);
-        // console.log(`  ensembleName=${ensembleName}`);
-        // console.log(`  surfaceName=${surfaceName}`);
-        // console.log(`  surfaceAttribute=${surfaceAttribute}`);
-        // console.log(`  surfaceType=${surfaceType}`);
-        // console.log(`  aggregation=${aggregation}`);
-        // console.log(`  realizationNum=${realizationNum}`);
-        // console.log(`  timeOrInterval=${timeOrInterval}`);
+        // console.debug("propagateSurfaceSelectionToView()");
+        // console.debug(`  caseUuid=${caseUuid}`);
+        // console.debug(`  ensembleName=${ensembleName}`);
+        // console.debug(`  surfaceName=${surfaceName}`);
+        // console.debug(`  surfaceAttribute=${surfaceAttribute}`);
+        // console.debug(`  surfaceType=${surfaceType}`);
+        // console.debug(`  aggregation=${aggregation}`);
+        // console.debug(`  realizationNum=${realizationNum}`);
+        // console.debug(`  timeOrInterval=${timeOrInterval}`);
 
         let surfAddr: SurfAddr | null = null;
         if (computedEnsemble && computedSurfaceName && computedSurfaceAttribute) {
@@ -152,12 +152,12 @@ export function MapSettings(props: ModuleFCProps<MapState>) {
             }
         }
 
-        console.log(`propagateSurfaceSelectionToView() => ${surfAddr ? "valid surfAddr" : "NULL surfAddr"}`);
+        console.debug(`propagateSurfaceSelectionToView() => ${surfAddr ? "valid surfAddr" : "NULL surfAddr"}`);
         props.moduleContext.getStateStore().setValue("surfaceAddress", surfAddr);
     });
 
     function handleEnsembleSelectionChange(selectedEnsembleIdStr: string) {
-        console.log("handleEnsembleSelectionChange()");
+        console.debug("handleEnsembleSelectionChange()");
         const newEnsemble = availableEnsembles?.find((item) => encodeEnsembleAsIdStr(item) === selectedEnsembleIdStr);
         setSelectedEnsemble(newEnsemble ?? null);
         if (newEnsemble) {
@@ -171,7 +171,7 @@ export function MapSettings(props: ModuleFCProps<MapState>) {
     }
 
     function handleSurfNameSelectionChange(selectedSurfNames: string[]) {
-        console.log("handleSurfNameSelectionChange()");
+        console.debug("handleSurfNameSelectionChange()");
         const newName = selectedSurfNames[0] ?? null;
         setSelectedSurfaceName(newName);
         if (newName && computedSurfaceAttribute) {
@@ -183,7 +183,7 @@ export function MapSettings(props: ModuleFCProps<MapState>) {
     }
 
     function handleSurfAttributeSelectionChange(selectedSurfAttributes: string[]) {
-        console.log("handleSurfAttributeSelectionChange()");
+        console.debug("handleSurfAttributeSelectionChange()");
         const newAttr = selectedSurfAttributes[0] ?? null;
         setSelectedSurfaceAttribute(newAttr);
         if (newAttr && computedSurfaceName) {
@@ -195,7 +195,7 @@ export function MapSettings(props: ModuleFCProps<MapState>) {
     }
 
     function handleTimeOrIntervalSelectionChange(selectedTimeOrIntervals: string[]) {
-        console.log("handleTimeOrIntervalSelectionChange()");
+        console.debug("handleTimeOrIntervalSelectionChange()");
         const newTimeOrInterval = selectedTimeOrIntervals[0] ?? null;
         setSelectedTimeOrInterval(newTimeOrInterval);
         if (newTimeOrInterval) {
@@ -206,12 +206,12 @@ export function MapSettings(props: ModuleFCProps<MapState>) {
     }
 
     function handleAggregationChanged(aggregation: SurfaceStatisticFunction | null) {
-        console.log("handleAggregationChanged()");
+        console.debug("handleAggregationChanged()");
         setAggregation(aggregation);
     }
 
     function handleRealizationTextChanged(event: React.ChangeEvent<HTMLInputElement>) {
-        console.log("handleRealizationTextChanged() " + event.target.value);
+        console.debug("handleRealizationTextChanged() " + event.target.value);
         const realNum = parseInt(event.target.value, 10);
         if (realNum >= 0) {
             setRealizationNum(realNum);

--- a/frontend/src/modules/Map/MapView.tsx
+++ b/frontend/src/modules/Map/MapView.tsx
@@ -19,7 +19,7 @@ export function MapView(props: ModuleFCProps<MapState>) {
         renderCount.current = renderCount.current + 1;
     });
 
-    console.log(`render MapView, surfAddr=${surfAddr ? makeSurfAddrString(surfAddr) : "null"}`);
+    console.debug(`render MapView, surfAddr=${surfAddr ? makeSurfAddrString(surfAddr) : "null"}`);
 
     const surfDataQuery = useSurfaceDataQueryByAddress(surfAddr);
     if (!surfDataQuery.data) {

--- a/frontend/src/modules/SimulationTimeSeries/settings.tsx
+++ b/frontend/src/modules/SimulationTimeSeries/settings.tsx
@@ -21,7 +21,7 @@ import { State } from "./state";
 //-----------------------------------------------------------------------------------------------------------
 export function settings({ moduleContext, workbenchServices }: ModuleFCProps<State>) {
     const myInstanceIdStr = moduleContext.getInstanceIdString();
-    console.log(`${myInstanceIdStr} -- render SimulationTimeSeries settings`);
+    console.debug(`${myInstanceIdStr} -- render SimulationTimeSeries settings`);
 
     const availableEnsembles = useSubscribedValue("navigator.ensembles", workbenchServices);
     const [selectedEnsemble, setSelectedEnsemble] = React.useState<Ensemble | null>(null);
@@ -33,13 +33,13 @@ export function settings({ moduleContext, workbenchServices }: ModuleFCProps<Sta
     const syncHelper = new SyncSettingsHelper(syncedSettingKeys, workbenchServices);
     const syncedValueEnsembles = syncHelper.useValue(SyncSettingKey.ENSEMBLE, "global.syncValue.ensembles");
     const syncedValueSummaryVector = syncHelper.useValue(SyncSettingKey.TIME_SERIES, "global.syncValue.timeSeries");
-    console.log(`${myInstanceIdStr} -- synced keys ${JSON.stringify(syncedSettingKeys)}`);
-    console.log(`${myInstanceIdStr} -- syncedValueEnsembles=${JSON.stringify(syncedValueEnsembles)}`);
-    console.log(`${myInstanceIdStr} -- syncedValueSummaryVector=${JSON.stringify(syncedValueSummaryVector)}`);
+    console.debug(`${myInstanceIdStr} -- synced keys ${JSON.stringify(syncedSettingKeys)}`);
+    console.debug(`${myInstanceIdStr} -- syncedValueEnsembles=${JSON.stringify(syncedValueEnsembles)}`);
+    console.debug(`${myInstanceIdStr} -- syncedValueSummaryVector=${JSON.stringify(syncedValueSummaryVector)}`);
 
     let candidateEnsemble = selectedEnsemble;
     if (syncedValueEnsembles?.length) {
-        console.log(`${myInstanceIdStr} -- syncing ensemble to ${syncedValueEnsembles[0].ensembleName}`);
+        console.debug(`${myInstanceIdStr} -- syncing ensemble to ${syncedValueEnsembles[0].ensembleName}`);
         candidateEnsemble = syncedValueEnsembles[0];
     }
     const computedEnsemble = fixupEnsemble(candidateEnsemble, availableEnsembles);
@@ -48,7 +48,7 @@ export function settings({ moduleContext, workbenchServices }: ModuleFCProps<Sta
 
     let candidateVectorName = selectedVectorName;
     if (syncedValueSummaryVector?.vectorName) {
-        console.log(`${myInstanceIdStr} -- syncing timeSeries to ${syncedValueSummaryVector.vectorName}`);
+        console.debug(`${myInstanceIdStr} -- syncing timeSeries to ${syncedValueSummaryVector.vectorName}`);
         candidateVectorName = syncedValueSummaryVector.vectorName;
     }
     const computedVectorName = fixupVectorName(candidateVectorName, vectorsQuery.data);
@@ -77,7 +77,7 @@ export function settings({ moduleContext, workbenchServices }: ModuleFCProps<Sta
     );
 
     function handleEnsembleSelectionChange(selectedEnsembleIdStrArr: string[]) {
-        console.log("handleEnsembleSelectionChange()");
+        console.debug("handleEnsembleSelectionChange()");
         const newIdStr = selectedEnsembleIdStrArr[0] ?? "";
         const newEnsemble = availableEnsembles?.find((item) => encodeEnsembleAsIdStr(item) === newIdStr);
         setSelectedEnsemble(newEnsemble ?? null);
@@ -87,7 +87,7 @@ export function settings({ moduleContext, workbenchServices }: ModuleFCProps<Sta
     }
 
     function handleVectorSelectionChange(selectedVecNames: string[]) {
-        console.log("handleVectorSelectionChange()");
+        console.debug("handleVectorSelectionChange()");
         const newName = selectedVecNames[0] ?? "";
         setSelectedVectorName(newName);
         if (newName) {
@@ -96,24 +96,24 @@ export function settings({ moduleContext, workbenchServices }: ModuleFCProps<Sta
     }
 
     function handleFrequencySelectionChange(newFreqStr: string) {
-        console.log(`handleFrequencySelectionChange()  newFreqStr=${newFreqStr}`);
+        console.debug(`handleFrequencySelectionChange()  newFreqStr=${newFreqStr}`);
         let newFreq: Frequency | null = null;
         if (newFreqStr !== "RAW") {
             newFreq = newFreqStr as Frequency;
         }
-        console.log(`handleFrequencySelectionChange()  newFreqStr=${newFreqStr}  newFreq=${newFreq}`);
+        console.debug(`handleFrequencySelectionChange()  newFreqStr=${newFreqStr}  newFreq=${newFreq}`);
         setResamplingFrequency(newFreq);
     }
 
     function handleShowStatisticsCheckboxChange(event: React.ChangeEvent<HTMLInputElement>) {
-        console.log("handleShowStatisticsCheckboxChange() " + event.target.checked);
+        console.debug("handleShowStatisticsCheckboxChange() " + event.target.checked);
         setShowStatistics(event.target.checked);
     }
 
     function handleRealizationRangeTextChanged(event: React.ChangeEvent<HTMLInputElement>) {
-        console.log("handleRealizationRangeTextChanged() " + event.target.value);
+        console.debug("handleRealizationRangeTextChanged() " + event.target.value);
         const rangeArr = parseRealizationRangeString(event.target.value, 200);
-        console.log(rangeArr);
+        console.debug(rangeArr);
         moduleContext.getStateStore().setValue("realizationsToInclude", rangeArr.length > 0 ? rangeArr : null);
     }
 

--- a/frontend/src/modules/TimeSeriesParameterDistribution/settings.tsx
+++ b/frontend/src/modules/TimeSeriesParameterDistribution/settings.tsx
@@ -69,7 +69,7 @@ export function settings({ moduleContext, workbenchServices }: ModuleFCProps<Sta
     );
 
     function handleEnsembleSelectionChange(selectedEnsembleIdStr: string) {
-        console.log("handleEnsembleSelectionChange()");
+        console.debug("handleEnsembleSelectionChange()");
         const newEnsemble = availableEnsembles?.find((item) => encodeEnsembleAsIdStr(item) === selectedEnsembleIdStr);
         setSelectedEnsemble(newEnsemble ?? null);
         if (newEnsemble) {
@@ -78,7 +78,7 @@ export function settings({ moduleContext, workbenchServices }: ModuleFCProps<Sta
     }
 
     function handleVectorSelectionChange(selectedVecNames: string[]) {
-        console.log("handleVectorSelectionChange()");
+        console.debug("handleVectorSelectionChange()");
         const newName = selectedVecNames[0] ?? "";
         setSelectedVectorName(newName);
         if (newName) {

--- a/frontend/src/shared-utils/vtkUtils.ts
+++ b/frontend/src/shared-utils/vtkUtils.ts
@@ -163,17 +163,17 @@ function writeChunk(b64Str: any, chunk: any, dstOffset: any, uint8: any) {
         default:
             break;
     }
-    console.log("offset", offset)
+    console.debug("offset", offset)
 
     return offset;
 }
 
 export function toArrayBuffer(b64Str: any): ArrayBuffer {
-    console.log(b64Str)
+    console.debug(b64Str)
     b64Str = b64Str["bvals"]
 
     const chunks = extractChunks(b64Str);
-    console.log(chunks)
+    console.debug(chunks)
     const totalEncodedLength = chunks[chunks.length - 1].end + 1;
     const padding = (4 - (totalEncodedLength % 4)) % 4; // -length mod 4
     // Any padding chars in the middle of b64Str is to be interpreted as \x00,


### PR DESCRIPTION
Closes #139.

Currently we only use `console.log` for log output. Should use the different levels (`debug`, `info`, `warn`, `error`) in order for the developer to be able to filter on severity in browser console.