### PR TITLE
Use official `webviz-subsurface-components` `npm` namespace

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,7 +13,7 @@
                 "@mui/base": "^5.0.0-beta.3",
                 "@tanstack/react-query": "^4.24.10",
                 "@tanstack/react-query-devtools": "^4.24.12",
-                "@webviz/subsurface-components": "CeetronSolutions/wsc-dist",
+                "@webviz/subsurface-components": "^0.4.16-alpha.3",
                 "axios": "^1.3.0",
                 "lodash": "^4.17.21",
                 "react": "^17.0.2",
@@ -952,40 +952,40 @@
             }
         },
         "node_modules/@emerson-eps/color-tables": {
-            "version": "0.4.48",
-            "resolved": "https://registry.npmjs.org/@emerson-eps/color-tables/-/color-tables-0.4.48.tgz",
-            "integrity": "sha512-38eECBMSiefjOciVQUiUELRezPhUGAhbTlQpKfxbQPA7JRIFwihWKCd2bpNpnjuztPsA9qSwWeE0qEHL/RDWPg==",
+            "version": "0.4.53",
+            "resolved": "https://registry.npmjs.org/@emerson-eps/color-tables/-/color-tables-0.4.53.tgz",
+            "integrity": "sha512-cXz1t3SnJDysKmTFcbLE/j5V/kGu4WwHjiqWeqbsQz7FsIKeJmqlr9sF6xNkquB+y8CG0pAvB2Mx6Ve8agtLPw==",
             "dependencies": {
-                "@emotion/react": "^11.10.5",
+                "@emotion/react": "^11.10.6",
                 "@emotion/styled": "^11.10.0",
-                "@equinor/eds-core-react": "^0.29.1",
+                "@equinor/eds-core-react": "^0.31.1",
                 "@mui/icons-material": "^5.10.9",
-                "@mui/material": "^5.10.2",
-                "@mui/styles": "^5.11.13",
-                "d3": "^7.2.0",
+                "@mui/material": "^5.12.1",
+                "@mui/system": "^5.12.0",
+                "d3": "^7.8.4",
                 "d3-color": "^3.0.1",
                 "d3-interpolate": "^3.0.1",
                 "react-color": "^2.19.3",
-                "react-resize-detector": "^8.0.2",
+                "react-resize-detector": "^9.1.0",
                 "web-vitals": "^3.0.2"
             },
             "peerDependencies": {
-                "react": "^17.0.2",
-                "react-dom": "^17.0.2"
+                "react": "^17 || ^18",
+                "react-dom": "^17 || ^18"
             }
         },
         "node_modules/@emerson-eps/color-tables/node_modules/@equinor/eds-core-react": {
-            "version": "0.29.1",
-            "resolved": "https://registry.npmjs.org/@equinor/eds-core-react/-/eds-core-react-0.29.1.tgz",
-            "integrity": "sha512-t8NyJSXC8qUdZrfJsd5au7DFCLRk+IaBpmiaxr070ajOSojF4Mdj4ELePmusZW0Rz4OxZ83/VXZww/B3w3u7jA==",
+            "version": "0.31.1",
+            "resolved": "https://registry.npmjs.org/@equinor/eds-core-react/-/eds-core-react-0.31.1.tgz",
+            "integrity": "sha512-js85TPQJhOMwHPiROltVrctJGWWZ2kJALLlkgZM1E5I86oWD5AIfNv73pFZQFYwtOTDvSExHDBJ2xAzgOC7Byw==",
             "dependencies": {
-                "@babel/runtime": "^7.20.7",
-                "@equinor/eds-icons": "0.18.0",
-                "@equinor/eds-tokens": "0.9.0",
+                "@babel/runtime": "^7.21.0",
+                "@equinor/eds-icons": "0.19.1",
+                "@equinor/eds-tokens": "0.9.1",
                 "@equinor/eds-utils": "0.7.0",
-                "@floating-ui/react": "^0.16.0",
-                "@tanstack/react-virtual": "3.0.0-beta.30",
-                "downshift": "^7.1.2"
+                "@floating-ui/react": "^0.23.0",
+                "@tanstack/react-virtual": "3.0.0-beta.54",
+                "downshift": "^7.6.0"
             },
             "engines": {
                 "node": ">=10.0.0",
@@ -998,73 +998,21 @@
             }
         },
         "node_modules/@emerson-eps/color-tables/node_modules/@equinor/eds-icons": {
-            "version": "0.18.0",
-            "resolved": "https://registry.npmjs.org/@equinor/eds-icons/-/eds-icons-0.18.0.tgz",
-            "integrity": "sha512-2M0XaNp5r2lIIN5bOfhE3/i/utiURDCC06WXVj/3H2H3ZUNgcYjYnU4tr2BJHRi5/ruH6z1UxWwYTB0hUZCrGQ==",
+            "version": "0.19.1",
+            "resolved": "https://registry.npmjs.org/@equinor/eds-icons/-/eds-icons-0.19.1.tgz",
+            "integrity": "sha512-0GZqzLhJQGqAHsTmviUK9au+eRsT9z2BcJTbWWmG8EtxjWNq5dcTpeGSOv6pWNY5nfcGhLNtjOIjRlSidWMHnw==",
             "engines": {
                 "node": ">=10.0.0",
                 "pnpm": ">=4"
             }
         },
         "node_modules/@emerson-eps/color-tables/node_modules/@equinor/eds-tokens": {
-            "version": "0.9.0",
-            "resolved": "https://registry.npmjs.org/@equinor/eds-tokens/-/eds-tokens-0.9.0.tgz",
-            "integrity": "sha512-7FLqrH13dRc/q+wxHzZrIGkV35XMYIGojjkqLIbIeM0AwijSE1PETKqLauNf8VtMZPevt/2Hr9dV2a2NpEORQw==",
+            "version": "0.9.1",
+            "resolved": "https://registry.npmjs.org/@equinor/eds-tokens/-/eds-tokens-0.9.1.tgz",
+            "integrity": "sha512-EElCCO6JUCAQFlLU7FXiQSH8MZT/AE45suwWCPLDs+6RNopiqvMBo3kNMVcNYojKEsQSM5z68aofdPljrZOnYw==",
             "engines": {
                 "node": ">=10.0.0",
                 "pnpm": ">=4"
-            }
-        },
-        "node_modules/@emerson-eps/color-tables/node_modules/@mui/styles": {
-            "version": "5.12.0",
-            "resolved": "https://registry.npmjs.org/@mui/styles/-/styles-5.12.0.tgz",
-            "integrity": "sha512-X7obkgZTd9X+7igqwKKe8pEncyXYdUCNmyJfHruV9TSc6LThoI29OYs6hkN6n+7ueNli+YDKdZ+TCoC1GpJuOw==",
-            "dependencies": {
-                "@babel/runtime": "^7.21.0",
-                "@emotion/hash": "^0.9.0",
-                "@mui/private-theming": "^5.12.0",
-                "@mui/types": "^7.2.4",
-                "@mui/utils": "^5.12.0",
-                "clsx": "^1.2.1",
-                "csstype": "^3.1.2",
-                "hoist-non-react-statics": "^3.3.2",
-                "jss": "^10.10.0",
-                "jss-plugin-camel-case": "^10.10.0",
-                "jss-plugin-default-unit": "^10.10.0",
-                "jss-plugin-global": "^10.10.0",
-                "jss-plugin-nested": "^10.10.0",
-                "jss-plugin-props-sort": "^10.10.0",
-                "jss-plugin-rule-value-function": "^10.10.0",
-                "jss-plugin-vendor-prefixer": "^10.10.0",
-                "prop-types": "^15.8.1"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/mui"
-            },
-            "peerDependencies": {
-                "@types/react": "^17.0.0",
-                "react": "^17.0.0"
-            },
-            "peerDependenciesMeta": {
-                "@types/react": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@emerson-eps/color-tables/node_modules/@types/react": {
-            "version": "17.0.58",
-            "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.58.tgz",
-            "integrity": "sha512-c1GzVY97P0fGxwGxhYq989j4XwlcHQoto6wQISOC2v6wm3h0PORRWJFHlkRjfGsiG3y1609WdQ+J+tKxvrEd6A==",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@types/prop-types": "*",
-                "@types/scheduler": "*",
-                "csstype": "^3.0.2"
             }
         },
         "node_modules/@emerson-eps/color-tables/node_modules/compute-scroll-into-view": {
@@ -1092,52 +1040,40 @@
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
             "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
         },
-        "node_modules/@emerson-eps/color-tables/node_modules/react-resize-detector": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/react-resize-detector/-/react-resize-detector-8.1.0.tgz",
-            "integrity": "sha512-S7szxlaIuiy5UqLhLL1KY3aoyGHbZzsTpYal9eYMwCyKqoqoVLCmIgAgNyIM1FhnP2KyBygASJxdhejrzjMb+w==",
-            "dependencies": {
-                "lodash": "^4.17.21"
-            },
-            "peerDependencies": {
-                "react": "^16.0.0 || ^17.0.0 || ^18.0.0",
-                "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
-            }
-        },
         "node_modules/@emotion/babel-plugin": {
-            "version": "11.10.6",
-            "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.10.6.tgz",
-            "integrity": "sha512-p2dAqtVrkhSa7xz1u/m9eHYdLi+en8NowrmXeF/dKtJpU8lCWli8RUAati7NcSl0afsBott48pdnANuD0wh9QQ==",
+            "version": "11.11.0",
+            "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.11.0.tgz",
+            "integrity": "sha512-m4HEDZleaaCH+XgDDsPF15Ht6wTLsgDTeR3WYj9Q/k76JtWhrJjcP4+/XlG8LGT/Rol9qUfOIztXeA84ATpqPQ==",
             "dependencies": {
                 "@babel/helper-module-imports": "^7.16.7",
                 "@babel/runtime": "^7.18.3",
-                "@emotion/hash": "^0.9.0",
-                "@emotion/memoize": "^0.8.0",
-                "@emotion/serialize": "^1.1.1",
+                "@emotion/hash": "^0.9.1",
+                "@emotion/memoize": "^0.8.1",
+                "@emotion/serialize": "^1.1.2",
                 "babel-plugin-macros": "^3.1.0",
                 "convert-source-map": "^1.5.0",
                 "escape-string-regexp": "^4.0.0",
                 "find-root": "^1.1.0",
                 "source-map": "^0.5.7",
-                "stylis": "4.1.3"
+                "stylis": "4.2.0"
             }
         },
         "node_modules/@emotion/cache": {
-            "version": "11.10.7",
-            "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.10.7.tgz",
-            "integrity": "sha512-VLl1/2D6LOjH57Y8Vem1RoZ9haWF4jesHDGiHtKozDQuBIkJm2gimVo0I02sWCuzZtVACeixTVB4jeE8qvCBoQ==",
+            "version": "11.11.0",
+            "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.11.0.tgz",
+            "integrity": "sha512-P34z9ssTCBi3e9EI1ZsWpNHcfY1r09ZO0rZbRO2ob3ZQMnFI35jB536qoXbkdesr5EUhYi22anuEJuyxifaqAQ==",
             "dependencies": {
-                "@emotion/memoize": "^0.8.0",
-                "@emotion/sheet": "^1.2.1",
-                "@emotion/utils": "^1.2.0",
-                "@emotion/weak-memoize": "^0.3.0",
-                "stylis": "4.1.3"
+                "@emotion/memoize": "^0.8.1",
+                "@emotion/sheet": "^1.2.2",
+                "@emotion/utils": "^1.2.1",
+                "@emotion/weak-memoize": "^0.3.1",
+                "stylis": "4.2.0"
             }
         },
         "node_modules/@emotion/hash": {
-            "version": "0.9.0",
-            "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.0.tgz",
-            "integrity": "sha512-14FtKiHhy2QoPIzdTcvh//8OyBlknNs2nXRwIhG904opCby3l+9Xaf/wuPvICBF0rc1ZCNBd3nKe9cd2mecVkQ=="
+            "version": "0.9.1",
+            "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.1.tgz",
+            "integrity": "sha512-gJB6HLm5rYwSLI6PQa+X1t5CFGrv1J1TWG+sOyMCeKz2ojaj6Fnl/rZEspogG+cvqbt4AE/2eIyD2QfLKTBNlQ=="
         },
         "node_modules/@emotion/is-prop-valid": {
             "version": "1.2.1",
@@ -1153,17 +1089,17 @@
             "integrity": "sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA=="
         },
         "node_modules/@emotion/react": {
-            "version": "11.10.6",
-            "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.10.6.tgz",
-            "integrity": "sha512-6HT8jBmcSkfzO7mc+N1L9uwvOnlcGoix8Zn7srt+9ga0MjREo6lRpuVX0kzo6Jp6oTqDhREOFsygN6Ew4fEQbw==",
+            "version": "11.11.0",
+            "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.11.0.tgz",
+            "integrity": "sha512-ZSK3ZJsNkwfjT3JpDAWJZlrGD81Z3ytNDsxw1LKq1o+xkmO5pnWfr6gmCC8gHEFf3nSSX/09YrG67jybNPxSUw==",
             "dependencies": {
                 "@babel/runtime": "^7.18.3",
-                "@emotion/babel-plugin": "^11.10.6",
-                "@emotion/cache": "^11.10.5",
-                "@emotion/serialize": "^1.1.1",
-                "@emotion/use-insertion-effect-with-fallbacks": "^1.0.0",
-                "@emotion/utils": "^1.2.0",
-                "@emotion/weak-memoize": "^0.3.0",
+                "@emotion/babel-plugin": "^11.11.0",
+                "@emotion/cache": "^11.11.0",
+                "@emotion/serialize": "^1.1.2",
+                "@emotion/use-insertion-effect-with-fallbacks": "^1.0.1",
+                "@emotion/utils": "^1.2.1",
+                "@emotion/weak-memoize": "^0.3.1",
                 "hoist-non-react-statics": "^3.3.1"
             },
             "peerDependencies": {
@@ -1176,33 +1112,33 @@
             }
         },
         "node_modules/@emotion/serialize": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.1.1.tgz",
-            "integrity": "sha512-Zl/0LFggN7+L1liljxXdsVSVlg6E/Z/olVWpfxUTxOAmi8NU7YoeWeLfi1RmnB2TATHoaWwIBRoL+FvAJiTUQA==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.1.2.tgz",
+            "integrity": "sha512-zR6a/fkFP4EAcCMQtLOhIgpprZOwNmCldtpaISpvz348+DP4Mz8ZoKaGGCQpbzepNIUWbq4w6hNZkwDyKoS+HA==",
             "dependencies": {
-                "@emotion/hash": "^0.9.0",
-                "@emotion/memoize": "^0.8.0",
-                "@emotion/unitless": "^0.8.0",
-                "@emotion/utils": "^1.2.0",
+                "@emotion/hash": "^0.9.1",
+                "@emotion/memoize": "^0.8.1",
+                "@emotion/unitless": "^0.8.1",
+                "@emotion/utils": "^1.2.1",
                 "csstype": "^3.0.2"
             }
         },
         "node_modules/@emotion/sheet": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.2.1.tgz",
-            "integrity": "sha512-zxRBwl93sHMsOj4zs+OslQKg/uhF38MB+OMKoCrVuS0nyTkqnau+BM3WGEoOptg9Oz45T/aIGs1qbVAsEFo3nA=="
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.2.2.tgz",
+            "integrity": "sha512-0QBtGvaqtWi+nx6doRwDdBIzhNdZrXUppvTM4dtZZWEGTXL/XE/yJxLMGlDT1Gt+UHH5IX1n+jkXyytE/av7OA=="
         },
         "node_modules/@emotion/styled": {
-            "version": "11.10.6",
-            "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.10.6.tgz",
-            "integrity": "sha512-OXtBzOmDSJo5Q0AFemHCfl+bUueT8BIcPSxu0EGTpGk6DmI5dnhSzQANm1e1ze0YZL7TDyAyy6s/b/zmGOS3Og==",
+            "version": "11.11.0",
+            "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.11.0.tgz",
+            "integrity": "sha512-hM5Nnvu9P3midq5aaXj4I+lnSfNi7Pmd4EWk1fOZ3pxookaQTNew6bp4JaCBYM4HVFZF9g7UjJmsUmC2JlxOng==",
             "dependencies": {
                 "@babel/runtime": "^7.18.3",
-                "@emotion/babel-plugin": "^11.10.6",
-                "@emotion/is-prop-valid": "^1.2.0",
-                "@emotion/serialize": "^1.1.1",
-                "@emotion/use-insertion-effect-with-fallbacks": "^1.0.0",
-                "@emotion/utils": "^1.2.0"
+                "@emotion/babel-plugin": "^11.11.0",
+                "@emotion/is-prop-valid": "^1.2.1",
+                "@emotion/serialize": "^1.1.2",
+                "@emotion/use-insertion-effect-with-fallbacks": "^1.0.1",
+                "@emotion/utils": "^1.2.1"
             },
             "peerDependencies": {
                 "@emotion/react": "^11.0.0-rc.0",
@@ -1220,27 +1156,27 @@
             "integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ=="
         },
         "node_modules/@emotion/unitless": {
-            "version": "0.8.0",
-            "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.0.tgz",
-            "integrity": "sha512-VINS5vEYAscRl2ZUDiT3uMPlrFQupiKgHz5AA4bCH1miKBg4qtwkim1qPmJj/4WG6TreYMY111rEFsjupcOKHw=="
+            "version": "0.8.1",
+            "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.1.tgz",
+            "integrity": "sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ=="
         },
         "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.0.0.tgz",
-            "integrity": "sha512-1eEgUGmkaljiBnRMTdksDV1W4kUnmwgp7X9G8B++9GYwl1lUdqSndSriIrTJ0N7LQaoauY9JJ2yhiOYK5+NI4A==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.0.1.tgz",
+            "integrity": "sha512-jT/qyKZ9rzLErtrjGgdkMBn2OP8wl0G3sQlBb3YPryvKHsjvINUhVaPFfP+fpBcOkmrVOVEEHQFJ7nbj2TH2gw==",
             "peerDependencies": {
                 "react": ">=16.8.0"
             }
         },
         "node_modules/@emotion/utils": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.2.0.tgz",
-            "integrity": "sha512-sn3WH53Kzpw8oQ5mgMmIzzyAaH2ZqFEbozVVBSYp538E06OSE6ytOp7pRAjNQR+Q/orwqdQYJSe2m3hCOeznkw=="
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.2.1.tgz",
+            "integrity": "sha512-Y2tGf3I+XVnajdItskUCn6LX+VUDmP6lTL4fcqsXAv43dnlbZiuW4MWQW38rW/BVWSE7Q/7+XQocmpnRYILUmg=="
         },
         "node_modules/@emotion/weak-memoize": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.3.0.tgz",
-            "integrity": "sha512-AHPmaAx+RYfZz0eYu6Gviiagpmiyw98ySSlQvCUhVGDRtDFe4DBS0x1bSjdF3gqUDYOczB+yYvBTtEylYSdRhg=="
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.3.1.tgz",
+            "integrity": "sha512-EsBwpc7hBUJWAsNPBmJy4hxWx12v6bshQsldrVmjxJoc3isbxhOrF2IcCpaXxfvq03NwkI7sbsOLXbYuqF/8Ww=="
         },
         "node_modules/@equinor/eds-core-react": {
             "version": "0.12.1",
@@ -1840,19 +1776,19 @@
             "integrity": "sha512-EvYTiXet5XqweYGClEmpu3BoxmsQ4hkj3QaYA6qEnigCWffTP3vNRwBReTdrwDwo7OoJ3wM8Uoe9Uk4n+d4hfg=="
         },
         "node_modules/@floating-ui/dom": {
-            "version": "1.2.6",
-            "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.2.6.tgz",
-            "integrity": "sha512-02vxFDuvuVPs22iJICacezYJyf7zwwOCWkPNkWNBr1U0Qt1cKFYzWvxts0AmqcOQGwt/3KJWcWIgtbUU38keyw==",
+            "version": "1.2.9",
+            "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.2.9.tgz",
+            "integrity": "sha512-sosQxsqgxMNkV3C+3UqTS6LxP7isRLwX8WMepp843Rb3/b0Wz8+MdUkxJksByip3C2WwLugLHN1b4ibn//zKwQ==",
             "dependencies": {
                 "@floating-ui/core": "^1.2.6"
             }
         },
         "node_modules/@floating-ui/react": {
-            "version": "0.16.0",
-            "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.16.0.tgz",
-            "integrity": "sha512-h+69TJSAY2R/k5rw+az56RzzDFc/Tg7EHn/qEgwkIVz56Zg9LlaRMMUvxkcvd+iN3CNFDLtEnDlsXnpshjsRsQ==",
+            "version": "0.23.1",
+            "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.23.1.tgz",
+            "integrity": "sha512-OCc2ViQOBUKOGcE9NLAbpyqB+8Zz92IKIhxgz7XAkynKkVzcVSKtkWOcgyvO4SAzB2OybgRwk3WdzdzDRdh2QQ==",
             "dependencies": {
-                "@floating-ui/react-dom": "^1.1.2",
+                "@floating-ui/react-dom": "^1.3.0",
                 "aria-hidden": "^1.1.3",
                 "tabbable": "^6.0.1"
             },
@@ -3169,15 +3105,15 @@
             }
         },
         "node_modules/@mui/base": {
-            "version": "5.0.0-beta.3",
-            "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-beta.3.tgz",
-            "integrity": "sha512-ErOMoGNpgf6BF5W+jgXDiRlXJnpSeg8XSRonuY5UCCMHIlOWtKDtt/LS3qDAbFFGb7tV/y6EBddbcMeexx+zHw==",
+            "version": "5.0.0-beta.4",
+            "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-beta.4.tgz",
+            "integrity": "sha512-ejhtqYJpjDgHGEljjMBQWZ22yEK0OzIXNa7toJmmXsP4TT3W7xVy8bTJ0TniPDf+JNjrsgfgiFTDGdlEhV1E+g==",
             "dependencies": {
                 "@babel/runtime": "^7.21.0",
                 "@emotion/is-prop-valid": "^1.2.1",
                 "@mui/types": "^7.2.4",
                 "@mui/utils": "^5.13.1",
-                "@popperjs/core": "^2.11.7",
+                "@popperjs/core": "^2.11.8",
                 "clsx": "^1.2.1",
                 "prop-types": "^15.8.1",
                 "react-is": "^18.2.0"
@@ -3201,9 +3137,9 @@
             }
         },
         "node_modules/@mui/core-downloads-tracker": {
-            "version": "5.12.1",
-            "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.12.1.tgz",
-            "integrity": "sha512-rNiQYHtkXljcvCEnhWrJzie1ifff5O98j3uW7ZlchFgD8HWxEcz/QoxZvo+sCKC9aayAgxi9RsVn2VjCyp5CrA==",
+            "version": "5.13.4",
+            "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.13.4.tgz",
+            "integrity": "sha512-yFrMWcrlI0TqRN5jpb6Ma9iI7sGTHpytdzzL33oskFHNQ8UgrtPas33Y1K7sWAMwCrr1qbWDrOHLAQG4tAzuSw==",
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/mui"
@@ -3235,17 +3171,17 @@
             }
         },
         "node_modules/@mui/material": {
-            "version": "5.12.1",
-            "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.12.1.tgz",
-            "integrity": "sha512-m+G9J6+FzIMhRqKV2y30yONH97wX107z9EWgiNCeS1/+y1CnytFZNG1ENdOuaJo1NimCRnmB/iXPvoOaSo6dOg==",
+            "version": "5.13.4",
+            "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.13.4.tgz",
+            "integrity": "sha512-Yq+4f1KLPa/Szd3xqra2hbOAf2Usl8GbubncArM6LIp40mBLtXIdPE29MNtHsbtuzz4g+eidrETgoi3wdbEYfQ==",
             "dependencies": {
                 "@babel/runtime": "^7.21.0",
-                "@mui/base": "5.0.0-alpha.126",
-                "@mui/core-downloads-tracker": "^5.12.1",
-                "@mui/system": "^5.12.1",
+                "@mui/base": "5.0.0-beta.4",
+                "@mui/core-downloads-tracker": "^5.13.4",
+                "@mui/system": "^5.13.2",
                 "@mui/types": "^7.2.4",
-                "@mui/utils": "^5.12.0",
-                "@types/react-transition-group": "^4.4.5",
+                "@mui/utils": "^5.13.1",
+                "@types/react-transition-group": "^4.4.6",
                 "clsx": "^1.2.1",
                 "csstype": "^3.1.2",
                 "prop-types": "^15.8.1",
@@ -3278,45 +3214,13 @@
                 }
             }
         },
-        "node_modules/@mui/material/node_modules/@mui/base": {
-            "version": "5.0.0-alpha.126",
-            "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-alpha.126.tgz",
-            "integrity": "sha512-I5e52A0Muv9Gaoy2GcqbYrQ6dpRyC2UXeA00brT3HuW0nF0E4fiTOIqdNTN+N5gyaYK0z3O6jtLt/97CCrIxVA==",
-            "dependencies": {
-                "@babel/runtime": "^7.21.0",
-                "@emotion/is-prop-valid": "^1.2.0",
-                "@mui/types": "^7.2.4",
-                "@mui/utils": "^5.12.0",
-                "@popperjs/core": "^2.11.7",
-                "clsx": "^1.2.1",
-                "prop-types": "^15.8.1",
-                "react-is": "^18.2.0"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/mui"
-            },
-            "peerDependencies": {
-                "@types/react": "^17.0.0 || ^18.0.0",
-                "react": "^17.0.0 || ^18.0.0",
-                "react-dom": "^17.0.0 || ^18.0.0"
-            },
-            "peerDependenciesMeta": {
-                "@types/react": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/@mui/private-theming": {
-            "version": "5.12.0",
-            "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.12.0.tgz",
-            "integrity": "sha512-w5dwMen1CUm1puAtubqxY9BIzrBxbOThsg2iWMvRJmWyJAPdf3Z583fPXpqeA2lhTW79uH2jajk5Ka4FuGlTPg==",
+            "version": "5.13.1",
+            "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.13.1.tgz",
+            "integrity": "sha512-HW4npLUD9BAkVppOUZHeO1FOKUJWAwbpy0VQoGe3McUYTlck1HezGHQCfBQ5S/Nszi7EViqiimECVl9xi+/WjQ==",
             "dependencies": {
                 "@babel/runtime": "^7.21.0",
-                "@mui/utils": "^5.12.0",
+                "@mui/utils": "^5.13.1",
                 "prop-types": "^15.8.1"
             },
             "engines": {
@@ -3337,12 +3241,12 @@
             }
         },
         "node_modules/@mui/styled-engine": {
-            "version": "5.12.0",
-            "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.12.0.tgz",
-            "integrity": "sha512-frh8L7CRnvD0RDmIqEv6jFeKQUIXqW90BaZ6OrxJ2j4kIsiVLu29Gss4SbBvvrWwwatR72sBmC3w1aG4fjp9mQ==",
+            "version": "5.13.2",
+            "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.13.2.tgz",
+            "integrity": "sha512-VCYCU6xVtXOrIN8lcbuPmoG+u7FYuOERG++fpY74hPpEWkyFQG97F+/XfTQVYzlR2m7nPjnwVUgATcTCMEaMvw==",
             "dependencies": {
                 "@babel/runtime": "^7.21.0",
-                "@emotion/cache": "^11.10.7",
+                "@emotion/cache": "^11.11.0",
                 "csstype": "^3.1.2",
                 "prop-types": "^15.8.1"
             },
@@ -3368,15 +3272,15 @@
             }
         },
         "node_modules/@mui/system": {
-            "version": "5.12.1",
-            "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.12.1.tgz",
-            "integrity": "sha512-Po+sicdV3bbRYXdU29XZaHPZrW7HUYUqU1qCu77GCCEMbahC756YpeyefdIYuPMUg0OdO3gKIUfDISBrkjJL+w==",
+            "version": "5.13.2",
+            "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.13.2.tgz",
+            "integrity": "sha512-TPyWmRJPt0JPVxacZISI4o070xEJ7ftxpVtu6LWuYVOUOINlhoGOclam4iV8PDT3EMQEHuUrwU49po34UdWLlw==",
             "dependencies": {
                 "@babel/runtime": "^7.21.0",
-                "@mui/private-theming": "^5.12.0",
-                "@mui/styled-engine": "^5.12.0",
+                "@mui/private-theming": "^5.13.1",
+                "@mui/styled-engine": "^5.13.2",
                 "@mui/types": "^7.2.4",
-                "@mui/utils": "^5.12.0",
+                "@mui/utils": "^5.13.1",
                 "clsx": "^1.2.1",
                 "csstype": "^3.1.2",
                 "prop-types": "^15.8.1"
@@ -3653,9 +3557,9 @@
             }
         },
         "node_modules/@popperjs/core": {
-            "version": "2.11.7",
-            "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.7.tgz",
-            "integrity": "sha512-Cr4OjIkipTtcXKjAsm8agyleBuDHvxzeBoa1v543lbv1YaIwQjESsVcmjiWiPEbC1FIeHOG/Op9kdCmAmiS3Kw==",
+            "version": "2.11.8",
+            "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+            "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/popperjs"
@@ -3725,16 +3629,6 @@
             },
             "peerDependencies": {
                 "react": ">=16.8"
-            }
-        },
-        "node_modules/@react-leaflet/core": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@react-leaflet/core/-/core-1.1.1.tgz",
-            "integrity": "sha512-7PGLWa9MZ5x/cWy8EH2VzI4T8q5WpuHbixzCDXqixP/WyqwIrg5NDUPgYuFnB4IEIZF+6nA265mYzswFo/h1Pw==",
-            "peerDependencies": {
-                "leaflet": "^1.7.1",
-                "react": "^17.0.1",
-                "react-dom": "^17.0.1"
             }
         },
         "node_modules/@reduxjs/toolkit": {
@@ -3889,11 +3783,11 @@
             }
         },
         "node_modules/@tanstack/react-virtual": {
-            "version": "3.0.0-beta.30",
-            "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.0.0-beta.30.tgz",
-            "integrity": "sha512-Sn1SSbSjDwb++jVOtgiQ/OHFMdcXFg8Qx02/cn0eq9xxHIhm/SqrKDpywIeydgNdOsdfBomOfxm/4gqTLrY1gg==",
+            "version": "3.0.0-beta.54",
+            "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.0.0-beta.54.tgz",
+            "integrity": "sha512-D1mDMf4UPbrtHRZZriCly5bXTBMhylslm4dhcHqTtDJ6brQcgGmk8YD9JdWBGWfGSWPKoh2x1H3e7eh+hgPXtQ==",
             "dependencies": {
-                "@tanstack/virtual-core": "3.0.0-beta.30"
+                "@tanstack/virtual-core": "3.0.0-beta.54"
             },
             "funding": {
                 "type": "github",
@@ -3904,9 +3798,9 @@
             }
         },
         "node_modules/@tanstack/virtual-core": {
-            "version": "3.0.0-beta.30",
-            "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.0.0-beta.30.tgz",
-            "integrity": "sha512-fewNoKiJeG5v0T4jg7UO99G+hUYDHig6AkiIeqvC1O2zEw96MlzR6DXw91aqxcsIPSVp83IPsgNa7su8yZWldw==",
+            "version": "3.0.0-beta.54",
+            "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.0.0-beta.54.tgz",
+            "integrity": "sha512-jtkwqdP2rY2iCCDVAFuaNBH3fiEi29aTn2RhtIoky8DTTiCdc48plpHHreLwmv1PICJ4AJUUESaq3xa8fZH8+g==",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/tannerlinsley"
@@ -5220,18 +5114,10 @@
                 "redux": "^4.0.0"
             }
         },
-        "node_modules/@types/react-resize-detector": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/@types/react-resize-detector/-/react-resize-detector-5.0.0.tgz",
-            "integrity": "sha512-JTqR0G+RcC6Guqi/JXQBq3jewflumUGd4fDUucmZN9L1d8TZuRHzDTtrmgYWrgLvRTBTV6FjegmLeV1UnrIuzw==",
-            "dependencies": {
-                "@types/react": "*"
-            }
-        },
         "node_modules/@types/react-transition-group": {
-            "version": "4.4.5",
-            "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.5.tgz",
-            "integrity": "sha512-juKD/eiSM3/xZYzjuzH6ZwpP+/lejltmiS3QEzV/vmb/Q8+HfDmxu+Baga8UEMGBqV88Nbg4l2hY/K2DkyaLLA==",
+            "version": "4.4.6",
+            "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.6.tgz",
+            "integrity": "sha512-VnCdSxfcm08KjsJVQcfBmhEQAPnLB8G08hAxn39azX1qYBQ/5RVQuoHuKIcfKOdncuaUvEpFKFzEvbtIMsfVew==",
             "dependencies": {
                 "@types/react": "*"
             }
@@ -5571,11 +5457,6 @@
                 "url": "https://opencollective.com/eslint"
             }
         },
-        "node_modules/@ungap/structured-clone": {
-            "version": "0.3.4",
-            "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-0.3.4.tgz",
-            "integrity": "sha512-TSVh8CpnwNAsPC5wXcIyh92Bv1gq6E9cNDeeLu7Z4h8V4/qWtXJp7y42qljRkqcpmsve1iozwv1wr+3BNdILCg=="
-        },
         "node_modules/@vitejs/plugin-react": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-3.1.0.tgz",
@@ -5885,26 +5766,19 @@
             }
         },
         "node_modules/@webviz/subsurface-components": {
-            "version": "0.0.0",
-            "resolved": "git+ssh://git@github.com/CeetronSolutions/wsc-dist.git#4084cbe9dadce1d8a4aa974dde8508dc2adccb98",
-            "license": "MPL",
+            "version": "0.4.16-alpha.3",
+            "resolved": "https://registry.npmjs.org/@webviz/subsurface-components/-/subsurface-components-0.4.16-alpha.3.tgz",
+            "integrity": "sha512-hGcPJms29QrHU7eqwPVp0V1EkXlGJo9whnayyVNIINjx3rGvcJrMlz2iYAyw9VHPdU5slUlFJiBlecoV1wUWig==",
             "dependencies": {
-                "@emerson-eps/color-tables": "^0.4.47",
+                "@emerson-eps/color-tables": "^0.4.50",
                 "@equinor/eds-core-react": "^0.12.1",
                 "@equinor/eds-icons": "^0.9.1",
                 "@equinor/videx-wellog": "^0.8.0",
-                "@material-ui/core": "^4.12.3",
-                "@material-ui/lab": "^4.0.0-alpha.60",
-                "@react-leaflet/core": "^1.1.1",
+                "@mui/material": "^5.12.2",
+                "@mui/system": "^5.12.1",
                 "@reduxjs/toolkit": "^1.7.2",
-                "@types/geojson": "^7946.0.7",
-                "@types/react": "^17.0.3",
-                "@types/react-dom": "^17.0.3",
-                "@types/react-redux": "^7.1.15",
-                "@types/react-resize-detector": "^5.0.0",
-                "@ungap/structured-clone": "^0.3.4",
                 "@vivaxy/png": "^1.3.0",
-                "@webviz/core-components": "^0.6.0",
+                "@webviz/core-components": "^0.6.2",
                 "ajv": "^7.2.1",
                 "clsx": "^1.1.1",
                 "convert-units": "^2.3.4",
@@ -5912,20 +5786,14 @@
                 "d3-format": "^1.4.5",
                 "deck.gl": "^8.8.25",
                 "deep-equal": "^2.0.5",
-                "fast-json-patch": "^3.0.0-1",
                 "gl-matrix": "^3.4.3",
-                "jsonschema": "^1.4.0",
                 "jsverify": "^0.8.4",
-                "leaflet": "^1.6.0",
-                "leaflet-draw": "^1.0.4",
                 "lodash": "^4.17.21",
                 "mathjs": "^9.4.2",
                 "nebula.gl": "^0.22.3",
-                "react-dropdown-tree-select": "^2.5.1",
-                "react-leaflet": "2.8",
-                "react-leaflet-draw": "^0.19.8",
+                "react-dropdown-tree-select": "^2.8.0",
                 "react-redux": "^7.2.6",
-                "react-resize-detector": "^7.0.0",
+                "react-resize-detector": "^9.1.0",
                 "react-tooltip": "^4.2.21",
                 "redux": "^4.0.5",
                 "semver": "^7.3.5",
@@ -5937,174 +5805,8 @@
                 "npm": ">=6.14"
             },
             "peerDependencies": {
-                "react": "^17.0.2",
-                "react-dom": "^17.0.2"
-            }
-        },
-        "node_modules/@webviz/subsurface-components/node_modules/@emotion/hash": {
-            "version": "0.8.0",
-            "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
-            "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
-        },
-        "node_modules/@webviz/subsurface-components/node_modules/@material-ui/core": {
-            "version": "4.12.4",
-            "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-4.12.4.tgz",
-            "integrity": "sha512-tr7xekNlM9LjA6pagJmL8QCgZXaubWUwkJnoYcMKd4gw/t4XiyvnTkjdGrUVicyB2BsdaAv1tvow45bPM4sSwQ==",
-            "deprecated": "Material UI v4 doesn't receive active development since September 2021. See the guide https://mui.com/material-ui/migration/migration-v4/ to upgrade to v5.",
-            "dependencies": {
-                "@babel/runtime": "^7.4.4",
-                "@material-ui/styles": "^4.11.5",
-                "@material-ui/system": "^4.12.2",
-                "@material-ui/types": "5.1.0",
-                "@material-ui/utils": "^4.11.3",
-                "@types/react-transition-group": "^4.2.0",
-                "clsx": "^1.0.4",
-                "hoist-non-react-statics": "^3.3.2",
-                "popper.js": "1.16.1-lts",
-                "prop-types": "^15.7.2",
-                "react-is": "^16.8.0 || ^17.0.0",
-                "react-transition-group": "^4.4.0"
-            },
-            "engines": {
-                "node": ">=8.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/material-ui"
-            },
-            "peerDependencies": {
-                "@types/react": "^16.8.6 || ^17.0.0",
-                "react": "^16.8.0 || ^17.0.0",
-                "react-dom": "^16.8.0 || ^17.0.0"
-            },
-            "peerDependenciesMeta": {
-                "@types/react": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@webviz/subsurface-components/node_modules/@material-ui/lab": {
-            "version": "4.0.0-alpha.61",
-            "resolved": "https://registry.npmjs.org/@material-ui/lab/-/lab-4.0.0-alpha.61.tgz",
-            "integrity": "sha512-rSzm+XKiNUjKegj8bzt5+pygZeckNLOr+IjykH8sYdVk7dE9y2ZuUSofiMV2bJk3qU+JHwexmw+q0RyNZB9ugg==",
-            "deprecated": "Material UI v4 doesn't receive active development since September 2021. See the guide https://mui.com/material-ui/migration/migration-v4/ to upgrade to v5.",
-            "dependencies": {
-                "@babel/runtime": "^7.4.4",
-                "@material-ui/utils": "^4.11.3",
-                "clsx": "^1.0.4",
-                "prop-types": "^15.7.2",
-                "react-is": "^16.8.0 || ^17.0.0"
-            },
-            "engines": {
-                "node": ">=8.0.0"
-            },
-            "peerDependencies": {
-                "@material-ui/core": "^4.12.1",
-                "@types/react": "^16.8.6 || ^17.0.0",
-                "react": "^16.8.0 || ^17.0.0",
-                "react-dom": "^16.8.0 || ^17.0.0"
-            },
-            "peerDependenciesMeta": {
-                "@types/react": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@webviz/subsurface-components/node_modules/@material-ui/styles": {
-            "version": "4.11.5",
-            "resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-4.11.5.tgz",
-            "integrity": "sha512-o/41ot5JJiUsIETME9wVLAJrmIWL3j0R0Bj2kCOLbSfqEkKf0fmaPt+5vtblUh5eXr2S+J/8J3DaCb10+CzPGA==",
-            "deprecated": "Material UI v4 doesn't receive active development since September 2021. See the guide https://mui.com/material-ui/migration/migration-v4/ to upgrade to v5.",
-            "dependencies": {
-                "@babel/runtime": "^7.4.4",
-                "@emotion/hash": "^0.8.0",
-                "@material-ui/types": "5.1.0",
-                "@material-ui/utils": "^4.11.3",
-                "clsx": "^1.0.4",
-                "csstype": "^2.5.2",
-                "hoist-non-react-statics": "^3.3.2",
-                "jss": "^10.5.1",
-                "jss-plugin-camel-case": "^10.5.1",
-                "jss-plugin-default-unit": "^10.5.1",
-                "jss-plugin-global": "^10.5.1",
-                "jss-plugin-nested": "^10.5.1",
-                "jss-plugin-props-sort": "^10.5.1",
-                "jss-plugin-rule-value-function": "^10.5.1",
-                "jss-plugin-vendor-prefixer": "^10.5.1",
-                "prop-types": "^15.7.2"
-            },
-            "engines": {
-                "node": ">=8.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/material-ui"
-            },
-            "peerDependencies": {
-                "@types/react": "^16.8.6 || ^17.0.0",
-                "react": "^16.8.0 || ^17.0.0",
-                "react-dom": "^16.8.0 || ^17.0.0"
-            },
-            "peerDependenciesMeta": {
-                "@types/react": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@webviz/subsurface-components/node_modules/@material-ui/styles/node_modules/csstype": {
-            "version": "2.6.21",
-            "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.21.tgz",
-            "integrity": "sha512-Z1PhmomIfypOpoMjRQB70jfvy/wxT50qW08YXO5lMIJkrdq4yOTR+AW7FqutScmB9NkLwxo+jU+kZLbofZZq/w=="
-        },
-        "node_modules/@webviz/subsurface-components/node_modules/@material-ui/system": {
-            "version": "4.12.2",
-            "resolved": "https://registry.npmjs.org/@material-ui/system/-/system-4.12.2.tgz",
-            "integrity": "sha512-6CSKu2MtmiJgcCGf6nBQpM8fLkuB9F55EKfbdTC80NND5wpTmKzwdhLYLH3zL4cLlK0gVaaltW7/wMuyTnN0Lw==",
-            "dependencies": {
-                "@babel/runtime": "^7.4.4",
-                "@material-ui/utils": "^4.11.3",
-                "csstype": "^2.5.2",
-                "prop-types": "^15.7.2"
-            },
-            "engines": {
-                "node": ">=8.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/material-ui"
-            },
-            "peerDependencies": {
-                "@types/react": "^16.8.6 || ^17.0.0",
-                "react": "^16.8.0 || ^17.0.0",
-                "react-dom": "^16.8.0 || ^17.0.0"
-            },
-            "peerDependenciesMeta": {
-                "@types/react": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@webviz/subsurface-components/node_modules/@material-ui/system/node_modules/csstype": {
-            "version": "2.6.21",
-            "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.21.tgz",
-            "integrity": "sha512-Z1PhmomIfypOpoMjRQB70jfvy/wxT50qW08YXO5lMIJkrdq4yOTR+AW7FqutScmB9NkLwxo+jU+kZLbofZZq/w=="
-        },
-        "node_modules/@webviz/subsurface-components/node_modules/@types/react": {
-            "version": "17.0.58",
-            "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.58.tgz",
-            "integrity": "sha512-c1GzVY97P0fGxwGxhYq989j4XwlcHQoto6wQISOC2v6wm3h0PORRWJFHlkRjfGsiG3y1609WdQ+J+tKxvrEd6A==",
-            "dependencies": {
-                "@types/prop-types": "*",
-                "@types/scheduler": "*",
-                "csstype": "^3.0.2"
-            }
-        },
-        "node_modules/@webviz/subsurface-components/node_modules/@types/react-dom": {
-            "version": "17.0.19",
-            "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.19.tgz",
-            "integrity": "sha512-PiYG40pnQRdPHnlf7tZnp0aQ6q9tspYr72vD61saO6zFCybLfMqwUCN0va1/P+86DXn18ZWeW30Bk7xlC5eEAQ==",
-            "dependencies": {
-                "@types/react": "^17"
+                "react": "^17 || ^18",
+                "react-dom": "^17 || ^18"
             }
         },
         "node_modules/@webviz/subsurface-components/node_modules/lru-cache": {
@@ -6117,11 +5819,6 @@
             "engines": {
                 "node": ">=10"
             }
-        },
-        "node_modules/@webviz/subsurface-components/node_modules/react-is": {
-            "version": "17.0.2",
-            "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-            "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
         },
         "node_modules/@webviz/subsurface-components/node_modules/semver": {
             "version": "7.5.0",
@@ -7455,9 +7152,9 @@
             }
         },
         "node_modules/d3": {
-            "version": "7.8.4",
-            "resolved": "https://registry.npmjs.org/d3/-/d3-7.8.4.tgz",
-            "integrity": "sha512-q2WHStdhiBtD8DMmhDPyJmXUxr6VWRngKyiJ5EfXMxPw+tqT6BhNjhJZ4w3BHsNm3QoVfZLY8Orq/qPFczwKRA==",
+            "version": "7.8.5",
+            "resolved": "https://registry.npmjs.org/d3/-/d3-7.8.5.tgz",
+            "integrity": "sha512-JgoahDG51ncUfJu6wX/1vWQEqOflgXyl4MaHqlcSruTez7yhaRKR9i8VjjcQGeS2en/jnFivXuaIMnseMMt0XA==",
             "dependencies": {
                 "d3-array": "3",
                 "d3-axis": "3",
@@ -9187,11 +8884,6 @@
             "dependencies": {
                 "is-string-blank": "^1.0.1"
             }
-        },
-        "node_modules/fast-json-patch": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-3.1.1.tgz",
-            "integrity": "sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ=="
         },
         "node_modules/fast-json-stable-stringify": {
             "version": "2.1.0",
@@ -12566,14 +12258,6 @@
                 "graceful-fs": "^4.1.6"
             }
         },
-        "node_modules/jsonschema": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.4.1.tgz",
-            "integrity": "sha512-S6cATIPVv1z0IlxdN+zUk5EPjkGCdnhN4wVSBlvoUO1tOLJootbo9CquNJmbIh4yikWHiUedhRYrNPn1arpEmQ==",
-            "engines": {
-                "node": "*"
-            }
-        },
         "node_modules/jss": {
             "version": "10.10.0",
             "resolved": "https://registry.npmjs.org/jss/-/jss-10.10.0.tgz",
@@ -12710,16 +12394,6 @@
             "engines": {
                 "node": ">= 0.10.0"
             }
-        },
-        "node_modules/leaflet": {
-            "version": "1.9.3",
-            "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.3.tgz",
-            "integrity": "sha512-iB2cR9vAkDOu5l3HAay2obcUHZ7xwUBBjph8+PGtmW/2lYhbLizWtG7nTeYht36WfOslixQF9D/uSIzhZgGMfQ=="
-        },
-        "node_modules/leaflet-draw": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/leaflet-draw/-/leaflet-draw-1.0.4.tgz",
-            "integrity": "sha512-rsQ6saQO5ST5Aj6XRFylr5zvarWgzWnrg46zQ1MEOEIHsppdC/8hnN8qMoFvACsPvTioAuysya/TVtog15tyAQ=="
         },
         "node_modules/lerc": {
             "version": "4.0.1",
@@ -14763,43 +14437,6 @@
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
             "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
         },
-        "node_modules/react-leaflet": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/react-leaflet/-/react-leaflet-2.8.0.tgz",
-            "integrity": "sha512-Y7oHtNrrlRH8muDttXf+jZ2Ga/X7jneSGi1GN8uEdeCfLProTqgG2Zoa5TfloS3ZnY20v7w+DIenMG59beFsQw==",
-            "dependencies": {
-                "@babel/runtime": "^7.12.1",
-                "fast-deep-equal": "^3.1.3",
-                "hoist-non-react-statics": "^3.3.2",
-                "warning": "^4.0.3"
-            },
-            "peerDependencies": {
-                "leaflet": "^1.6.0",
-                "react": "^16.8.0 || ^17.0.0",
-                "react-dom": "^16.8.0  || ^17.0.0"
-            }
-        },
-        "node_modules/react-leaflet-draw": {
-            "version": "0.19.8",
-            "resolved": "https://registry.npmjs.org/react-leaflet-draw/-/react-leaflet-draw-0.19.8.tgz",
-            "integrity": "sha512-6e3KhDov++6QKR80ixohzZdESlqSiloYspZklT1qY5oxIOYmF+/Io830Yyd0RvUEMFCt6GirszalLrzuL2GP6A==",
-            "dependencies": {
-                "fast-deep-equal": "^2.0.1",
-                "lodash-es": "^4.17.15"
-            },
-            "peerDependencies": {
-                "leaflet": "^1.3.0",
-                "leaflet-draw": "^1.0.3",
-                "prop-types": "^15.5.2",
-                "react": "^16.3.0 || ^17.0.0",
-                "react-leaflet": "^2.0.0"
-            }
-        },
-        "node_modules/react-leaflet-draw/node_modules/fast-deep-equal": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-            "integrity": "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w=="
-        },
         "node_modules/react-lifecycles-compat": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
@@ -14869,9 +14506,9 @@
             }
         },
         "node_modules/react-resize-detector": {
-            "version": "7.1.2",
-            "resolved": "https://registry.npmjs.org/react-resize-detector/-/react-resize-detector-7.1.2.tgz",
-            "integrity": "sha512-zXnPJ2m8+6oq9Nn8zsep/orts9vQv3elrpA+R8XTcW7DVVUJ9vwDwMXaBtykAYjMnkCIaOoK9vObyR7ZgFNlOw==",
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/react-resize-detector/-/react-resize-detector-9.1.0.tgz",
+            "integrity": "sha512-vGFbfkIZp4itJqR4yl+GhjrZHtdlQvou1r10ek0yZUMkizKbPdekKTpPb003IV3b8E5BJFThVG0oocjE3lNsug==",
             "dependencies": {
                 "lodash": "^4.17.21"
             },
@@ -15263,9 +14900,9 @@
             }
         },
         "node_modules/robust-predicates": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.1.tgz",
-            "integrity": "sha512-ndEIpszUHiG4HtDsQLeIuMvRsDnn8c8rYStabochtUeCvfuvNptb5TUbVD68LRAILPX7p9nqQGh4xJgn3EHS/g=="
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
+            "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg=="
         },
         "node_modules/rollup": {
             "version": "3.20.6",
@@ -15814,9 +15451,9 @@
             "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
         },
         "node_modules/stylis": {
-            "version": "4.1.3",
-            "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.1.3.tgz",
-            "integrity": "sha512-GP6WDNWf+o403jrEp9c5jibKavrtLW+/qYGhFxFrG8maXhwTBI7gLLhiBb0o7uFccWN+EOS9aMO6cGHWAO07OA=="
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
+            "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw=="
         },
         "node_modules/sucrase": {
             "version": "3.32.0",
@@ -15958,9 +15595,9 @@
             }
         },
         "node_modules/tabbable": {
-            "version": "6.1.1",
-            "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.1.1.tgz",
-            "integrity": "sha512-4kl5w+nCB44EVRdO0g/UGoOp3vlwgycUVtkk/7DPyeLZUCuNFFKCFG6/t/DgHLrUPHjrZg6s5tNm+56Q2B0xyg=="
+            "version": "6.1.2",
+            "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.1.2.tgz",
+            "integrity": "sha512-qCN98uP7i9z0fIS4amQ5zbGBOq+OSigYeGvPy7NDk8Y9yncqDZ9pRPgfsc2PJIVM9RrJj7GIfuRgmjoUU9zTHQ=="
         },
         "node_modules/tailwindcss": {
             "version": "3.3.1",
@@ -17182,9 +16819,9 @@
             "peer": true
         },
         "node_modules/web-vitals": {
-            "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-3.3.1.tgz",
-            "integrity": "sha512-LTfY5GjcY3ngFzNsYFSYL+AmVmlWrzPTUxSMDis2rZbf+SzT7HH3NH4Y/l45XOlrAIunOBeURN9qtBHkRskAiA=="
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-3.3.2.tgz",
+            "integrity": "sha512-qRkpmSeKfEWAzNhtX541xA8gCJ+pqCqBmUlDVkVDSCSYUvfvNqF+k9g8I+uyreRcDBdfiJrd0/aLbTy5ydo49Q=="
         },
         "node_modules/webgl-context": {
             "version": "2.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,7 +19,7 @@
         "@mui/base": "^5.0.0-beta.3",
         "@tanstack/react-query": "^4.24.10",
         "@tanstack/react-query-devtools": "^4.24.12",
-        "@webviz/subsurface-components": "CeetronSolutions/wsc-dist",
+        "@webviz/subsurface-components": "^0.4.16-alpha.3",
         "axios": "^1.3.0",
         "lodash": "^4.17.21",
         "react": "^17.0.2",


### PR DESCRIPTION
Closes #158.

This ensures we are aligned with `webviz-subsurface-components` development again.

Map (still) works locally, but unfortunately it does **_not_** solve #96 - should probably first revisit that issue when the `webviz-subsurface-components` are split into smaller npm packages.