### PR TITLE
Added `.dockerignore`

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+.git
+.github
+.gitignore
+.vscode
+
+# frontend:
+**/node_modules
+
+# backend:
+**/__pycache__
+*.pyc
+.mypy_cache


### PR DESCRIPTION
Reduces build time of Docker images locally by reducing the context of the `COPY` command.

We will also to a larger extent be able to use already cached build layers locally.

Closes #164.