### PR TITLE
Revert `fmu-sumo` workaround

### DIFF
--- a/backend.Dockerfile
+++ b/backend.Dockerfile
@@ -12,7 +12,6 @@ WORKDIR /home/appuser/backend
 ENV PATH="${PATH}:/home/appuser/.local/bin"
 RUN pip install poetry \
     && poetry export --without-hashes -f requirements.txt -o requirements.txt \
-    && pip install -r requirements.txt \
-    && pip install git+https://github.com/equinor/fmu-sumo.git@0.3.7
+    && pip install -r requirements.txt
 
 CMD exec uvicorn --proxy-headers --host=0.0.0.0 $UVICORN_ENTRYPOINT


### PR DESCRIPTION
We can remove this now after https://github.com/equinor/fmu-sumo/pull/183.

We can/will do proper pinning of `fmu-sumo` and `sumo-wrapper-python` after https://github.com/equinor/fmu-sumo/issues/182.