### PR TITLE
Removed react/destructuring-assignment eslint rule

### DIFF
--- a/frontend/.eslintrc.cjs
+++ b/frontend/.eslintrc.cjs
@@ -8,7 +8,6 @@ module.exports = {
         "@typescript-eslint/no-explicit-any": "off",
         "react/jsx-uses-react": "off", // Import of React is not required anymore in React 17
         "react/react-in-jsx-scope": "off", // Import of React is not required anymore in React 17
-        "react/destructuring-assignment": ["error", "never"],
         "no-console": ["error", { allow: ["debug", "info", "warn", "error"] }],
     },
     parser: "@typescript-eslint/parser",

--- a/frontend/src/framework/components/ChannelSelect/channelSelect.tsx
+++ b/frontend/src/framework/components/ChannelSelect/channelSelect.tsx
@@ -18,7 +18,6 @@ export type ChannelSelectProps = {
 } & BaseComponentProps;
 
 export const ChannelSelect: React.FC<ChannelSelectProps> = (props) => {
-    // eslint-disable-next-line react/destructuring-assignment
     const { channelKeyCategory, onChange, broadcaster, ...rest } = props;
     const [channel, setChannel] = React.useState<string>(props.initialChannel ?? "");
     const [channels, setChannels] = React.useState<string[]>([]);

--- a/frontend/src/lib/components/Button/button.tsx
+++ b/frontend/src/lib/components/Button/button.tsx
@@ -12,7 +12,6 @@ export type ButtonProps = {
 } & ButtonUnstyledProps;
 
 export const Button = React.forwardRef((props: ButtonProps, ref: React.ForwardedRef<HTMLButtonElement>) => {
-    // eslint-disable-next-line react/destructuring-assignment
     const { disabled, variant, children, startIcon, endIcon, ...rest } = props;
     const classNames = ["inline-flex", "items-center", "px-4", "py-2", "font-medium", "rounded-md"];
 

--- a/frontend/src/lib/components/IconButton/iconButton.tsx
+++ b/frontend/src/lib/components/IconButton/iconButton.tsx
@@ -13,7 +13,6 @@ export type IconButtonProps = {
 
 export const IconButton = React.forwardRef(
     (props: ButtonUnstyledProps & IconButtonProps, ref: React.ForwardedRef<HTMLButtonElement>) => {
-        // eslint-disable-next-line react/destructuring-assignment
         const { children, color, size, ...rest } = props;
         return (
             <BaseComponent disabled={rest.disabled}>

--- a/frontend/src/lib/components/Input/input.tsx
+++ b/frontend/src/lib/components/Input/input.tsx
@@ -10,7 +10,6 @@ export type InputProps = InputUnstyledProps & {
 };
 
 export const Input = React.forwardRef((props: InputProps, ref: React.ForwardedRef<HTMLInputElement>) => {
-    // eslint-disable-next-line react/destructuring-assignment
     const { startAdornment, endAdornment, wrapperStyle, ...other } = props;
 
     const internalRef = React.useRef<HTMLInputElement>(null);

--- a/frontend/src/lib/components/Slider/slider.tsx
+++ b/frontend/src/lib/components/Slider/slider.tsx
@@ -21,7 +21,6 @@ function keepValueInRange(value: number, min: number, max: number): number {
 }
 
 export const Slider = React.forwardRef((props: SliderProps, ref: React.ForwardedRef<HTMLDivElement>) => {
-    // eslint-disable-next-line react/destructuring-assignment
     const { displayValue, value: propsValue, ...rest } = props;
 
     const [value, setValue] = React.useState<number | number[]>(propsValue ?? 0);

--- a/frontend/src/lib/components/ToggleButton/toggleButton.tsx
+++ b/frontend/src/lib/components/ToggleButton/toggleButton.tsx
@@ -10,7 +10,6 @@ export type ToggleButtonProps = ButtonUnstyledProps & {
 };
 
 export const ToggleButton = React.forwardRef((props: ToggleButtonProps, ref: React.ForwardedRef<HTMLButtonElement>) => {
-    // eslint-disable-next-line react/destructuring-assignment
     const { active, onToggle, ...other } = props;
     const [isActive, setIsActive] = React.useState<boolean>(active);
 


### PR DESCRIPTION
Removed the esling react/destructuring-assignment rule and removed line-specific eslint rule disabling comments (eslint-disable-next-line)
