### PR TITLE
Include hashes in auto-generated `requirements.txt`

### DIFF
--- a/backend.Dockerfile
+++ b/backend.Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /home/appuser/backend
 
 ENV PATH="${PATH}:/home/appuser/.local/bin"
 RUN pip install poetry \
-    && poetry export --without-hashes -f requirements.txt -o requirements.txt \
+    && poetry export -f requirements.txt -o requirements.txt \
     && pip install -r requirements.txt
 
 CMD exec uvicorn --proxy-headers --host=0.0.0.0 $UVICORN_ENTRYPOINT


### PR DESCRIPTION
Since we do not have any packages installed directly from `git` anymore, we can re-introduce `poetry` hashes.