### PR TITLE
Renamed the initialState concept in framework to defaultState

### DIFF
--- a/frontend/src/framework/Module.tsx
+++ b/frontend/src/framework/Module.tsx
@@ -34,7 +34,7 @@ export class Module<StateType extends StateBaseType> {
     private numInstances: number;
     private importState: ImportState;
     private moduleInstances: ModuleInstance<StateType>[];
-    private initialState: StateType | null;
+    private defaultState: StateType | null;
     private stateOptions: StateOptions<StateType> | undefined;
     private workbench: Workbench | null;
     private syncableSettingKeys: SyncSettingKey[];
@@ -53,7 +53,7 @@ export class Module<StateType extends StateBaseType> {
         this.settingsFC = () => <div>Not defined</div>;
         this.importState = ImportState.NotImported;
         this.moduleInstances = [];
-        this.initialState = null;
+        this.defaultState = null;
         this.workbench = null;
         this.syncableSettingKeys = syncableSettingKeys;
         this.channelsDef = broadcastChannelsDef;
@@ -75,12 +75,12 @@ export class Module<StateType extends StateBaseType> {
         this.workbench = workbench;
     }
 
-    public setInitialState(initialState: StateType, options?: StateOptions<StateType>): void {
-        this.initialState = initialState;
+    public setDefaultState(defaultState: StateType, options?: StateOptions<StateType>): void {
+        this.defaultState = defaultState;
         this.stateOptions = options;
         this.moduleInstances.forEach((instance) => {
-            if (this.initialState && !instance.isInitialised()) {
-                instance.setInitialState(cloneDeep(this.initialState), cloneDeep(this.stateOptions));
+            if (this.defaultState && !instance.isInitialised()) {
+                instance.setDefaultState(cloneDeep(this.defaultState), cloneDeep(this.stateOptions));
             }
         });
     }
@@ -113,10 +113,10 @@ export class Module<StateType extends StateBaseType> {
 
     private maybeImportSelf(): void {
         if (this.importState !== ImportState.NotImported) {
-            if (this.initialState && this.importState === ImportState.Imported) {
+            if (this.defaultState && this.importState === ImportState.Imported) {
                 this.moduleInstances.forEach((instance) => {
-                    if (this.initialState && !instance.isInitialised()) {
-                        instance.setInitialState(cloneDeep(this.initialState), cloneDeep(this.stateOptions));
+                    if (this.defaultState && !instance.isInitialised()) {
+                        instance.setDefaultState(cloneDeep(this.defaultState), cloneDeep(this.stateOptions));
                     }
                 });
             }
@@ -129,8 +129,8 @@ export class Module<StateType extends StateBaseType> {
             .then(() => {
                 this.setImportState(ImportState.Imported);
                 this.moduleInstances.forEach((instance) => {
-                    if (this.initialState && !instance.isInitialised()) {
-                        instance.setInitialState(cloneDeep(this.initialState), cloneDeep(this.stateOptions));
+                    if (this.defaultState && !instance.isInitialised()) {
+                        instance.setDefaultState(cloneDeep(this.defaultState), cloneDeep(this.stateOptions));
                     }
                 });
             })

--- a/frontend/src/framework/ModuleInstance.ts
+++ b/frontend/src/framework/ModuleInstance.ts
@@ -34,7 +34,7 @@ export class ModuleInstance<StateType extends StateBaseType> {
     private syncedSettingsSubscribers: Set<(syncedSettings: SyncSettingKey[]) => void>;
     private titleChangeSubscribers: Set<(title: string) => void>;
     private broadcastChannels: Record<string, BroadcastChannel>;
-    private cachedInitialState: StateType | null;
+    private cachedDefaultState: StateType | null;
     private cachedStateStoreOptions?: StateOptions<StateType>;
 
     constructor(
@@ -56,7 +56,7 @@ export class ModuleInstance<StateType extends StateBaseType> {
         this.titleChangeSubscribers = new Set();
         this.moduleInstanceState = ModuleInstanceState.INITIALIZING;
         this.fatalError = null;
-        this.cachedInitialState = null;
+        this.cachedDefaultState = null;
 
         this.broadcastChannels = {} as Record<string, BroadcastChannel>;
 
@@ -80,13 +80,13 @@ export class ModuleInstance<StateType extends StateBaseType> {
         return this.broadcastChannels[channelName];
     }
 
-    public setInitialState(initialState: StateType, options?: StateOptions<StateType>): void {
-        if (this.cachedInitialState === null) {
-            this.cachedInitialState = initialState;
+    public setDefaultState(defaultState: StateType, options?: StateOptions<StateType>): void {
+        if (this.cachedDefaultState === null) {
+            this.cachedDefaultState = defaultState;
             this.cachedStateStoreOptions = options;
         }
 
-        this.stateStore = new StateStore<StateType>(cloneDeep(initialState), options);
+        this.stateStore = new StateStore<StateType>(cloneDeep(defaultState), options);
         this.context = new ModuleContext<StateType>(this, this.stateStore);
         this.initialised = true;
         this.setModuleInstanceState(ModuleInstanceState.OK);
@@ -238,7 +238,7 @@ export class ModuleInstance<StateType extends StateBaseType> {
         this.setModuleInstanceState(ModuleInstanceState.RESETTING);
 
         return new Promise((resolve) => {
-            this.setInitialState(this.cachedInitialState as StateType, this.cachedStateStoreOptions);
+            this.setDefaultState(this.cachedDefaultState as StateType, this.cachedStateStoreOptions);
             resolve();
         });
     }

--- a/frontend/src/framework/ModuleRegistry.ts
+++ b/frontend/src/framework/ModuleRegistry.ts
@@ -30,12 +30,12 @@ export class ModuleRegistry {
 
     public static initModule<ModuleStateType extends StateBaseType>(
         moduleName: string,
-        initialState: ModuleStateType,
+        defaultState: ModuleStateType,
         options?: StateOptions<ModuleStateType>
     ): Module<ModuleStateType> {
         const module = this._registeredModules[moduleName];
         if (module) {
-            module.setInitialState(initialState, options);
+            module.setDefaultState(defaultState, options);
             return module as Module<ModuleStateType>;
         }
         throw "Did you forget to register your module in 'src/modules/registerAllModules.ts'?";

--- a/frontend/src/framework/StateStore.ts
+++ b/frontend/src/framework/StateStore.ts
@@ -14,8 +14,8 @@ export class StateStore<StateType extends StateBaseType> {
     private _options?: StateOptions<StateType>;
     private _subscribersMap: Partial<Record<keyof StateType, Set<any>>>;
 
-    constructor(initialState: StateType, options?: StateOptions<StateType>) {
-        this._state = initialState;
+    constructor(defaultState: StateType, options?: StateOptions<StateType>) {
+        this._state = defaultState;
         this._subscribersMap = {};
         this._options = options;
     }

--- a/frontend/src/modules/DbgWorkbenchSpy/loadModule.tsx
+++ b/frontend/src/modules/DbgWorkbenchSpy/loadModule.tsx
@@ -2,11 +2,11 @@ import { ModuleRegistry } from "@framework/ModuleRegistry";
 
 import { SharedState, WorkbenchSpySettings, WorkbenchSpyView } from "./implementation";
 
-const initialState: SharedState = {
+const defaultState: SharedState = {
     triggeredRefreshCounter: 0,
 };
 
-const module = ModuleRegistry.initModule<SharedState>("DbgWorkbenchSpy", initialState);
+const module = ModuleRegistry.initModule<SharedState>("DbgWorkbenchSpy", defaultState);
 
 module.viewFC = WorkbenchSpyView;
 module.settingsFC = WorkbenchSpySettings;

--- a/frontend/src/modules/DistributionPlot/loadModule.tsx
+++ b/frontend/src/modules/DistributionPlot/loadModule.tsx
@@ -4,7 +4,7 @@ import { settings } from "./settings";
 import { State } from "./state";
 import { view } from "./view";
 
-const initialState: State = {
+const defaultState: State = {
     channelNameX: null,
     channelNameY: null,
     channelNameZ: null,
@@ -13,7 +13,7 @@ const initialState: State = {
     orientation: "h",
 };
 
-const module = ModuleRegistry.initModule<State>("DistributionPlot", initialState);
+const module = ModuleRegistry.initModule<State>("DistributionPlot", defaultState);
 
 module.viewFC = view;
 module.settingsFC = settings;

--- a/frontend/src/modules/Grid3D/loadModule.tsx
+++ b/frontend/src/modules/Grid3D/loadModule.tsx
@@ -4,7 +4,7 @@ import { settings } from "./settings";
 import state from "./state";
 import { view } from "./view";
 
-const initialState: state = {
+const defaultState: state = {
     gridName: "Simgrid",
     parameterName: "PORO",
     realizations: ["1"],
@@ -12,7 +12,7 @@ const initialState: state = {
 
 };
 
-const module = ModuleRegistry.initModule<state>("Grid3D", initialState, {
+const module = ModuleRegistry.initModule<state>("Grid3D", defaultState, {
 
 });
 

--- a/frontend/src/modules/Grid3DIntersection/loadModule.tsx
+++ b/frontend/src/modules/Grid3DIntersection/loadModule.tsx
@@ -4,7 +4,7 @@ import { settings } from "./settings";
 import state from "./state";
 import { view } from "./view";
 
-const initialState: state = {
+const defaultState: state = {
     gridName: "Simgrid",
     parameterName: "PORO",
     realizations: ["1"],
@@ -12,7 +12,7 @@ const initialState: state = {
 
 };
 
-const module = ModuleRegistry.initModule<state>("Grid3DIntersection", initialState, {
+const module = ModuleRegistry.initModule<state>("Grid3DIntersection", defaultState, {
 
 });
 

--- a/frontend/src/modules/InplaceVolumetrics/loadModule.tsx
+++ b/frontend/src/modules/InplaceVolumetrics/loadModule.tsx
@@ -4,7 +4,7 @@ import { settings } from "./settings";
 import { State } from "./state";
 import { view } from "./view";
 
-const initialState: State = {
+const defaultState: State = {
     ensembleIdent: null,
     tableName: null,
     categoricalOptions: null,
@@ -13,7 +13,7 @@ const initialState: State = {
     realizationsToInclude: null,
 };
 
-const module = ModuleRegistry.initModule<State>("InplaceVolumetrics", initialState);
+const module = ModuleRegistry.initModule<State>("InplaceVolumetrics", defaultState);
 
 module.viewFC = view;
 module.settingsFC = settings;

--- a/frontend/src/modules/Map/loadModule.tsx
+++ b/frontend/src/modules/Map/loadModule.tsx
@@ -4,11 +4,11 @@ import { MapSettings } from "./MapSettings";
 import { MapState } from "./MapState";
 import { MapView } from "./MapView";
 
-const initialState: MapState = {
+const defaultState: MapState = {
     surfaceAddress: null,
 };
 
-const module = ModuleRegistry.initModule<MapState>("Map", initialState, {
+const module = ModuleRegistry.initModule<MapState>("Map", defaultState, {
     surfaceAddress: { deepCompare: true },
 });
 

--- a/frontend/src/modules/MyModule/loadModule.tsx
+++ b/frontend/src/modules/MyModule/loadModule.tsx
@@ -4,11 +4,11 @@ import { settings } from "./settings";
 import { State } from "./state";
 import { view } from "./view";
 
-const initialState: State = {
+const defaultState: State = {
     count: 0,
 };
 
-const module = ModuleRegistry.initModule<State>("MyModule", initialState);
+const module = ModuleRegistry.initModule<State>("MyModule", defaultState);
 
 module.viewFC = view;
 module.settingsFC = settings;

--- a/frontend/src/modules/MyModule2/loadModule.tsx
+++ b/frontend/src/modules/MyModule2/loadModule.tsx
@@ -3,11 +3,11 @@ import { Input } from "@lib/components/Input";
 
 import { State } from "./state";
 
-const initialState: State = {
+const defaultState: State = {
     text: "Hello World",
 };
 
-const module = ModuleRegistry.initModule<State>("MyModule2", initialState);
+const module = ModuleRegistry.initModule<State>("MyModule2", defaultState);
 
 module.viewFC = (props) => {
     const text = props.moduleContext.useStoreValue("text");

--- a/frontend/src/modules/Pvt/loadModule.tsx
+++ b/frontend/src/modules/Pvt/loadModule.tsx
@@ -4,7 +4,7 @@ import { settings } from "./settings";
 import state from "./state";
 import { view } from "./view";
 
-const initialState: state = {
+const defaultState: state = {
     pvtVisualizations: ["volumefactor", "viscosity", "density", "ratio"],
     pvtNum: 1,
     pvtName: "Oil (PVTO)",
@@ -14,7 +14,7 @@ const initialState: state = {
 
 };
 
-const module = ModuleRegistry.initModule<state>("Pvt", initialState, {
+const module = ModuleRegistry.initModule<state>("Pvt", defaultState, {
 
 });
 

--- a/frontend/src/modules/Sensitivity/loadModule.tsx
+++ b/frontend/src/modules/Sensitivity/loadModule.tsx
@@ -4,13 +4,13 @@ import { settings } from "./settings";
 import { PlotType, State } from "./state";
 import { view } from "./view";
 
-const initialState: State = {
+const defaultState: State = {
     plotType: PlotType.TORNADO,
     selectedSensitivity: null,
     responseChannelName: null,
 };
 
-const module = ModuleRegistry.initModule<State>("Sensitivity", initialState);
+const module = ModuleRegistry.initModule<State>("Sensitivity", defaultState);
 
 module.viewFC = view;
 module.settingsFC = settings;

--- a/frontend/src/modules/SimulationTimeSeries/loadModule.tsx
+++ b/frontend/src/modules/SimulationTimeSeries/loadModule.tsx
@@ -5,14 +5,14 @@ import { settings } from "./settings";
 import { State } from "./state";
 import { view } from "./view";
 
-const initialState: State = {
+const defaultState: State = {
     vectorSpec: null,
     resamplingFrequency: Frequency_api.MONTHLY,
     showStatistics: true,
     realizationsToInclude: null,
 };
 
-const module = ModuleRegistry.initModule<State>("SimulationTimeSeries", initialState);
+const module = ModuleRegistry.initModule<State>("SimulationTimeSeries", defaultState);
 
 module.viewFC = view;
 module.settingsFC = settings;

--- a/frontend/src/modules/SimulationTimeSeriesSensitivity/loadModule.tsx
+++ b/frontend/src/modules/SimulationTimeSeriesSensitivity/loadModule.tsx
@@ -5,7 +5,7 @@ import { settings } from "./settings";
 import { State } from "./state";
 import { view } from "./view";
 
-const initialState: State = {
+const defaultState: State = {
     vectorSpec: null,
     resamplingFrequency: Frequency_api.MONTHLY,
     selectedSensitivity: null,
@@ -14,7 +14,7 @@ const initialState: State = {
     realizationsToInclude: null,
 };
 
-const module = ModuleRegistry.initModule<State>("SimulationTimeSeriesSensitivity", initialState);
+const module = ModuleRegistry.initModule<State>("SimulationTimeSeriesSensitivity", defaultState);
 
 module.viewFC = view;
 module.settingsFC = settings;

--- a/frontend/src/modules/TimeSeriesParameterDistribution/loadModule.tsx
+++ b/frontend/src/modules/TimeSeriesParameterDistribution/loadModule.tsx
@@ -4,14 +4,14 @@ import { settings } from "./settings";
 import { State } from "./state";
 import { view } from "./view";
 
-const initialState: State = {
+const defaultState: State = {
     vectorSpec: null,
     timeStep: null,
     parameterName: undefined
 };
 
 
-const module = ModuleRegistry.initModule<State>("TimeSeriesParameterDistribution", initialState);
+const module = ModuleRegistry.initModule<State>("TimeSeriesParameterDistribution", defaultState);
 
 module.viewFC = view;
 module.settingsFC = settings;


### PR DESCRIPTION
For clarity, rename the `initialState` concept in the framework to `defaultState`. 
Done to prepare for upcoming introduction of a new concept called `initialSettings` in PR #226 
