### PR TITLE
Set `max-warnings` to 0 for eslint

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,7 @@
         "preview": "vite preview",
         "generate-api": "openapi --input http://localhost:5000/openapi.json --output ./src/api --client axios --name ApiService --postfixModels _api",
         "typecheck": "tsc --noEmit",
-        "lint": "eslint 'src/**/*.+(ts|tsx|js|jsx|json)' 'tests/**/*.+(ts|tsx|js|jsx|json)'",
+        "lint": "eslint 'src/**/*.+(ts|tsx|js|jsx|json)' 'tests/**/*.+(ts|tsx|js|jsx|json)' --max-warnings=0",
         "validate": "npm run typecheck && npm run lint",
         "test": "jest"
     },


### PR DESCRIPTION
We have a lot of warnings for unused imports/variables. Whenever merging into main, we should make sure that all warnings are taken care of. If any warning cannot be fixed, it can be explicitly ignored by using eslint comment commands.