### PR TITLE
Housekeeping: prefix private properties and remove unneeded public

### DIFF
--- a/frontend/src/framework/Broadcaster.ts
+++ b/frontend/src/framework/Broadcaster.ts
@@ -138,26 +138,26 @@ export class BroadcastChannel {
         return generatedData;
     }
 
-    public getName(): string {
+    getName(): string {
         return this._name;
     }
 
-    public getDataDef(): BroadcastChannelDef {
+    getDataDef(): BroadcastChannelDef {
         return this._dataDef;
     }
 
-    public getMetaData(): BroadcastChannelMeta {
+    getMetaData(): BroadcastChannelMeta {
         if (!this._metaData) {
             throw new Error("No meta data");
         }
         return this._metaData;
     }
 
-    public getModuleInstanceId(): string {
+    getModuleInstanceId(): string {
         return this._moduleInstanceId;
     }
 
-    public broadcast(metaData: BroadcastChannelMeta, dataGenerator: () => BroadcastChannelData[]): void {
+    broadcast(metaData: BroadcastChannelMeta, dataGenerator: () => BroadcastChannelData[]): void {
         this._dataGenerator = dataGenerator;
         this._metaData = metaData;
 
@@ -172,7 +172,7 @@ export class BroadcastChannel {
         }
     }
 
-    public subscribe(
+    subscribe(
         callbackChannelDataChanged: (data: BroadcastChannelData[], metaData: BroadcastChannelMeta) => void
     ): () => void {
         this._subscribers.add(callbackChannelDataChanged);
@@ -200,7 +200,7 @@ export class Broadcaster {
         this._subscribers = new Set();
     }
 
-    public registerChannel(
+    registerChannel(
         channelName: string,
         channelDef: BroadcastChannelDef,
         moduleInstanceId: string
@@ -211,12 +211,12 @@ export class Broadcaster {
         return channel;
     }
 
-    public unregisterAllChannelsForModuleInstance(moduleInstanceId: string): void {
+    unregisterAllChannelsForModuleInstance(moduleInstanceId: string): void {
         this._channels = this._channels.filter((c) => c.getModuleInstanceId() !== moduleInstanceId);
         this.notifySubscribersAboutChannelsChanges();
     }
 
-    public getChannel(channelName: string): BroadcastChannel | null {
+    getChannel(channelName: string): BroadcastChannel | null {
         const channel = this._channels.find((c) => c.getName() === channelName);
         if (!channel) {
             return null;
@@ -225,11 +225,11 @@ export class Broadcaster {
         return channel as BroadcastChannel;
     }
 
-    public getChannelNames(): string[] {
+    getChannelNames(): string[] {
         return this._channels.map((c) => c.getName());
     }
 
-    public subscribeToChannelsChanges(cb: (channels: BroadcastChannel[]) => void): () => void {
+    subscribeToChannelsChanges(cb: (channels: BroadcastChannel[]) => void): () => void {
         this._subscribers.add(cb);
         cb(this._channels);
         return () => {

--- a/frontend/src/framework/Module.tsx
+++ b/frontend/src/framework/Module.tsx
@@ -34,15 +34,15 @@ export class Module<StateType extends StateBaseType> {
     private _defaultTitle: string;
     public viewFC: ModuleFC<StateType>;
     public settingsFC: ModuleFC<StateType>;
-    private numInstances: number;
-    private importState: ImportState;
-    private moduleInstances: ModuleInstance<StateType>[];
-    private defaultState: StateType | null;
-    private stateOptions: StateOptions<StateType> | undefined;
-    private workbench: Workbench | null;
-    private syncableSettingKeys: SyncSettingKey[];
-    private channelsDef: BroadcastChannelsDef;
-    private drawPreviewFunc: DrawPreviewFunc | null;
+    private _numInstances: number;
+    private _importState: ImportState;
+    private _moduleInstances: ModuleInstance<StateType>[];
+    private _defaultState: StateType | null;
+    private _stateOptions: StateOptions<StateType> | undefined;
+    private _workbench: Workbench | null;
+    private _syncableSettingKeys: SyncSettingKey[];
+    private _channelsDef: BroadcastChannelsDef;
+    private _drawPreviewFunc: DrawPreviewFunc | null;
 
     constructor(
         name: string,
@@ -53,24 +53,24 @@ export class Module<StateType extends StateBaseType> {
     ) {
         this._name = name;
         this._defaultTitle = defaultTitle;
-        this.numInstances = 0;
+        this._numInstances = 0;
         this.viewFC = () => <div>Not defined</div>;
         this.settingsFC = () => <div>Not defined</div>;
-        this.importState = ImportState.NotImported;
-        this.moduleInstances = [];
-        this.defaultState = null;
-        this.workbench = null;
-        this.syncableSettingKeys = syncableSettingKeys;
-        this.channelsDef = broadcastChannelsDef;
-        this.drawPreviewFunc = drawPreviewFunc;
+        this._importState = ImportState.NotImported;
+        this._moduleInstances = [];
+        this._defaultState = null;
+        this._workbench = null;
+        this._syncableSettingKeys = syncableSettingKeys;
+        this._channelsDef = broadcastChannelsDef;
+        this._drawPreviewFunc = drawPreviewFunc;
     }
 
     getDrawPreviewFunc(): DrawPreviewFunc | null {
-        return this.drawPreviewFunc;
+        return this._drawPreviewFunc;
     }
 
     getImportState(): ImportState {
-        return this.importState;
+        return this._importState;
     }
 
     getName() {
@@ -82,51 +82,51 @@ export class Module<StateType extends StateBaseType> {
     }
 
     setWorkbench(workbench: Workbench): void {
-        this.workbench = workbench;
+        this._workbench = workbench;
     }
 
     setDefaultState(defaultState: StateType, options?: StateOptions<StateType>): void {
-        this.defaultState = defaultState;
-        this.stateOptions = options;
-        this.moduleInstances.forEach((instance) => {
-            if (this.defaultState && !instance.isInitialised()) {
-                instance.setDefaultState(cloneDeep(this.defaultState), cloneDeep(this.stateOptions));
+        this._defaultState = defaultState;
+        this._stateOptions = options;
+        this._moduleInstances.forEach((instance) => {
+            if (this._defaultState && !instance.isInitialised()) {
+                instance.setDefaultState(cloneDeep(this._defaultState), cloneDeep(this._stateOptions));
             }
         });
     }
 
     getSyncableSettingKeys(): SyncSettingKey[] {
-        return this.syncableSettingKeys;
+        return this._syncableSettingKeys;
     }
 
     makeInstance(): ModuleInstance<StateType> {
-        if (!this.workbench) {
+        if (!this._workbench) {
             throw new Error("Module must be added to a workbench before making an instance");
         }
 
-        const instance = new ModuleInstance<StateType>(this, this.numInstances++, this.channelsDef, this.workbench);
-        this.moduleInstances.push(instance);
+        const instance = new ModuleInstance<StateType>(this, this._numInstances++, this._channelsDef, this._workbench);
+        this._moduleInstances.push(instance);
         this.maybeImportSelf();
         return instance;
     }
 
     private setImportState(state: ImportState): void {
-        this.importState = state;
-        this.moduleInstances.forEach((instance) => {
+        this._importState = state;
+        this._moduleInstances.forEach((instance) => {
             instance.notifySubscribersAboutImportStateChange();
         });
 
-        if (this.workbench && state === ImportState.Imported) {
-            this.workbench.maybeMakeFirstModuleInstanceActive();
+        if (this._workbench && state === ImportState.Imported) {
+            this._workbench.maybeMakeFirstModuleInstanceActive();
         }
     }
 
     private maybeImportSelf(): void {
-        if (this.importState !== ImportState.NotImported) {
-            if (this.defaultState && this.importState === ImportState.Imported) {
-                this.moduleInstances.forEach((instance) => {
-                    if (this.defaultState && !instance.isInitialised()) {
-                        instance.setDefaultState(cloneDeep(this.defaultState), cloneDeep(this.stateOptions));
+        if (this._importState !== ImportState.NotImported) {
+            if (this._defaultState && this._importState === ImportState.Imported) {
+                this._moduleInstances.forEach((instance) => {
+                    if (this._defaultState && !instance.isInitialised()) {
+                        instance.setDefaultState(cloneDeep(this._defaultState), cloneDeep(this._stateOptions));
                     }
                 });
             }
@@ -138,9 +138,9 @@ export class Module<StateType extends StateBaseType> {
         import(`@modules/${this._name}/loadModule.tsx`)
             .then(() => {
                 this.setImportState(ImportState.Imported);
-                this.moduleInstances.forEach((instance) => {
-                    if (this.defaultState && !instance.isInitialised()) {
-                        instance.setDefaultState(cloneDeep(this.defaultState), cloneDeep(this.stateOptions));
+                this._moduleInstances.forEach((instance) => {
+                    if (this._defaultState && !instance.isInitialised()) {
+                        instance.setDefaultState(cloneDeep(this._defaultState), cloneDeep(this._stateOptions));
                     }
                 });
             })

--- a/frontend/src/framework/Module.tsx
+++ b/frontend/src/framework/Module.tsx
@@ -65,27 +65,27 @@ export class Module<StateType extends StateBaseType> {
         this.drawPreviewFunc = drawPreviewFunc;
     }
 
-    public getDrawPreviewFunc(): DrawPreviewFunc | null {
+    getDrawPreviewFunc(): DrawPreviewFunc | null {
         return this.drawPreviewFunc;
     }
 
-    public getImportState(): ImportState {
+    getImportState(): ImportState {
         return this.importState;
     }
 
-    public getName() {
+    getName() {
         return this._name;
     }
 
-    public getDefaultTitle() {
+    getDefaultTitle() {
         return this._defaultTitle;
     }
 
-    public setWorkbench(workbench: Workbench): void {
+    setWorkbench(workbench: Workbench): void {
         this.workbench = workbench;
     }
 
-    public setDefaultState(defaultState: StateType, options?: StateOptions<StateType>): void {
+    setDefaultState(defaultState: StateType, options?: StateOptions<StateType>): void {
         this.defaultState = defaultState;
         this.stateOptions = options;
         this.moduleInstances.forEach((instance) => {
@@ -95,11 +95,11 @@ export class Module<StateType extends StateBaseType> {
         });
     }
 
-    public getSyncableSettingKeys(): SyncSettingKey[] {
+    getSyncableSettingKeys(): SyncSettingKey[] {
         return this.syncableSettingKeys;
     }
 
-    public makeInstance(): ModuleInstance<StateType> {
+    makeInstance(): ModuleInstance<StateType> {
         if (!this.workbench) {
             throw new Error("Module must be added to a workbench before making an instance");
         }

--- a/frontend/src/framework/ModuleInstance.ts
+++ b/frontend/src/framework/ModuleInstance.ts
@@ -75,7 +75,7 @@ export class ModuleInstance<StateType extends StateBaseType> {
         }
     }
 
-    public getBroadcastChannel(channelName: string): BroadcastChannel {
+    getBroadcastChannel(channelName: string): BroadcastChannel {
         if (!this.broadcastChannels[channelName]) {
             throw new Error(`Channel '${channelName}' does not exist on module '${this.title}'`);
         }
@@ -83,7 +83,7 @@ export class ModuleInstance<StateType extends StateBaseType> {
         return this.broadcastChannels[channelName];
     }
 
-    public setDefaultState(defaultState: StateType, options?: StateOptions<StateType>): void {
+    setDefaultState(defaultState: StateType, options?: StateOptions<StateType>): void {
         if (this.cachedDefaultState === null) {
             this.cachedDefaultState = defaultState;
             this.cachedStateStoreOptions = options;
@@ -95,25 +95,25 @@ export class ModuleInstance<StateType extends StateBaseType> {
         this.setModuleInstanceState(ModuleInstanceState.OK);
     }
 
-    public addSyncedSetting(settingKey: SyncSettingKey): void {
+    addSyncedSetting(settingKey: SyncSettingKey): void {
         this.syncedSettingKeys.push(settingKey);
         this.notifySubscribersAboutSyncedSettingKeysChange();
     }
 
-    public getSyncedSettingKeys(): SyncSettingKey[] {
+    getSyncedSettingKeys(): SyncSettingKey[] {
         return this.syncedSettingKeys;
     }
 
-    public isSyncedSetting(settingKey: SyncSettingKey): boolean {
+    isSyncedSetting(settingKey: SyncSettingKey): boolean {
         return this.syncedSettingKeys.includes(settingKey);
     }
 
-    public removeSyncedSetting(settingKey: SyncSettingKey): void {
+    removeSyncedSetting(settingKey: SyncSettingKey): void {
         this.syncedSettingKeys = this.syncedSettingKeys.filter((a) => a !== settingKey);
         this.notifySubscribersAboutSyncedSettingKeysChange();
     }
 
-    public subscribeToSyncedSettingKeysChange(cb: (syncedSettings: SyncSettingKey[]) => void): () => void {
+    subscribeToSyncedSettingKeysChange(cb: (syncedSettings: SyncSettingKey[]) => void): () => void {
         this.syncedSettingsSubscribers.add(cb);
 
         // Trigger callback immediately with our current set of keys
@@ -124,90 +124,90 @@ export class ModuleInstance<StateType extends StateBaseType> {
         };
     }
 
-    public isInitialised(): boolean {
+    isInitialised(): boolean {
         return this.initialised;
     }
 
-    public getViewFC(): ModuleFC<StateType> {
+    getViewFC(): ModuleFC<StateType> {
         return this.module.viewFC;
     }
 
-    public getSettingsFC(): ModuleFC<StateType> {
+    getSettingsFC(): ModuleFC<StateType> {
         return this.module.settingsFC;
     }
 
-    public getImportState(): ImportState {
+    getImportState(): ImportState {
         return this.module.getImportState();
     }
 
-    public getContext(): ModuleContext<StateType> {
+    getContext(): ModuleContext<StateType> {
         if (!this.context) {
             throw `Module context is not available yet. Did you forget to init the module '${this.title}.'?`;
         }
         return this.context;
     }
 
-    public getId(): string {
+    getId(): string {
         return this.id;
     }
 
-    public getName(): string {
+    getName(): string {
         return this.module.getName();
     }
 
-    public getTitle(): string {
+    getTitle(): string {
         return this.title;
     }
 
-    public setTitle(title: string): void {
+    setTitle(title: string): void {
         this.title = title;
         this.notifySubscribersAboutTitleChange();
     }
 
-    public subscribeToTitleChange(cb: (title: string) => void): () => void {
+    subscribeToTitleChange(cb: (title: string) => void): () => void {
         this.titleChangeSubscribers.add(cb);
         return () => {
             this.titleChangeSubscribers.delete(cb);
         };
     }
 
-    public notifySubscribersAboutTitleChange(): void {
+    notifySubscribersAboutTitleChange(): void {
         this.titleChangeSubscribers.forEach((subscriber) => {
             subscriber(this.title);
         });
     }
 
-    public getModule(): Module<StateType> {
+    getModule(): Module<StateType> {
         return this.module;
     }
 
-    public subscribeToImportStateChange(cb: () => void): () => void {
+    subscribeToImportStateChange(cb: () => void): () => void {
         this.importStateSubscribers.add(cb);
         return () => {
             this.importStateSubscribers.delete(cb);
         };
     }
 
-    public notifySubscribersAboutImportStateChange(): void {
+    notifySubscribersAboutImportStateChange(): void {
         this.importStateSubscribers.forEach((subscriber) => {
             subscriber();
         });
     }
 
-    public notifySubscribersAboutSyncedSettingKeysChange(): void {
+    notifySubscribersAboutSyncedSettingKeysChange(): void {
         this.syncedSettingsSubscribers.forEach((subscriber) => {
             subscriber(this.syncedSettingKeys);
         });
     }
 
-    public subscribeToModuleInstanceStateChange(cb: () => void): () => void {
+    subscribeToModuleInstanceStateChange(cb: () => void): () => void {
         this.moduleInstanceStateSubscribers.add(cb);
         return () => {
             this.moduleInstanceStateSubscribers.delete(cb);
         };
     }
 
-    public notifySubscribersAboutModuleInstanceStateChange(): void {
+    notifySubscribersAboutModuleInstanceStateChange(): void {
         this.moduleInstanceStateSubscribers.forEach((subscriber) => {
             subscriber(this.moduleInstanceState);
         });
@@ -218,11 +218,11 @@ export class ModuleInstance<StateType extends StateBaseType> {
         this.notifySubscribersAboutModuleInstanceStateChange();
     }
 
-    public getModuleInstanceState(): ModuleInstanceState {
+    getModuleInstanceState(): ModuleInstanceState {
         return this.moduleInstanceState;
     }
 
-    public setFatalError(err: Error, errInfo: ErrorInfo): void {
+    setFatalError(err: Error, errInfo: ErrorInfo): void {
         this.setModuleInstanceState(ModuleInstanceState.ERROR);
         this.fatalError = {
             err,
@@ -230,14 +230,14 @@ export class ModuleInstance<StateType extends StateBaseType> {
         };
     }
 
-    public getFatalError(): {
+    getFatalError(): {
         err: Error;
         errInfo: ErrorInfo;
     } | null {
         return this.fatalError;
     }
 
-    public reset(): Promise<void> {
+    reset(): Promise<void> {
         this.setModuleInstanceState(ModuleInstanceState.RESETTING);
 
         return new Promise((resolve) => {

--- a/frontend/src/framework/ModuleRegistry.ts
+++ b/frontend/src/framework/ModuleRegistry.ts
@@ -14,10 +14,11 @@ export type RegisterModuleOptions = {
 
 export class ModuleRegistry {
     private static _registeredModules: Record<string, Module<any>> = {};
+
     /* eslint-disable-next-line @typescript-eslint/no-empty-function */
     private constructor() {}
 
-    public static registerModule<ModuleStateType extends StateBaseType>(
+    static registerModule<ModuleStateType extends StateBaseType>(
         options: RegisterModuleOptions
     ): Module<ModuleStateType> {
         const module = new Module<ModuleStateType>(
@@ -31,7 +32,7 @@ export class ModuleRegistry {
         return module;
     }
 
-    public static initModule<ModuleStateType extends StateBaseType>(
+    static initModule<ModuleStateType extends StateBaseType>(
         moduleName: string,
         defaultState: ModuleStateType,
         options?: StateOptions<ModuleStateType>
@@ -44,7 +45,7 @@ export class ModuleRegistry {
         throw "Did you forget to register your module in 'src/modules/registerAllModules.ts'?";
     }
 
-    public static getModule(moduleName: string): Module<any> {
+    static getModule(moduleName: string): Module<any> {
         const module = this._registeredModules[moduleName];
         if (module) {
             return module as Module<any>;
@@ -52,7 +53,7 @@ export class ModuleRegistry {
         throw "Did you forget to register your module in 'src/modules/registerAllModules.ts'?";
     }
 
-    public static getRegisteredModules(): Record<string, Module<any>> {
+    static getRegisteredModules(): Record<string, Module<any>> {
         return this._registeredModules;
     }
 }

--- a/frontend/src/framework/StateStore.ts
+++ b/frontend/src/framework/StateStore.ts
@@ -20,15 +20,15 @@ export class StateStore<StateType extends StateBaseType> {
         this._options = options;
     }
 
-    public hasKey(key: keyof StateType): boolean {
+    hasKey(key: keyof StateType): boolean {
         return key in this._state;
     }
 
-    public getValue<K extends keyof StateType>(key: K): StateType[K] {
+    getValue<K extends keyof StateType>(key: K): StateType[K] {
         return this._state[key];
     }
 
-    public setValue<K extends keyof StateType>(key: K, value: StateType[K]) {
+    setValue<K extends keyof StateType>(key: K, value: StateType[K]) {
         if (this._state[key] === value) {
             return;
         }
@@ -46,7 +46,7 @@ export class StateStore<StateType extends StateBaseType> {
         }
     }
 
-    public subscribe<K extends keyof StateType>(key: K, cb: (value: StateType[K]) => void) {
+    subscribe<K extends keyof StateType>(key: K, cb: (value: StateType[K]) => void) {
         const subscribersSet = this._subscribersMap[key] || new Set();
         subscribersSet.add(cb);
         this._subscribersMap[key] = subscribersSet;

--- a/frontend/src/framework/Workbench.ts
+++ b/frontend/src/framework/Workbench.ts
@@ -63,7 +63,7 @@ export class Workbench {
         this.layout = [];
     }
 
-    public loadLayoutFromLocalStorage(): boolean {
+    loadLayoutFromLocalStorage(): boolean {
         const layoutString = localStorage.getItem("layout");
         if (!layoutString) return false;
 
@@ -72,31 +72,31 @@ export class Workbench {
         return true;
     }
 
-    public getGuiStateStore(): StateStore<WorkbenchGuiState> {
+    getGuiStateStore(): StateStore<WorkbenchGuiState> {
         return this.guiStateStore;
     }
 
-    public getLayout(): LayoutElement[] {
+    getLayout(): LayoutElement[] {
         return this.layout;
     }
 
-    public getWorkbenchSession(): WorkbenchSession {
+    getWorkbenchSession(): WorkbenchSession {
         return this._workbenchSession;
     }
 
-    public getWorkbenchServices(): WorkbenchServices {
+    getWorkbenchServices(): WorkbenchServices {
         return this._workbenchServices;
     }
 
-    public getBroadcaster(): Broadcaster {
+    getBroadcaster(): Broadcaster {
         return this._broadcaster;
     }
 
-    public getActiveModuleId(): string {
+    getActiveModuleId(): string {
         return this._activeModuleId;
     }
 
-    public getActiveModuleName(): string {
+    getActiveModuleName(): string {
         return (
             this.moduleInstances
                 .find((moduleInstance) => moduleInstance.getId() === this._activeModuleId)
@@ -104,7 +104,7 @@ export class Workbench {
         );
     }
 
-    public setActiveModuleId(id: string) {
+    setActiveModuleId(id: string) {
         this._activeModuleId = id;
         this.notifySubscribers(WorkbenchEvents.ActiveModuleChanged);
     }
@@ -127,15 +127,15 @@ export class Workbench {
         };
     }
 
-    public getModuleInstances(): ModuleInstance<any>[] {
+    getModuleInstances(): ModuleInstance<any>[] {
         return this.moduleInstances;
     }
 
-    public getModuleInstance(id: string): ModuleInstance<any> | undefined {
+    getModuleInstance(id: string): ModuleInstance<any> | undefined {
         return this.moduleInstances.find((moduleInstance) => moduleInstance.getId() === id);
     }
 
-    public makeLayout(layout: LayoutElement[]): void {
+    makeLayout(layout: LayoutElement[]): void {
         this.moduleInstances = [];
         this.setLayout(layout);
         layout.forEach((element, index: number) => {
@@ -160,7 +160,7 @@ export class Workbench {
         this.setLayout([]);
     }
 
-    public makeAndAddModuleInstance(moduleName: string, layout: LayoutElement): ModuleInstance<any> {
+    makeAndAddModuleInstance(moduleName: string, layout: LayoutElement): ModuleInstance<any> {
         const module = ModuleRegistry.getModule(moduleName);
         if (!module) {
             throw new Error(`Module ${moduleName} not found`);
@@ -178,7 +178,7 @@ export class Workbench {
         return moduleInstance;
     }
 
-    public removeModuleInstance(moduleInstanceId: string): void {
+    removeModuleInstance(moduleInstanceId: string): void {
         this._broadcaster.unregisterAllChannelsForModuleInstance(moduleInstanceId);
         this.moduleInstances = this.moduleInstances.filter((el) => el.getId() !== moduleInstanceId);
 
@@ -191,7 +191,7 @@ export class Workbench {
         this.notifySubscribers(WorkbenchEvents.ModuleInstancesChanged);
     }
 
-    public setLayout(layout: LayoutElement[]): void {
+    setLayout(layout: LayoutElement[]): void {
         this.layout = layout;
         this.notifySubscribers(WorkbenchEvents.FullModuleRerenderRequested);
 
@@ -201,7 +201,7 @@ export class Workbench {
         localStorage.setItem("layout", JSON.stringify(modifiedLayout));
     }
 
-    public maybeMakeFirstModuleInstanceActive(): void {
+    maybeMakeFirstModuleInstanceActive(): void {
         if (!this.moduleInstances.some((el) => el.getId() === this._activeModuleId)) {
             this._activeModuleId =
                 this.moduleInstances
@@ -212,7 +212,7 @@ export class Workbench {
         }
     }
 
-    public async loadAndSetupEnsembleSetInSession(
+    async loadAndSetupEnsembleSetInSession(
         queryClient: QueryClient,
         specifiedEnsembleIdents: EnsembleIdent[]
     ): Promise<void> {

--- a/frontend/src/framework/Workbench.ts
+++ b/frontend/src/framework/Workbench.ts
@@ -41,26 +41,26 @@ export type WorkbenchGuiState = {
 };
 
 export class Workbench {
-    private moduleInstances: ModuleInstance<any>[];
+    private _moduleInstances: ModuleInstance<any>[];
     private _activeModuleId: string;
-    private guiStateStore: StateStore<WorkbenchGuiState>;
+    private _guiStateStore: StateStore<WorkbenchGuiState>;
     private _workbenchSession: WorkbenchSessionPrivate;
     private _workbenchServices: PrivateWorkbenchServices;
     private _broadcaster: Broadcaster;
     private _subscribersMap: { [key: string]: Set<() => void> };
-    private layout: LayoutElement[];
+    private _layout: LayoutElement[];
 
     constructor() {
-        this.moduleInstances = [];
+        this._moduleInstances = [];
         this._activeModuleId = "";
-        this.guiStateStore = new StateStore<WorkbenchGuiState>({
+        this._guiStateStore = new StateStore<WorkbenchGuiState>({
             drawerContent: DrawerContent.None,
         });
         this._workbenchSession = new WorkbenchSessionPrivate();
         this._workbenchServices = new PrivateWorkbenchServices(this);
         this._broadcaster = new Broadcaster();
         this._subscribersMap = {};
-        this.layout = [];
+        this._layout = [];
     }
 
     loadLayoutFromLocalStorage(): boolean {
@@ -73,11 +73,11 @@ export class Workbench {
     }
 
     getGuiStateStore(): StateStore<WorkbenchGuiState> {
-        return this.guiStateStore;
+        return this._guiStateStore;
     }
 
     getLayout(): LayoutElement[] {
-        return this.layout;
+        return this._layout;
     }
 
     getWorkbenchSession(): WorkbenchSession {
@@ -98,7 +98,7 @@ export class Workbench {
 
     getActiveModuleName(): string {
         return (
-            this.moduleInstances
+            this._moduleInstances
                 .find((moduleInstance) => moduleInstance.getId() === this._activeModuleId)
                 ?.getTitle() || ""
         );
@@ -128,15 +128,15 @@ export class Workbench {
     }
 
     getModuleInstances(): ModuleInstance<any>[] {
-        return this.moduleInstances;
+        return this._moduleInstances;
     }
 
     getModuleInstance(id: string): ModuleInstance<any> | undefined {
-        return this.moduleInstances.find((moduleInstance) => moduleInstance.getId() === id);
+        return this._moduleInstances.find((moduleInstance) => moduleInstance.getId() === id);
     }
 
     makeLayout(layout: LayoutElement[]): void {
-        this.moduleInstances = [];
+        this._moduleInstances = [];
         this.setLayout(layout);
         layout.forEach((element, index: number) => {
             const module = ModuleRegistry.getModule(element.moduleName);
@@ -146,17 +146,17 @@ export class Workbench {
 
             module.setWorkbench(this);
             const moduleInstance = module.makeInstance();
-            this.moduleInstances.push(moduleInstance);
-            this.layout[index] = { ...this.layout[index], moduleInstanceId: moduleInstance.getId() };
+            this._moduleInstances.push(moduleInstance);
+            this._layout[index] = { ...this._layout[index], moduleInstanceId: moduleInstance.getId() };
             this.notifySubscribers(WorkbenchEvents.ModuleInstancesChanged);
         });
     }
 
     private clearLayout(): void {
-        for (const moduleInstance of this.moduleInstances) {
+        for (const moduleInstance of this._moduleInstances) {
             this._broadcaster.unregisterAllChannelsForModuleInstance(moduleInstance.getId());
         }
-        this.moduleInstances = [];
+        this._moduleInstances = [];
         this.setLayout([]);
     }
 
@@ -169,9 +169,9 @@ export class Workbench {
         module.setWorkbench(this);
 
         const moduleInstance = module.makeInstance();
-        this.moduleInstances.push(moduleInstance);
+        this._moduleInstances.push(moduleInstance);
 
-        this.layout.push({ ...layout, moduleInstanceId: moduleInstance.getId() });
+        this._layout.push({ ...layout, moduleInstanceId: moduleInstance.getId() });
         this.notifySubscribers(WorkbenchEvents.ModuleInstancesChanged);
         this._activeModuleId = moduleInstance.getId();
         this.notifySubscribers(WorkbenchEvents.ActiveModuleChanged);
@@ -180,9 +180,9 @@ export class Workbench {
 
     removeModuleInstance(moduleInstanceId: string): void {
         this._broadcaster.unregisterAllChannelsForModuleInstance(moduleInstanceId);
-        this.moduleInstances = this.moduleInstances.filter((el) => el.getId() !== moduleInstanceId);
+        this._moduleInstances = this._moduleInstances.filter((el) => el.getId() !== moduleInstanceId);
 
-        const newLayout = this.layout.filter((el) => el.moduleInstanceId !== moduleInstanceId);
+        const newLayout = this._layout.filter((el) => el.moduleInstanceId !== moduleInstanceId);
         this.setLayout(newLayout);
         if (this._activeModuleId === moduleInstanceId) {
             this._activeModuleId = "";
@@ -192,7 +192,7 @@ export class Workbench {
     }
 
     setLayout(layout: LayoutElement[]): void {
-        this.layout = layout;
+        this._layout = layout;
         this.notifySubscribers(WorkbenchEvents.FullModuleRerenderRequested);
 
         const modifiedLayout = layout.map((el) => {
@@ -202,9 +202,9 @@ export class Workbench {
     }
 
     maybeMakeFirstModuleInstanceActive(): void {
-        if (!this.moduleInstances.some((el) => el.getId() === this._activeModuleId)) {
+        if (!this._moduleInstances.some((el) => el.getId() === this._activeModuleId)) {
             this._activeModuleId =
-                this.moduleInstances
+                this._moduleInstances
                     .filter((el) => el.getImportState() === ImportState.Imported)
                     .at(0)
                     ?.getId() || "";
@@ -238,8 +238,8 @@ export class Workbench {
 
         this.makeLayout(newLayout);
 
-        for (let i = 0; i < this.moduleInstances.length; i++) {
-            const moduleInstance = this.moduleInstances[i];
+        for (let i = 0; i < this._moduleInstances.length; i++) {
+            const moduleInstance = this._moduleInstances[i];
             const templateModule = template.moduleInstances[i];
             if (templateModule.syncedSettings) {
                 for (const syncSettingKey of templateModule.syncedSettings) {
@@ -260,7 +260,7 @@ export class Workbench {
                         throw new Error("Could not find module instance for data channel");
                     }
 
-                    const listensToModuleInstance = this.moduleInstances[moduleInstanceIndex];
+                    const listensToModuleInstance = this._moduleInstances[moduleInstanceIndex];
                     const channel = listensToModuleInstance.getContext().getChannel(dataChannel.channelName);
                     if (!channel) {
                         throw new Error("Could not find channel");

--- a/frontend/src/framework/WorkbenchServices.ts
+++ b/frontend/src/framework/WorkbenchServices.ts
@@ -83,7 +83,7 @@ export class WorkbenchServices {
         }
     }
 
-    public getBroadcaster(): Broadcaster {
+    getBroadcaster(): Broadcaster {
         return this._workbench.getBroadcaster();
     }
 }

--- a/frontend/src/framework/components/MultiEnsembleSelect/multiEnsembleSelect.tsx
+++ b/frontend/src/framework/components/MultiEnsembleSelect/multiEnsembleSelect.tsx
@@ -1,7 +1,6 @@
-import { Select, SelectProps, SelectOption } from "@lib/components/Select";
-
-import { EnsembleIdent } from "../../EnsembleIdent";
-import { EnsembleSet } from "../../EnsembleSet";
+import { EnsembleIdent } from "@framework/EnsembleIdent";
+import { EnsembleSet } from "@framework/EnsembleSet";
+import { Select, SelectOption, SelectProps } from "@lib/components/Select";
 
 type MultiEnsembleSelectProps = {
     ensembleSet: EnsembleSet;
@@ -10,7 +9,7 @@ type MultiEnsembleSelectProps = {
 } & Omit<SelectProps, "options" | "value" | "onChange" | "multiple">;
 
 export function MultiEnsembleSelect(props: MultiEnsembleSelectProps): JSX.Element {
-    const {ensembleSet, value, onChange, ...rest} = props;
+    const { ensembleSet, value, onChange, ...rest } = props;
 
     function handleSelectionChanged(selectedEnsembleIdentStrArr: string[]) {
         const identArr: EnsembleIdent[] = [];
@@ -34,5 +33,5 @@ export function MultiEnsembleSelect(props: MultiEnsembleSelectProps): JSX.Elemen
         selectedArr.push(ident.toString());
     }
 
-    return <Select options={optionsArr} value={selectedArr} onChange={handleSelectionChanged}  {...rest} />;
+    return <Select options={optionsArr} value={selectedArr} onChange={handleSelectionChanged} {...rest} />;
 }

--- a/frontend/src/framework/components/SingleEnsembleSelect/singleEnsembleSelect.tsx
+++ b/frontend/src/framework/components/SingleEnsembleSelect/singleEnsembleSelect.tsx
@@ -1,13 +1,12 @@
+import { EnsembleIdent } from "@framework/EnsembleIdent";
+import { EnsembleSet } from "@framework/EnsembleSet";
 import { Dropdown, DropdownOption, DropdownProps } from "@lib/components/Dropdown";
-
-import { EnsembleIdent } from "../../EnsembleIdent";
-import { EnsembleSet } from "../../EnsembleSet";
 
 type SingleEnsembleSelectProps = {
     ensembleSet: EnsembleSet;
     value: EnsembleIdent | null;
     onChange: (ensembleIdent: EnsembleIdent | null) => void;
-}& Omit<DropdownProps, "options" | "value" | "onChange">;
+} & Omit<DropdownProps, "options" | "value" | "onChange">;
 
 export function SingleEnsembleSelect(props: SingleEnsembleSelectProps): JSX.Element {
     const { ensembleSet, value, onChange, ...rest } = props;
@@ -22,5 +21,5 @@ export function SingleEnsembleSelect(props: SingleEnsembleSelectProps): JSX.Elem
         optionsArr.push({ value: ens.getIdent().toString(), label: ens.getDisplayName() });
     }
 
-    return <Dropdown options={optionsArr} value={value?.toString()} onChange={handleSelectionChanged} {...rest}/>;
+    return <Dropdown options={optionsArr} value={value?.toString()} onChange={handleSelectionChanged} {...rest} />;
 }

--- a/frontend/src/framework/internal/components/Content/private-components/layoutBox.tsx
+++ b/frontend/src/framework/internal/components/Content/private-components/layoutBox.tsx
@@ -70,15 +70,15 @@ export class LayoutBox {
         this._layoutDirection = direction;
     }
 
-    public getRect(): Rect {
+    getRect(): Rect {
         return this._rectRelativeToParent;
     }
 
-    public getModuleInstanceId(): string | undefined {
+    getModuleInstanceId(): string | undefined {
         return this._moduleInstanceId;
     }
 
-    public getRectWithMargin(realSizeFactor: Size): Rect {
+    getRectWithMargin(realSizeFactor: Size): Rect {
         const absoluteRect = this.getAbsoluteRect();
         if (this._parent === null) {
             return {
@@ -104,7 +104,7 @@ export class LayoutBox {
         };
     }
 
-    public toString(): string {
+    toString(): string {
         let text = `LayoutBox(${this._rectRelativeToParent.x}, ${this._rectRelativeToParent.y}, ${this._rectRelativeToParent.width}, ${this._rectRelativeToParent.height})`;
         let currentParent = this._parent;
         while (currentParent) {
@@ -114,7 +114,7 @@ export class LayoutBox {
         return text;
     }
 
-    public log(): string {
+    log(): string {
         let text = "";
         for (let i = 0; i < this._level; i++) {
             text += " ";
@@ -126,7 +126,7 @@ export class LayoutBox {
         return text;
     }
 
-    public transformRectToRelative(rect: Rect): Rect {
+    transformRectToRelative(rect: Rect): Rect {
         let newRect = {
             x: (rect.x - this._rectRelativeToParent.x) / this._rectRelativeToParent.width,
             y: (rect.y - this._rectRelativeToParent.y) / this._rectRelativeToParent.height,
@@ -148,7 +148,7 @@ export class LayoutBox {
         return this._parent.transformRectToAbsolute(this._rectRelativeToParent);
     }
 
-    public transformRectToAbsolute(rect: Rect): Rect {
+    transformRectToAbsolute(rect: Rect): Rect {
         let newRect = {
             x: rect.x * this._rectRelativeToParent.width + this._rectRelativeToParent.x,
             y: rect.y * this._rectRelativeToParent.height + this._rectRelativeToParent.y,
@@ -334,22 +334,22 @@ export class LayoutBox {
         }
     }
 
-    public prependChild(child: LayoutBox) {
+    prependChild(child: LayoutBox) {
         this._children.unshift(child);
         this.reorderChildren();
     }
 
-    public appendChild(child: LayoutBox) {
+    appendChild(child: LayoutBox) {
         this._children.push(child);
         this.reorderChildren();
     }
 
-    public insertChildAt(child: LayoutBox, index: number) {
+    insertChildAt(child: LayoutBox, index: number) {
         this._children.splice(index, 0, child);
         this.reorderChildren();
     }
 
-    public removeChild(child: LayoutBox) {
+    removeChild(child: LayoutBox) {
         this._children = this._children.filter((c) => c !== child);
         if (this._children.length > 0) {
             this.reorderChildren();
@@ -361,15 +361,15 @@ export class LayoutBox {
         }
     }
 
-    public setChildren(children: LayoutBox[]): void {
+    setChildren(children: LayoutBox[]): void {
         this._children = children;
     }
 
-    public getChildren(): LayoutBox[] {
+    getChildren(): LayoutBox[] {
         return this._children;
     }
 
-    public findBoxContainingPoint(point: Point, realSize: Size): LayoutBox | null {
+    findBoxContainingPoint(point: Point, realSize: Size): LayoutBox | null {
         if (!rectContainsPoint(this.getRectWithMargin(realSize), point)) {
             return null;
         }
@@ -386,7 +386,7 @@ export class LayoutBox {
         return found || this;
     }
 
-    public findBoxContainingModuleInstance(moduleInstanceId: string): LayoutBox | null {
+    findBoxContainingModuleInstance(moduleInstanceId: string): LayoutBox | null {
         if (this._moduleInstanceId === moduleInstanceId) {
             return this;
         }
@@ -403,7 +403,7 @@ export class LayoutBox {
         return found;
     }
 
-    public getEdgeRects(realSize: Size): LayoutBoxEdge[] {
+    getEdgeRects(realSize: Size): LayoutBoxEdge[] {
         const rect = this.getRectWithMargin(realSize);
         const edges: LayoutBoxEdge[] = [];
 
@@ -519,7 +519,7 @@ export class LayoutBox {
         return edges;
     }
 
-    public findEdgeContainingPoint(
+    findEdgeContainingPoint(
         point: Point,
         realSize: Size,
         draggedModuleInstanceId: string
@@ -588,7 +588,7 @@ export class LayoutBox {
         return clone;
     }
 
-    public previewLayout(
+    previewLayout(
         pointerPoint: Point,
         realSize: Size,
         draggedModuleInstanceId: string,
@@ -703,7 +703,7 @@ export class LayoutBox {
         return position;
     }
 
-    public moveLayoutElement(source: LayoutBox, destination: LayoutBox, edge: LayoutBoxEdge): void {
+    moveLayoutElement(source: LayoutBox, destination: LayoutBox, edge: LayoutBoxEdge): void {
         if (source === destination) {
             return;
         }
@@ -759,7 +759,7 @@ export class LayoutBox {
         }
     }
 
-    public addLayoutElement(newBox: LayoutBox, destination: LayoutBox, edge: LayoutBoxEdge): void {
+    addLayoutElement(newBox: LayoutBox, destination: LayoutBox, edge: LayoutBoxEdge): void {
         if (edge.edge === LayoutBoxEdgeType.LEFT || edge.edge === LayoutBoxEdgeType.TOP) {
             if (destination._layoutDirection === LayoutDirection.SINGLE) {
                 const layoutType =
@@ -790,7 +790,7 @@ export class LayoutBox {
         }
     }
 
-    public removeLayoutElement(moduleInstanceId: string): void {
+    removeLayoutElement(moduleInstanceId: string): void {
         if (this._isWrapper) {
             this._children.forEach((child) => child.removeLayoutElement(moduleInstanceId));
         } else if (this._moduleInstanceId === moduleInstanceId) {
@@ -800,7 +800,7 @@ export class LayoutBox {
         }
     }
 
-    public toLayout(): LayoutElement[] {
+    toLayout(): LayoutElement[] {
         const layout: LayoutElement[] = [];
 
         if (this._isWrapper) {

--- a/frontend/src/framework/internal/components/ErrorBoundary/errorBoundary.tsx
+++ b/frontend/src/framework/internal/components/ErrorBoundary/errorBoundary.tsx
@@ -12,19 +12,19 @@ interface State {
 }
 
 export class ErrorBoundary extends React.Component<Props, State> {
-    public state: State = {
+    state: State = {
         error: null,
     };
 
-    public static getDerivedStateFromError(err: Error): State {
+    static getDerivedStateFromError(err: Error): State {
         return { error: err };
     }
 
-    public componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+    componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
         this.props.moduleInstance.setFatalError(error, errorInfo);
     }
 
-    public render() {
+    render() {
         if (this.state.error) {
             return null;
         }

--- a/frontend/src/lib/components/ResizablePanels/resizablePanels.tsx
+++ b/frontend/src/lib/components/ResizablePanels/resizablePanels.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 
-import { useElementSize } from "../../hooks/useElementSize";
+import { useElementSize } from "@lib/hooks/useElementSize";
+
 import { resolveClassNames } from "../_utils/resolveClassNames";
 
 type ResizablePanelsProps = {

--- a/frontend/src/lib/components/Virtualization/virtualization.tsx
+++ b/frontend/src/lib/components/Virtualization/virtualization.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 
-import { useElementSize } from "../../hooks/useElementSize";
+import { useElementSize } from "@lib/hooks/useElementSize";
+
 import { withDefaults } from "../_utils/components";
 
 export type VirtualizationProps<T = any> = {

--- a/frontend/src/modules/Pvt/pvtPlotDataAccessor.ts
+++ b/frontend/src/modules/Pvt/pvtPlotDataAccessor.ts
@@ -49,22 +49,22 @@ export const getAvailablePlotsForPhase = (phase: string): PlotOptionType[] => {
     }
 }
 export class PvtPlotAccessor {
-    private pvtData: PvtData_api;
+    private _pvtData: PvtData_api;
 
     constructor(pvtData: PvtData_api) {
-        this.pvtData = pvtData;
+        this._pvtData = pvtData;
     }
 
 
     getPlotLabel(dataValue: string): string {
 
-        if (this.pvtData.phase === "Oil") {
+        if (this._pvtData.phase === "Oil") {
             return OilPlotOptions.filter((plot) => plot.value === dataValue)[0].label
         }
-        else if (this.pvtData.phase === "Gas") {
+        else if (this._pvtData.phase === "Gas") {
             return GasPlotOptions.filter((plot) => plot.value === dataValue)[0].label
         }
-        else if (this.pvtData.phase === "Water") {
+        else if (this._pvtData.phase === "Water") {
             return WaterPlotOptions.filter((plot) => plot.value === dataValue)[0]?.label || ""
         }
         else {
@@ -72,9 +72,9 @@ export class PvtPlotAccessor {
         }
     }
     getPlotData(dataValue: string): PlotDataType {
-        const title = this.getPlotLabel(dataValue) + "(" + this.pvtData.phase + ")"
-        const pvtNum = this.pvtData.pvtnum
-        const phaseType = this.pvtData.phase
+        const title = this.getPlotLabel(dataValue) + "(" + this._pvtData.phase + ")"
+        const pvtNum = this._pvtData.pvtnum
+        const phaseType = this._pvtData.phase
 
         let traces: TraceData[] = []
         if (phaseType === "Oil" || phaseType === "Water") {
@@ -148,30 +148,30 @@ export class PvtPlotAccessor {
     }
     private getDataSeries(dataValue: string): number[] {
         if (dataValue === "volumefactor") {
-            return this.pvtData.volumefactor
+            return this._pvtData.volumefactor
         } else if (dataValue === "viscosity") {
-            return this.pvtData.viscosity
+            return this._pvtData.viscosity
         } else if (dataValue === "density") {
-            return this.pvtData.density
+            return this._pvtData.density
         } else if (dataValue === "ratio") {
-            return this.pvtData.ratio
+            return this._pvtData.ratio
         } else if (dataValue === "pressure") {
-            return this.pvtData.pressure
+            return this._pvtData.pressure
         } else {
             return []
         }
     }
     private getDataUnit(dataValue: string): string {
         if (dataValue === "volumefactor") {
-            return this.pvtData.volumefactor_unit
+            return this._pvtData.volumefactor_unit
         } else if (dataValue === "viscosity") {
-            return this.pvtData.viscosity_unit
+            return this._pvtData.viscosity_unit
         } else if (dataValue === "density") {
-            return this.pvtData.density_unit
+            return this._pvtData.density_unit
         } else if (dataValue === "ratio") {
-            return this.pvtData.ratio_unit
+            return this._pvtData.ratio_unit
         } else if (dataValue === "pressure") {
-            return this.pvtData.pressure_unit
+            return this._pvtData.pressure_unit
         } else {
             return ""
         }

--- a/frontend/src/modules/Pvt/pvtQueryDataAccessor.ts
+++ b/frontend/src/modules/Pvt/pvtQueryDataAccessor.ts
@@ -1,25 +1,25 @@
 import { PvtData_api } from '@api'
 
 export class PvtQueryDataAccessor {
-    private pvtQueryData: PvtData_api[];
+    private _pvtQueryData: PvtData_api[];
 
 
     constructor(pvtQueryData: PvtData_api[]) {
-        this.pvtQueryData = pvtQueryData;
+        this._pvtQueryData = pvtQueryData;
     }
 
     getPvtNames(): string[] {
-        return [... new Set(this.pvtQueryData.map((pvtData) => pvtData.name))]
+        return [... new Set(this._pvtQueryData.map((pvtData) => pvtData.name))]
     }
 
     getPvtNums(pvtName: string): number[] {
-        const data = this.pvtQueryData.filter((pvtData) => pvtData.name == pvtName);
+        const data = this._pvtQueryData.filter((pvtData) => pvtData.name == pvtName);
         return data.map((pvtData) => pvtData.pvtnum);
 
     }
 
     getPvtData(pvtName: string, pvtNum: number): PvtData_api {
-        const data = this.pvtQueryData.filter((pvtData) => (pvtData.name == pvtName && pvtData.pvtnum == pvtNum));
+        const data = this._pvtQueryData.filter((pvtData) => (pvtData.name == pvtName && pvtData.pvtnum == pvtNum));
         return data[0];
     }
 

--- a/frontend/src/modules/Sensitivity/sensitivityResponseCalculator.ts
+++ b/frontend/src/modules/Sensitivity/sensitivityResponseCalculator.ts
@@ -56,7 +56,7 @@ export class SensitivityResponseCalculator {
         this.referenceAverage = this.computeSensitivityAverage(this.referenceSensitivity);
     }
 
-    public computeSensitivitiesForResponse(): SensitivityResponseDataset {
+    computeSensitivitiesForResponse(): SensitivityResponseDataset {
         // Compute sensitivity responses for all sensitivities
         const sensitivityResponses: SensitivityResponse[] = [];
         this.sensitivities.getSensitivityArr().forEach((sensitivity) => {

--- a/frontend/src/modules/Sensitivity/sensitivityResponseCalculator.ts
+++ b/frontend/src/modules/Sensitivity/sensitivityResponseCalculator.ts
@@ -35,31 +35,31 @@ export class SensitivityResponseCalculator {
     /**
      * Class for calculating sensitivities for a given Ensemble response
      */
-    private ensembleResponse: EnsembleScalarResponse_api;
-    private sensitivities: EnsembleSensitivities;
-    private referenceSensitivity: string;
-    private referenceAverage: number;
+    private _ensembleResponse: EnsembleScalarResponse_api;
+    private _sensitivities: EnsembleSensitivities;
+    private _referenceSensitivity: string;
+    private _referenceAverage: number;
 
     constructor(
         sensitivities: EnsembleSensitivities,
         ensembleResponse: EnsembleScalarResponse_api,
         referenceSensitivity = "rms_seed"
     ) {
-        this.ensembleResponse = ensembleResponse;
-        this.sensitivities = sensitivities;
-        if (!this.sensitivities.hasSensitivityName(referenceSensitivity)) {
+        this._ensembleResponse = ensembleResponse;
+        this._sensitivities = sensitivities;
+        if (!this._sensitivities.hasSensitivityName(referenceSensitivity)) {
             throw new Error(
                 `SensitivityResponseCalculator: Reference sensitivity ${referenceSensitivity} not found in ensemble`
             );
         }
-        this.referenceSensitivity = referenceSensitivity;
-        this.referenceAverage = this.computeSensitivityAverage(this.referenceSensitivity);
+        this._referenceSensitivity = referenceSensitivity;
+        this._referenceAverage = this.computeSensitivityAverage(this._referenceSensitivity);
     }
 
     computeSensitivitiesForResponse(): SensitivityResponseDataset {
         // Compute sensitivity responses for all sensitivities
         const sensitivityResponses: SensitivityResponse[] = [];
-        this.sensitivities.getSensitivityArr().forEach((sensitivity) => {
+        this._sensitivities.getSensitivityArr().forEach((sensitivity) => {
             //Skip if the sensitivity is the so called "ref" case. This is a special case that is not a sensitivity.
             if (sensitivity.name === IGNORED_CASE) {
                 // TODO: Add check for single realization
@@ -76,11 +76,11 @@ export class SensitivityResponseCalculator {
 
         const sensitivityResponseDataset: SensitivityResponseDataset = {
             sensitivityResponses: this.sortSensitivityResponses(sensitivityResponses),
-            referenceSensitivity: this.referenceSensitivity,
-            referenceAverage: this.referenceAverage,
+            referenceSensitivity: this._referenceSensitivity,
+            referenceAverage: this._referenceAverage,
             scale: SensitivityScale.RELATIVE,
-            responseName: this.ensembleResponse.name,
-            responseUnit: this.ensembleResponse.unit,
+            responseName: this._ensembleResponse.name,
+            responseUnit: this._ensembleResponse.unit,
         };
         return sensitivityResponseDataset;
     }
@@ -88,9 +88,9 @@ export class SensitivityResponseCalculator {
     private getResponseValuesForRealizations(realizations: number[]): number[] {
         //Find response values for given realizations
         const responseValues: number[] = [];
-        this.ensembleResponse.realizations.forEach((value, index) => {
+        this._ensembleResponse.realizations.forEach((value, index) => {
             if (realizations.includes(value)) {
-                responseValues.push(this.ensembleResponse.values[index]);
+                responseValues.push(this._ensembleResponse.values[index]);
             }
         });
         return responseValues;
@@ -117,7 +117,7 @@ export class SensitivityResponseCalculator {
 
     private computeSensitivityAverage(sensitivityName: string): number {
         // Compute average of response values for given sensitivity
-        const sensitivity = this.sensitivities.getSensitivityByName(sensitivityName);
+        const sensitivity = this._sensitivities.getSensitivityByName(sensitivityName);
         const realizations: number[] = [];
         sensitivity.cases.forEach((case_) => {
             case_.realizations.forEach((realization) => {
@@ -151,9 +151,9 @@ export class SensitivityResponseCalculator {
 
         sensitivity.cases.forEach((case_) => {
             case_.realizations.forEach((realization) => {
-                if (this.ensembleResponse.realizations.includes(realization)) {
-                    const index = this.ensembleResponse.realizations.indexOf(realization);
-                    if (this.ensembleResponse.values[index] <= this.referenceAverage) {
+                if (this._ensembleResponse.realizations.includes(realization)) {
+                    const index = this._ensembleResponse.realizations.indexOf(realization);
+                    if (this._ensembleResponse.values[index] <= this._referenceAverage) {
                         realizations.push(realization);
                     }
                 }
@@ -168,9 +168,9 @@ export class SensitivityResponseCalculator {
 
         sensitivity.cases.forEach((case_) => {
             case_.realizations.forEach((realization) => {
-                if (this.ensembleResponse.realizations.includes(realization)) {
-                    const index = this.ensembleResponse.realizations.indexOf(realization);
-                    if (this.ensembleResponse.values[index] > this.referenceAverage) {
+                if (this._ensembleResponse.realizations.includes(realization)) {
+                    const index = this._ensembleResponse.realizations.indexOf(realization);
+                    if (this._ensembleResponse.values[index] > this._referenceAverage) {
                         realizations.push(realization);
                     }
                 }
@@ -192,12 +192,12 @@ export class SensitivityResponseCalculator {
             lowCaseName: "P90",
             lowCaseAverage: this.computeResponseOilP90(sensitivityCase.realizations),
             lowCaseReferenceDifference:
-                this.computeResponseOilP90(sensitivityCase.realizations) - this.referenceAverage,
+                this.computeResponseOilP90(sensitivityCase.realizations) - this._referenceAverage,
             lowCaseRealizations: this.getSensitivityRealizationsLessOrEqualToReferenceAverage(sensitivity),
             highCaseName: "P10",
             highCaseAverage: this.computeResponseOilP10(sensitivityCase.realizations),
             highCaseReferenceDifference:
-                this.computeResponseOilP10(sensitivityCase.realizations) - this.referenceAverage,
+                this.computeResponseOilP10(sensitivityCase.realizations) - this._referenceAverage,
             highCaseRealizations: this.getSensitivityRealizationsGreaterThanReferenceAverage(sensitivity),
         };
         return sensitivityResponse;
@@ -219,10 +219,10 @@ export class SensitivityResponseCalculator {
                 lowCaseName: sensitivityCase.name,
                 lowCaseAverage: this.computeResponseAverage(sensitivityCase.realizations),
                 lowCaseReferenceDifference:
-                    this.computeResponseAverage(sensitivityCase.realizations) - this.referenceAverage,
+                    this.computeResponseAverage(sensitivityCase.realizations) - this._referenceAverage,
                 lowCaseRealizations: sensitivityCase.realizations,
                 highCaseName: "",
-                highCaseAverage: this.referenceAverage,
+                highCaseAverage: this._referenceAverage,
                 highCaseReferenceDifference: 0,
                 highCaseRealizations: [],
             };
@@ -242,11 +242,11 @@ export class SensitivityResponseCalculator {
             sensitivityName: sensitivity.name,
             lowCaseName: sensitivity.cases[lowCaseIndex].name,
             lowCaseAverage: caseAverages[lowCaseIndex],
-            lowCaseReferenceDifference: caseAverages[lowCaseIndex] - this.referenceAverage,
+            lowCaseReferenceDifference: caseAverages[lowCaseIndex] - this._referenceAverage,
             lowCaseRealizations: sensitivity.cases[lowCaseIndex].realizations,
             highCaseName: sensitivity.cases[highCaseIndex].name,
             highCaseAverage: caseAverages[highCaseIndex],
-            highCaseReferenceDifference: caseAverages[highCaseIndex] - this.referenceAverage,
+            highCaseReferenceDifference: caseAverages[highCaseIndex] - this._referenceAverage,
             highCaseRealizations: sensitivity.cases[highCaseIndex].realizations,
         };
         return sensitivityResponse;

--- a/frontend/src/modules/SimulationTimeSeriesSensitivity/view.tsx
+++ b/frontend/src/modules/SimulationTimeSeriesSensitivity/view.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 
 import { VectorRealizationData_api } from "@api";
+import { StatisticFunction_api } from "@api";
 import { BroadcastChannelMeta } from "@framework/Broadcaster";
 import { ModuleFCProps } from "@framework/Module";
 import { useElementSize } from "@lib/hooks/useElementSize";
@@ -16,8 +17,6 @@ import {
     sensitivityStatisticsTrace,
 } from "./simulationTimeSeriesChart/traces";
 import { State } from "./state";
-
-import { StatisticFunction } from "../../api/models/StatisticFunction";
 
 export const view = ({ moduleContext, workbenchSession }: ModuleFCProps<State>) => {
     const wrapperDivRef = React.useRef<HTMLDivElement>(null);
@@ -91,7 +90,7 @@ export const view = ({ moduleContext, workbenchSession }: ModuleFCProps<State>) 
                     if (statisticsQuery.data) {
                         const meanCase = statisticsQuery.data.filter((stat) => stat.sensitivity_name === "rms_seed")[0];
                         const meanObj = meanCase.value_objects.filter(
-                            (statObj) => statObj.statistic_function === StatisticFunction.MEAN
+                            (statObj) => statObj.statistic_function === StatisticFunction_api.MEAN
                         );
                         traceDataArr.push(
                             sensitivityStatisticsTrace(
@@ -110,7 +109,7 @@ export const view = ({ moduleContext, workbenchSession }: ModuleFCProps<State>) 
                             if (cases) {
                                 for (const caseIdent of cases) {
                                     const meanObj = caseIdent.value_objects.filter(
-                                        (statObj) => statObj.statistic_function === StatisticFunction.MEAN
+                                        (statObj) => statObj.statistic_function === StatisticFunction_api.MEAN
                                     );
                                     traceDataArr.push(
                                         sensitivityStatisticsTrace(


### PR DESCRIPTION
* Prefix all private properties with an `_`
* Removed unneeded use of the `public` visibility modifier
* Fixed some imports so they use aliases instead of relative import paths