### PR TITLE
Import `MyModule`, `MyModule2` and `DbgWorkbench` only in dev mode

### DIFF
--- a/frontend/src/modules/registerAllModules.ts
+++ b/frontend/src/modules/registerAllModules.ts
@@ -1,4 +1,5 @@
-import "./DbgWorkbenchSpy/registerModule";
+import { isDevMode } from "@lib/utils/devMode";
+
 import "./DistributionPlot/registerModule";
 import "./Grid3D/registerModule";
 import "./Grid3D/registerModule";
@@ -6,10 +7,14 @@ import "./Grid3DIntersection/registerModule";
 import "./Grid3DIntersection/registerModule";
 import "./InplaceVolumetrics/registerModule";
 import "./Map/registerModule";
-import "./MyModule2/registerModule";
-import "./MyModule/registerModule";
 import "./Pvt/registerModule";
 import "./Sensitivity/registerModule";
 import "./SimulationTimeSeries/registerModule";
 import "./SimulationTimeSeriesSensitivity/registerModule";
 import "./TimeSeriesParameterDistribution/registerModule";
+
+if (isDevMode()) {
+    import("./MyModule2/registerModule");
+    import("./MyModule/registerModule");
+    import("./DbgWorkbenchSpy/registerModule");
+}


### PR DESCRIPTION
Keeping all modules for development/test purposes but not importing in production.

Closes #224.