### PR TITLE
Add env variable for Sumo environment

### DIFF
--- a/backend/src/backend/config.py
+++ b/backend/src/backend/config.py
@@ -15,13 +15,13 @@ CLIENT_ID = "900ed417-a860-4970-bd37-73b059ca6f0d"
 CLIENT_SECRET = os.environ["WEBVIZ_CLIENT_SECRET"]
 SMDA_SUBSCRIPTION_KEY = os.environ["WEBVIZ_SMDA_SUBSCRIPTION_KEY"]
 SMDA_RESOURCE_SCOPE = os.environ["WEBVIZ_SMDA_RESOURCE_SCOPE"]
-
+SUMO_ENV = os.getenv("WEBVIZ_SUMO_ENV", "dev")
 GRAPH_SCOPES = ["User.Read"]
 
 RESOURCE_SCOPES_DICT = {
     # "sumo": [f"api://{sumo_app_reg['prod']['RESOURCE_ID']}/access_as_user"],
     # Note that when switching back to prod, SUMO env in create_sumo_client_instance() must also be changed
-    "sumo": [f"api://{sumo_app_reg['prod']['RESOURCE_ID']}/access_as_user"],
+    "sumo": [f"api://{sumo_app_reg[SUMO_ENV]['RESOURCE_ID']}/access_as_user"],
     "smda": [SMDA_RESOURCE_SCOPE],
 }
 

--- a/backend/src/services/sumo_access/_helpers.py
+++ b/backend/src/services/sumo_access/_helpers.py
@@ -1,7 +1,9 @@
+import os
+
 from sumo.wrapper import SumoClient
 
 
-SUMO_ENV = "prod"
+SUMO_ENV = os.getenv("WEBVIZ_SUMO_ENV", "dev")
 
 
 def create_sumo_client_instance(access_token: str) -> SumoClient:

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -24,6 +24,7 @@ services:
       - WEBVIZ_CLIENT_SECRET
       - WEBVIZ_SMDA_RESOURCE_SCOPE
       - WEBVIZ_SMDA_SUBSCRIPTION_KEY
+      - WEBVIZ_SUMO_ENV
 
   backend-user-session:
     build:
@@ -37,6 +38,8 @@ services:
       - WEBVIZ_CLIENT_SECRET
       - WEBVIZ_SMDA_RESOURCE_SCOPE
       - WEBVIZ_SMDA_SUBSCRIPTION_KEY
+      - WEBVIZ_SUMO_ENV
+      
     volumes:
       - ./backend/src:/home/appuser/backend/src
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,7 @@ services:
       - WEBVIZ_CLIENT_SECRET
       - WEBVIZ_SMDA_RESOURCE_SCOPE
       - WEBVIZ_SMDA_SUBSCRIPTION_KEY
+      - WEBVIZ_SUMO_ENV
     volumes:
       - ./backend/src:/home/appuser/backend/src
 
@@ -46,6 +47,7 @@ services:
       - WEBVIZ_CLIENT_SECRET
       - WEBVIZ_SMDA_RESOURCE_SCOPE
       - WEBVIZ_SMDA_SUBSCRIPTION_KEY
+      - WEBVIZ_SUMO_ENV
     volumes:
       - ./backend/src:/home/appuser/backend/src
 


### PR DESCRIPTION
Until we completely move to the Sumo prod environment, we need an env variable to switch between dev and prod.
Added `WEBVIZ_SUMO_ENV` with default set to dev.