### PR TITLE
Moving module instance number control to `Workbench` and clearing layout on unmount in `App`

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,14 +14,20 @@ const layout: LayoutElement[] = [];
 
 function App() {
     const workbench = new Workbench();
+    console.debug("render app");
 
     React.useEffect(() => {
+        console.debug("app useEffect");
         if (!workbench.loadLayoutFromLocalStorage()) {
             workbench.makeLayout(layout);
         }
         if (workbench.getLayout().length === 0) {
             workbench.getGuiStateStore().setValue("drawerContent", DrawerContent.ModulesList);
         }
+
+        return function () {
+            workbench.clearLayout();
+        };
     }, []);
 
     return (

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,10 +14,8 @@ const layout: LayoutElement[] = [];
 
 function App() {
     const workbench = new Workbench();
-    console.debug("render app");
 
     React.useEffect(() => {
-        console.debug("app useEffect");
         if (!workbench.loadLayoutFromLocalStorage()) {
             workbench.makeLayout(layout);
         }

--- a/frontend/src/framework/Module.tsx
+++ b/frontend/src/framework/Module.tsx
@@ -36,7 +36,6 @@ export class Module<StateType extends StateBaseType> {
     private _defaultTitle: string;
     public viewFC: ModuleFC<StateType>;
     public settingsFC: ModuleFC<StateType>;
-    private _numInstances: number;
     private _importState: ImportState;
     private _moduleInstances: ModuleInstance<StateType>[];
     private _defaultState: StateType | null;
@@ -55,7 +54,6 @@ export class Module<StateType extends StateBaseType> {
     ) {
         this._name = name;
         this._defaultTitle = defaultTitle;
-        this._numInstances = 0;
         this.viewFC = () => <div>Not defined</div>;
         this.settingsFC = () => <div>Not defined</div>;
         this._importState = ImportState.NotImported;
@@ -101,12 +99,12 @@ export class Module<StateType extends StateBaseType> {
         return this._syncableSettingKeys;
     }
 
-    makeInstance(): ModuleInstance<StateType> {
+    makeInstance(instanceNumber: number): ModuleInstance<StateType> {
         if (!this._workbench) {
             throw new Error("Module must be added to a workbench before making an instance");
         }
 
-        const instance = new ModuleInstance<StateType>(this, this._numInstances++, this._channelsDef, this._workbench);
+        const instance = new ModuleInstance<StateType>(this, instanceNumber, this._channelsDef, this._workbench);
         this._moduleInstances.push(instance);
         this.maybeImportSelf();
         return instance;

--- a/frontend/src/framework/Workbench.ts
+++ b/frontend/src/framework/Workbench.ts
@@ -1,7 +1,5 @@
 import { QueryClient } from "@tanstack/react-query";
 
-import { v4 } from "uuid";
-
 import { Broadcaster } from "./Broadcaster";
 import { EnsembleIdent } from "./EnsembleIdent";
 import { InitialSettings } from "./InitialSettings";


### PR DESCRIPTION
This fixes issues with React 18 calling `useEffect` in `App` twice and adding data channels etc. twice.