### PR TITLE
Fix wildcard usage for VectorSelector in SimulationTimeSeriesMatrix

### DIFF
--- a/frontend/src/modules/SimulationTimeSeriesMatrix/settings.tsx
+++ b/frontend/src/modules/SimulationTimeSeriesMatrix/settings.tsx
@@ -112,7 +112,7 @@ export function settings({ moduleContext, workbenchSession }: ModuleFCProps<Stat
     }
 
     function handleVectorSelectChange(selection: SmartNodeSelectorSelection) {
-        setSelectedVectorNames(selection.selectedTags);
+        setSelectedVectorNames(selection.selectedNodes);
     }
 
     function handleFrequencySelectionChange(newFrequencyStr: string) {


### PR DESCRIPTION
Use selectedNodes instead of selectedTags to allow usage of wildcard