### PR TITLE
Fixed two bugs in GUI

### DIFF
--- a/frontend/src/framework/internal/components/Content/private-components/ViewWrapper/private-components/header.tsx
+++ b/frontend/src/framework/internal/components/Content/private-components/ViewWrapper/private-components/header.tsx
@@ -38,6 +38,10 @@ export const Header: React.FC<HeaderProps> = (props) => {
         return unsubscribeFunc;
     }, []);
 
+    function handlePointerUp(e: React.PointerEvent<HTMLDivElement>) {
+        e.stopPropagation();
+    }
+
     return (
         <div
             className={`bg-slate-100 p-2 pl-4 pr-4 flex items-center select-none shadow ${
@@ -73,6 +77,7 @@ export const Header: React.FC<HeaderProps> = (props) => {
             <div
                 className="hover:text-slate-500 cursor-pointer"
                 onPointerDown={props.onRemoveClick}
+                onPointerUp={handlePointerUp}
                 title="Remove this module"
             >
                 <Close className="w-4 h-4" />

--- a/frontend/src/framework/internal/components/Content/private-components/layout.tsx
+++ b/frontend/src/framework/internal/components/Content/private-components/layout.tsx
@@ -286,6 +286,11 @@ export const Layout: React.FC<LayoutProps> = (props) => {
                 LayoutEventTypes.MODULE_INSTANCE_POINTER_DOWN,
                 handleModuleInstancePointerDown
             );
+            document.removeEventListener(LayoutEventTypes.NEW_MODULE_POINTER_DOWN, handleNewModulePointerDown);
+            document.removeEventListener(
+                LayoutEventTypes.REMOVE_MODULE_INSTANCE_REQUEST,
+                handleRemoveModuleInstanceRequest
+            );
             document.removeEventListener("pointerup", handlePointerUp);
             document.removeEventListener("pointermove", handlePointerMove);
             document.removeEventListener("keydown", handleButtonClick);


### PR DESCRIPTION
- Two event handlers not removed in `layout.tsx`
- Stopping event propagation in `header.tsx` on pointer up

---
Visible bugs:
- Jumping to modules list when removing module (although there are still modules left in the layout)
- Removing module by clicking on cross always opened module settings (not wanted when adding/removing modules and having modules list open)