### PR TITLE
Support sending of binary arrays using base64 encoding

### DIFF
--- a/backend/src/backend/primary/routers/grid/schemas.py
+++ b/backend/src/backend/primary/routers/grid/schemas.py
@@ -2,10 +2,12 @@ from typing import List
 
 from pydantic import BaseModel
 
+from src.services.utils.b64 import B64FloatArray, B64UintArray
+
 
 class GridSurface(BaseModel):
-    polys: dict
-    points: dict
+    polys_b64arr: B64UintArray
+    points_b64arr: B64FloatArray
     xmin: float
     xmax: float
     ymin: float

--- a/backend/src/backend/primary/routers/surface/converters.py
+++ b/backend/src/backend/primary/routers/surface/converters.py
@@ -1,10 +1,15 @@
 from typing import List
 
-import orjson
+import numpy as np
 import xtgeo
-from src.services.sumo_access.surface_types import SurfaceMeta as SumoSurfaceMeta
+from numpy.typing import NDArray
+
 from src.services.smda_access.types import StratigraphicSurface
-from src.services.utils.surface_to_float32 import surface_to_float32_array
+from src.services.sumo_access.surface_types import SurfaceMeta as SumoSurfaceMeta
+from src.services.utils.b64 import b64_encode_float_array_as_float32
+from src.services.utils.perf_timer import PerfTimer
+from src.services.utils.surface_to_float32 import surface_to_float32_numpy_array
+
 from . import schemas
 
 
@@ -25,7 +30,13 @@ def to_api_surface_data(xtgeo_surf: xtgeo.RegularSurface) -> schemas.SurfaceData
     """
     Create API SurfaceData from xtgeo regular surface
     """
-    float32values = surface_to_float32_array(xtgeo_surf)
+
+    timer = PerfTimer()
+    
+    float32_np_arr: NDArray[np.float32] = surface_to_float32_numpy_array(xtgeo_surf)
+    values_b64arr = b64_encode_float_array_as_float32(float32_np_arr)
+
+    print(f"xxxxxxxxxx - conversion/encoding {timer.lap_ms():.1f}ms")
 
     return schemas.SurfaceData(
         x_ori=xtgeo_surf.xori,
@@ -41,7 +52,7 @@ def to_api_surface_data(xtgeo_surf: xtgeo.RegularSurface) -> schemas.SurfaceData
         val_min=xtgeo_surf.values.min(),
         val_max=xtgeo_surf.values.max(),
         rot_deg=xtgeo_surf.rotation,
-        mesh_data=orjson.dumps(float32values).decode(),  # pylint: disable=maybe-no-member
+        values_b64arr=values_b64arr,
     )
 
 

--- a/backend/src/backend/primary/routers/surface/converters.py
+++ b/backend/src/backend/primary/routers/surface/converters.py
@@ -7,7 +7,6 @@ from numpy.typing import NDArray
 from src.services.smda_access.types import StratigraphicSurface
 from src.services.sumo_access.surface_types import SurfaceMeta as SumoSurfaceMeta
 from src.services.utils.b64 import b64_encode_float_array_as_float32
-from src.services.utils.perf_timer import PerfTimer
 from src.services.utils.surface_to_float32 import surface_to_float32_numpy_array
 
 from . import schemas
@@ -31,12 +30,8 @@ def to_api_surface_data(xtgeo_surf: xtgeo.RegularSurface) -> schemas.SurfaceData
     Create API SurfaceData from xtgeo regular surface
     """
 
-    timer = PerfTimer()
-    
     float32_np_arr: NDArray[np.float32] = surface_to_float32_numpy_array(xtgeo_surf)
     values_b64arr = b64_encode_float_array_as_float32(float32_np_arr)
-
-    print(f"xxxxxxxxxx - conversion/encoding {timer.lap_ms():.1f}ms")
 
     return schemas.SurfaceData(
         x_ori=xtgeo_surf.xori,

--- a/backend/src/backend/primary/routers/surface/router.py
+++ b/backend/src/backend/primary/routers/surface/router.py
@@ -103,7 +103,7 @@ def get_statistical_surface_data(
     if not xtgeo_surf:
         raise HTTPException(status_code=404, detail="Could not find or compute surface")
 
-    surf_data_response = converters.to_api_surface_data(xtgeo_surf)
+    surf_data_response: schemas.SurfaceData = converters.to_api_surface_data(xtgeo_surf)
 
     LOGGER.debug(f"Calculated statistical dynamic surface and created image, total time: {timer.elapsed_ms()}ms")
 
@@ -142,7 +142,7 @@ def get_property_surface_resampled_to_static_surface(
 
     resampled_surface = converters.resample_property_surface_to_mesh_surface(xtgeo_surf_mesh, xtgeo_surf_property)
 
-    surf_data_response = converters.to_api_surface_data(resampled_surface)
+    surf_data_response: schemas.SurfaceData = converters.to_api_surface_data(resampled_surface)
 
     LOGGER.debug(f"Loaded property surface and created image, total time: {timer.elapsed_ms()}ms")
 

--- a/backend/src/backend/primary/routers/surface/schemas.py
+++ b/backend/src/backend/primary/routers/surface/schemas.py
@@ -4,6 +4,7 @@ from typing import Optional
 from pydantic import BaseModel
 
 from src.services.smda_access.types import StratigraphicFeature
+from src.services.utils.b64 import B64FloatArray
 
 
 class SurfaceStatisticFunction(str, Enum):
@@ -66,4 +67,4 @@ class SurfaceData(BaseModel):
     val_min: float
     val_max: float
     rot_deg: float
-    mesh_data: str
+    values_b64arr: B64FloatArray

--- a/backend/src/backend/user_session/routers/grid/router.py
+++ b/backend/src/backend/user_session/routers/grid/router.py
@@ -20,7 +20,7 @@ from src.backend.primary.routers.grid.schemas import (
     GridIntersection,
 )
 from src.services.sumo_access.grid_access import GridAccess
-from src.services.utils.b64 import b64_encode_numpy
+from src.services.utils.b64 import b64_encode_float_array_as_float32, b64_encode_uint_array_as_smallest_size
 from src.services.utils.vtk_utils import (
     VtkGridSurface,
     get_scalar_values,
@@ -72,8 +72,8 @@ async def grid_surface(
     points_np = np.around(points_np, decimals=2)
 
     grid_surface_payload = GridSurface(
-        points=b64_encode_numpy(points_np),
-        polys=b64_encode_numpy(polys_np),
+        points_b64arr=b64_encode_float_array_as_float32(points_np),
+        polys_b64arr=b64_encode_uint_array_as_smallest_size(polys_np),
         **grid_geometrics,
     )
     return ORJSONResponse(grid_surface_payload.dict())

--- a/backend/src/services/utils/b64.py
+++ b/backend/src/services/utils/b64.py
@@ -92,4 +92,3 @@ def b64_encode_uint_array_as_smallest_size(
 def _base64_encode_numpy_arr_to_str(np_arr: NDArray) -> str:
     base64_bytes: bytes = base64.b64encode(np_arr.ravel(order="C").data)
     return base64_bytes.decode("ascii")
-

--- a/backend/src/services/utils/b64.py
+++ b/backend/src/services/utils/b64.py
@@ -1,44 +1,95 @@
 import base64
-from typing import Any, Optional
+from typing import Literal
+from pydantic import BaseModel
 
 import numpy as np
+from numpy.typing import NDArray
 
 
-def b64_encode_numpy(obj: Any) -> dict:
-    # Convert 1D numpy arrays with numeric types to memoryviews with
-    # datatype and shape metadata.
-    if len(obj) == 0:
-        return obj.tolist()
+class B64FloatArray(BaseModel):
+    element_type: Literal["float32", "float64"]
+    data_b64str: str
 
-    buffer: Optional[str] = None
-    dtype = obj.dtype
-    if dtype.kind in ["u", "i", "f"] and str(dtype) != "int64" and str(dtype) != "uint64":
-        # We have a numpy array that is compatible with JavaScript typed
-        # arrays
-        buffer = base64.b64encode(memoryview(obj.ravel(order="C"))).decode("utf-8")
-        return {"bvals": buffer, "dtype": str(dtype), "shape": obj.shape}
 
-    dtype_str: Optional[str] = None
-    # Try to see if we can downsize the array
-    max_value = np.amax(obj)
-    min_value = np.amin(obj)
-    signed = min_value < 0
-    test_value = max(max_value, -min_value)
-    if test_value < np.iinfo(np.int16).max and signed:
-        dtype_str = "int16"
-        buffer = base64.b64encode(memoryview(obj.astype(np.int16).ravel(order="C"))).decode("utf-8")
-    elif test_value < np.iinfo(np.int32).max and signed:
-        dtype_str = "int32"
-        buffer = base64.b64encode(memoryview(obj.astype(np.int32).ravel(order="C"))).decode("utf-8")
-    elif test_value < np.iinfo(np.uint16).max and not signed:
-        dtype_str = "uint16"
-        buffer = base64.b64encode(memoryview(obj.astype(np.uint16).ravel(order="C"))).decode("utf-8")
-    elif test_value < np.iinfo(np.uint32).max and not signed:
-        dtype_str = "uint32"
-        buffer = base64.b64encode(memoryview(obj.astype(np.uint32).ravel(order="C"))).decode("utf-8")
+class B64UintArray(BaseModel):
+    element_type: Literal["uint16", "uint32", "uint64"]
+    data_b64str: str
 
-    if dtype:
-        return {"bvals": buffer, "dtype": dtype_str, "shape": obj.shape}
 
-    # Convert all other numpy arrays to lists
-    return obj.tolist()
+class B64IntArray(BaseModel):
+    element_type: Literal["int16", "int32"]
+    data_b64str: str
+
+
+# class B64TypedArray(BaseModel):
+#     element_type: Literal["float32", "float64", "uint16", "uint32", "uint64", "int16", "int32"]
+#     data_b64str: str
+
+
+def b64_encode_float_array_as_float32(input_arr: NDArray[np.floating] | list[float]) -> B64FloatArray:
+    """
+    Base64 encodes an array of floating point numbers using 32bit float element size.
+    """
+    np_arr: NDArray[np.float32] = np.asarray(input_arr, dtype=np.float32)
+    base64_str = _base64_encode_numpy_arr_to_str(np_arr)
+    return B64FloatArray(element_type="float32", data_b64str=base64_str)
+
+
+def b64_encode_float_array_as_float64(input_arr: NDArray[np.floating] | list[float]) -> B64FloatArray:
+    """
+    Base64 encodes array of floating point numbers using 64bit float element size.
+    """
+    np_arr: NDArray[np.float64] = np.asarray(input_arr, dtype=np.float64)
+    base64_str = _base64_encode_numpy_arr_to_str(np_arr)
+    return B64FloatArray(element_type="float64", data_b64str=base64_str)
+
+
+def b64_encode_int_array_as_int32(input_arr: NDArray[np.integer] | list[int]) -> B64IntArray:
+    """
+    Base64 encodes an array of signed integers as using 32bit int element size.
+    """
+    np_arr: NDArray[np.int32] = np.asarray(input_arr, dtype=np.int32)
+    base64_str = _base64_encode_numpy_arr_to_str(np_arr)
+    return B64IntArray(element_type="int32", data_b64str=base64_str)
+
+
+def b64_encode_uint_array_as_uint32(input_arr: NDArray[np.unsignedinteger] | list[int]) -> B64UintArray:
+    """
+    Base64 encodes an array of unsigned integers using 32bit uint element size.
+    """
+    np_arr: NDArray[np.uint32] = np.asarray(input_arr, dtype=np.uint32)
+    base64_str = _base64_encode_numpy_arr_to_str(np_arr)
+    return B64UintArray(element_type="uint32", data_b64str=base64_str)
+
+
+def b64_encode_uint_array_as_smallest_size(
+    input_arr: NDArray[np.unsignedinteger] | list[int], max_value: int | None = None
+) -> B64UintArray:
+    """
+    Base64 encodes an array of unsigned integers using the smallest possible element size.
+    If the maximum value in the array is known, it can be specified in the max_value parameter.
+    """
+    if max_value is None:
+        max_value = np.amax(input_arr)
+
+    element_type: Literal["uint16", "uint32", "uint64"]
+
+    if max_value <= np.iinfo(np.uint16).max:
+        np_arr = np.asarray(input_arr, dtype=np.uint16)
+        element_type = "uint16"
+    elif max_value <= np.iinfo(np.uint32).max:
+        np_arr = np.asarray(input_arr, dtype=np.uint32)
+        element_type = "uint32"
+    else:
+        np_arr = np.asarray(input_arr, dtype=np.uint64)
+        element_type = "uint64"
+
+    base64_str = _base64_encode_numpy_arr_to_str(np_arr)
+
+    return B64UintArray(element_type=element_type, data_b64str=base64_str)
+
+
+def _base64_encode_numpy_arr_to_str(np_arr: NDArray) -> str:
+    base64_bytes: bytes = base64.b64encode(np_arr.ravel(order="C").data)
+    return base64_bytes.decode("ascii")
+

--- a/backend/src/services/utils/surface_to_float32.py
+++ b/backend/src/services/utils/surface_to_float32.py
@@ -1,17 +1,15 @@
-from typing import List
-
 import numpy as np
+from numpy.typing import NDArray
 import xtgeo
 
 
-def surface_to_float32_array(surface: xtgeo.RegularSurface) -> List[float]:
-    values = surface.values.astype(np.float32)
-    values.fill_value = np.nan
-    values = np.ma.filled(values)
+def surface_to_float32_numpy_array(surface: xtgeo.RegularSurface) -> NDArray[np.float32]:
+    masked_values = surface.values.astype(np.float32)
+    values = np.ma.filled(masked_values, fill_value=np.nan)
 
     # Rotate 90 deg left.
     # This will cause the width of to run along the X axis
     # and height of along Y axis (starting from bottom.)
     values = np.rot90(values)
 
-    return values.flatten().tolist()
+    return values.flatten()

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -9,6 +9,8 @@ export { CancelablePromise, CancelError } from './core/CancelablePromise';
 export { OpenAPI } from './core/OpenAPI';
 export type { OpenAPIConfig } from './core/OpenAPI';
 
+export { B64FloatArray as B64FloatArray_api } from './models/B64FloatArray';
+export { B64UintArray as B64UintArray_api } from './models/B64UintArray';
 export type { Body_get_realizations_response as Body_get_realizations_response_api } from './models/Body_get_realizations_response';
 export type { CaseInfo as CaseInfo_api } from './models/CaseInfo';
 export type { Completions as Completions_api } from './models/Completions';

--- a/frontend/src/api/models/B64FloatArray.ts
+++ b/frontend/src/api/models/B64FloatArray.ts
@@ -1,0 +1,19 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type B64FloatArray = {
+    element_type: B64FloatArray.element_type;
+    data_b64str: string;
+};
+
+export namespace B64FloatArray {
+
+    export enum element_type {
+        FLOAT32 = 'float32',
+        FLOAT64 = 'float64',
+    }
+
+
+}
+

--- a/frontend/src/api/models/B64UintArray.ts
+++ b/frontend/src/api/models/B64UintArray.ts
@@ -1,0 +1,20 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type B64UintArray = {
+    element_type: B64UintArray.element_type;
+    data_b64str: string;
+};
+
+export namespace B64UintArray {
+
+    export enum element_type {
+        UINT16 = 'uint16',
+        UINT32 = 'uint32',
+        UINT64 = 'uint64',
+    }
+
+
+}
+

--- a/frontend/src/api/models/GridSurface.ts
+++ b/frontend/src/api/models/GridSurface.ts
@@ -2,9 +2,12 @@
 /* tslint:disable */
 /* eslint-disable */
 
+import type { B64FloatArray } from './B64FloatArray';
+import type { B64UintArray } from './B64UintArray';
+
 export type GridSurface = {
-    polys: Record<string, any>;
-    points: Record<string, any>;
+    polys_b64arr: B64UintArray;
+    points_b64arr: B64FloatArray;
     xmin: number;
     xmax: number;
     ymin: number;

--- a/frontend/src/api/models/SurfaceData.ts
+++ b/frontend/src/api/models/SurfaceData.ts
@@ -2,6 +2,8 @@
 /* tslint:disable */
 /* eslint-disable */
 
+import type { B64FloatArray } from './B64FloatArray';
+
 export type SurfaceData = {
     x_ori: number;
     y_ori: number;
@@ -16,6 +18,6 @@ export type SurfaceData = {
     val_min: number;
     val_max: number;
     rot_deg: number;
-    mesh_data: string;
+    values_b64arr: B64FloatArray;
 };
 

--- a/frontend/src/modules/Grid3D/queryDataTransforms.ts
+++ b/frontend/src/modules/Grid3D/queryDataTransforms.ts
@@ -1,0 +1,26 @@
+import { GridSurface_api } from "@api";
+
+import { b64DecodeFloatArrayToFloat32, b64DecodeUintArrayToUint32} from "@modules_shared/base64";
+
+// Data structure for the transformed GridSurface data
+// Removes the base64 encoded data and replaces them with typed arrays
+export type GridSurface_trans = Omit<GridSurface_api, "points_b64arr" | "polys_b64arr"> & {
+    pointsFloat32Arr: Float32Array;
+    polysUint32Arr: Uint32Array;
+};
+
+export function transformGridSurface(apiData: GridSurface_api): GridSurface_trans {
+    const startTS = performance.now();
+
+    const { points_b64arr, polys_b64arr, ...untransformedData } = apiData;
+    const pointsFloat32Arr = b64DecodeFloatArrayToFloat32(points_b64arr);
+    const polysUint32Arr = b64DecodeUintArrayToUint32(polys_b64arr);
+
+    console.debug(`transformGridSurface() took: ${(performance.now() - startTS).toFixed(1)}ms`);
+
+    return {
+        ...untransformedData,
+        pointsFloat32Arr: pointsFloat32Arr,
+        polysUint32Arr: polysUint32Arr,
+    };
+}

--- a/frontend/src/modules/Grid3D/queryHooks.ts
+++ b/frontend/src/modules/Grid3D/queryHooks.ts
@@ -1,15 +1,16 @@
-import { GridSurface_api } from "@api";
 import { apiService } from "@framework/ApiService";
 import { UseQueryResult, useQuery } from "@tanstack/react-query";
 
+import { GridSurface_trans, transformGridSurface } from "./queryDataTransforms";
 
 const STALE_TIME = 60 * 1000;
 const CACHE_TIME = 60 * 1000;
 
-export function useGridSurface(caseUuid: string | null, ensembleName: string | null, gridName: string | null, realization: string | null): UseQueryResult<GridSurface_api> {
+export function useGridSurface(caseUuid: string | null, ensembleName: string | null, gridName: string | null, realization: string | null): UseQueryResult<GridSurface_trans> {
     return useQuery({
         queryKey: ["getGridSurface", caseUuid, ensembleName, gridName, realization],
         queryFn: () => apiService.grid.gridSurface(caseUuid ?? "", ensembleName ?? "", gridName ?? "", realization ?? ""),
+        select: transformGridSurface,
         staleTime: STALE_TIME,
         cacheTime: 0,
         enabled: caseUuid && ensembleName && gridName && realization ? true : false,

--- a/frontend/src/modules/Grid3D/view.tsx
+++ b/frontend/src/modules/Grid3D/view.tsx
@@ -1,8 +1,6 @@
-import React from "react";
-
 import { ModuleFCProps } from "@framework/Module";
 import { useFirstEnsembleInEnsembleSet } from "@framework/WorkbenchSession";
-import { toArrayBuffer } from "@modules_shared/vtkUtils";
+import { b64DecodeFloatArrayToFloat32, b64DecodeUintArrayToUint32 } from "@modules/_shared/base64";
 import SubsurfaceViewer from "@webviz/subsurface-viewer";
 
 import { useGridParameter, useGridSurface, useStatisticalGridParameter } from "./queryHooks";
@@ -30,8 +28,8 @@ export function view({ moduleContext, workbenchSession }: ModuleFCProps<state>) 
     const bounds = gridSurfaceQuery?.data ? [gridSurfaceQuery.data.xmin, gridSurfaceQuery.data.ymin, -gridSurfaceQuery.data.zmax, gridSurfaceQuery.data.xmax, gridSurfaceQuery.data.ymax, -gridSurfaceQuery.data.zmin] : [0, 0, 0, 100, 100, 100];
 
     if (!gridSurfaceQuery.data) { return (<div>no grid geometry</div>) }
-    const pointsArray = gridSurfaceQuery?.data ? toArrayBuffer(gridSurfaceQuery.data.points as any) : []
-    const polysArray = gridSurfaceQuery?.data ? toArrayBuffer(gridSurfaceQuery.data.polys as any) : []
+    const points: Float32Array = b64DecodeFloatArrayToFloat32(gridSurfaceQuery.data.points_b64arr);
+    const polys: Uint32Array = b64DecodeUintArrayToUint32(gridSurfaceQuery.data.polys_b64arr);
 
 
     let propertiesArray: number[] = []
@@ -41,8 +39,6 @@ export function view({ moduleContext, workbenchSession }: ModuleFCProps<state>) 
     else if (useStatistics && statisticalGridParameterQuery?.data) {
         propertiesArray = Array.from(statisticalGridParameterQuery.data)
     }
-    const points: Float32Array = new Float32Array(pointsArray as number[])
-    const polys: Uint32Array = new Uint32Array(polysArray as number[])
 
     return (
         <div className="relative w-full h-full flex flex-col">

--- a/frontend/src/modules/Grid3D/view.tsx
+++ b/frontend/src/modules/Grid3D/view.tsx
@@ -1,6 +1,5 @@
 import { ModuleFCProps } from "@framework/Module";
 import { useFirstEnsembleInEnsembleSet } from "@framework/WorkbenchSession";
-import { b64DecodeFloatArrayToFloat32, b64DecodeUintArrayToUint32 } from "@modules/_shared/base64";
 import SubsurfaceViewer from "@webviz/subsurface-viewer";
 
 import { useGridParameter, useGridSurface, useStatisticalGridParameter } from "./queryHooks";
@@ -28,9 +27,6 @@ export function view({ moduleContext, workbenchSession }: ModuleFCProps<state>) 
     const bounds = gridSurfaceQuery?.data ? [gridSurfaceQuery.data.xmin, gridSurfaceQuery.data.ymin, -gridSurfaceQuery.data.zmax, gridSurfaceQuery.data.xmax, gridSurfaceQuery.data.ymax, -gridSurfaceQuery.data.zmin] : [0, 0, 0, 100, 100, 100];
 
     if (!gridSurfaceQuery.data) { return (<div>no grid geometry</div>) }
-    const points: Float32Array = b64DecodeFloatArrayToFloat32(gridSurfaceQuery.data.points_b64arr);
-    const polys: Uint32Array = b64DecodeUintArrayToUint32(gridSurfaceQuery.data.polys_b64arr);
-
 
     let propertiesArray: number[] = []
     if (!useStatistics && gridParameterQuery?.data) {
@@ -39,6 +35,9 @@ export function view({ moduleContext, workbenchSession }: ModuleFCProps<state>) 
     else if (useStatistics && statisticalGridParameterQuery?.data) {
         propertiesArray = Array.from(statisticalGridParameterQuery.data)
     }
+
+    const points: Float32Array = gridSurfaceQuery.data.pointsFloat32Arr;
+    const polys: Uint32Array = gridSurfaceQuery.data.polysUint32Arr;
 
     return (
         <div className="relative w-full h-full flex flex-col">

--- a/frontend/src/modules/Map/MapView.tsx
+++ b/frontend/src/modules/Map/MapView.tsx
@@ -19,7 +19,7 @@ export function MapView(props: ModuleFCProps<MapState>) {
     console.debug(`render MapView, surfAddr=${surfaceAddress ? makeSurfaceAddressString(surfaceAddress) : "null"}`);
 
     const surfDataQuery = useSurfaceDataQueryByAddress(surfaceAddress);
-    console.log(`surfDataQuery.status=${surfDataQuery.status}`);
+    console.debug(`surfDataQuery.status=${surfDataQuery.status}`);
 
     if (!surfDataQuery.data) {
         return <div>No data</div>;

--- a/frontend/src/modules/Map/MapView.tsx
+++ b/frontend/src/modules/Map/MapView.tsx
@@ -1,11 +1,11 @@
 import React from "react";
 
 import { ModuleFCProps } from "@framework/Module";
-import { useSurfaceDataQueryByAddress } from "@modules/_shared/Surface";
+import { useSurfaceDataQueryByAddress } from "@modules_shared/Surface";
 import SubsurfaceViewer from "@webviz/subsurface-viewer";
 
 import { MapState } from "./MapState";
-import { makeSurfaceAddressString } from "@modules/_shared/Surface/surfaceAddress";
+import { makeSurfaceAddressString } from "@modules_shared/Surface/surfaceAddress";
 
 //-----------------------------------------------------------------------------------------------------------
 export function MapView(props: ModuleFCProps<MapState>) {
@@ -16,7 +16,7 @@ export function MapView(props: ModuleFCProps<MapState>) {
         renderCount.current = renderCount.current + 1;
     });
 
-    console.debug(`render MapView, surfAddr=${surfaceAddress ? makeSurfaceAddressString(surfaceAddress) : "null"}`);
+    console.debug(`render MapView start [${surfaceAddress ? makeSurfaceAddressString(surfaceAddress) : "null"}]`);
 
     const surfDataQuery = useSurfaceDataQueryByAddress(surfaceAddress);
     console.debug(`surfDataQuery.status=${surfDataQuery.status}`);
@@ -25,7 +25,7 @@ export function MapView(props: ModuleFCProps<MapState>) {
         return <div>No data</div>;
     }
 
-    console.debug(`done render MapView, surfAddr=${surfaceAddress ? makeSurfaceAddressString(surfaceAddress) : "null"}`);
+    console.debug(`render MapView done  [${surfaceAddress ? makeSurfaceAddressString(surfaceAddress) : "null"}]`);
 
     const surfData = surfDataQuery.data;
     return (

--- a/frontend/src/modules/Map/MapView.tsx
+++ b/frontend/src/modules/Map/MapView.tsx
@@ -5,6 +5,7 @@ import { useSurfaceDataQueryByAddress } from "@modules/_shared/Surface";
 import SubsurfaceViewer from "@webviz/subsurface-viewer";
 
 import { MapState } from "./MapState";
+import { makeSurfaceAddressString } from "@modules/_shared/Surface/surfaceAddress";
 
 //-----------------------------------------------------------------------------------------------------------
 export function MapView(props: ModuleFCProps<MapState>) {
@@ -15,10 +16,16 @@ export function MapView(props: ModuleFCProps<MapState>) {
         renderCount.current = renderCount.current + 1;
     });
 
+    console.debug(`render MapView, surfAddr=${surfaceAddress ? makeSurfaceAddressString(surfaceAddress) : "null"}`);
+
     const surfDataQuery = useSurfaceDataQueryByAddress(surfaceAddress);
+    console.log(`surfDataQuery.status=${surfDataQuery.status}`);
+
     if (!surfDataQuery.data) {
         return <div>No data</div>;
     }
+
+    console.debug(`done render MapView, surfAddr=${surfaceAddress ? makeSurfaceAddressString(surfaceAddress) : "null"}`);
 
     const surfData = surfDataQuery.data;
     return (
@@ -29,7 +36,8 @@ export function MapView(props: ModuleFCProps<MapState>) {
                     {
                         "@@type": "MapLayer",
                         id: "mesh-layer",
-                        meshData: JSON.parse(surfData.mesh_data),
+                        // Drop conversion as soon as SubsurfaceViewer accepts typed arrays
+                        meshData: Array.from(surfData.valuesFloat32Arr), 
                         frame: {
                             origin: [surfData.x_ori, surfData.y_ori],
                             count: [surfData.x_count, surfData.y_count],

--- a/frontend/src/modules/SubsurfaceMap/queryHooks.tsx
+++ b/frontend/src/modules/SubsurfaceMap/queryHooks.tsx
@@ -6,8 +6,8 @@ import {
     WellBoreTrajectory_api,
 } from "@api";
 import { apiService } from "@framework/ApiService";
-import { SurfaceAddress } from "@modules/_shared/Surface";
-import { SurfaceData_trans, transformSurfaceData } from "@modules/_shared/Surface/queryDataTransforms";
+import { SurfaceAddress } from "@modules_shared/Surface";
+import { SurfaceData_trans, transformSurfaceData } from "@modules_shared/Surface/queryDataTransforms";
 import { QueryFunction, QueryKey, UseQueryResult, useQuery } from "@tanstack/react-query";
 
 import { SurfacePolygonsAddress } from "./SurfacePolygonsAddress";

--- a/frontend/src/modules/SubsurfaceMap/queryHooks.tsx
+++ b/frontend/src/modules/SubsurfaceMap/queryHooks.tsx
@@ -7,6 +7,7 @@ import {
 } from "@api";
 import { apiService } from "@framework/ApiService";
 import { SurfaceAddress } from "@modules/_shared/Surface";
+import { SurfaceData_trans, transformSurfaceData } from "@modules/_shared/Surface/queryDataTransforms";
 import { QueryFunction, QueryKey, UseQueryResult, useQuery } from "@tanstack/react-query";
 
 import { SurfacePolygonsAddress } from "./SurfacePolygonsAddress";
@@ -60,8 +61,8 @@ export function usePropertySurfaceDataByQueryAddress(
     meshSurfAddr: SurfaceAddress | null,
     propertySurfAddr: SurfaceAddress | null,
     enabled: boolean
-): UseQueryResult<SurfaceData_api> {
-    function dummyApiCall(): Promise<SurfaceData_api> {
+): UseQueryResult<SurfaceData_trans> {
+    function dummyApiCall(): Promise<SurfaceData_trans> {
         return new Promise((_resolve, reject) => {
             reject(null);
         });
@@ -136,6 +137,7 @@ export function usePropertySurfaceDataByQueryAddress(
     return useQuery({
         queryKey: queryKey,
         queryFn: queryFn,
+        select: transformSurfaceData,
         staleTime: STALE_TIME,
         cacheTime: CACHE_TIME,
         enabled: enabled,

--- a/frontend/src/modules/SubsurfaceMap/view.tsx
+++ b/frontend/src/modules/SubsurfaceMap/view.tsx
@@ -8,7 +8,7 @@ import { Wellbore } from "@framework/Wellbore";
 import { Button } from "@lib/components/Button";
 import { CircularProgress } from "@lib/components/CircularProgress";
 import { ColorScaleGradientType } from "@lib/utils/ColorScale";
-import { useSurfaceDataQueryByAddress } from "@modules/_shared/Surface";
+import { useSurfaceDataQueryByAddress } from "@modules_shared/Surface";
 import { ViewAnnotation } from "@webviz/subsurface-viewer/dist/components/ViewAnnotation";
 
 import {

--- a/frontend/src/modules/SubsurfaceMap/view.tsx
+++ b/frontend/src/modules/SubsurfaceMap/view.tsx
@@ -103,7 +103,8 @@ export function view({ moduleContext, workbenchSettings, workbenchServices }: Mo
 
     // Mesh data query should only trigger update if the property surface address is not set or if the property surface data is loaded
     if (meshSurfDataQuery.data && !propertySurfAddr) {
-        const newMeshData = jsonParseWithUndefined(meshSurfDataQuery.data.mesh_data);
+        // Drop conversion as soon as SubsurfaceViewer accepts typed arrays
+        const newMeshData = Array.from(meshSurfDataQuery.data.valuesFloat32Arr);
 
         const newSurfaceMetaData: SurfaceMeta = { ...meshSurfDataQuery.data };
         const surfaceLayer: Record<string, unknown> = createSurfaceMeshLayer(
@@ -114,8 +115,9 @@ export function view({ moduleContext, workbenchSettings, workbenchServices }: Mo
         newLayers.push(surfaceLayer);
         colorRange = [meshSurfDataQuery.data.val_min, meshSurfDataQuery.data.val_max];
     } else if (meshSurfDataQuery.data && propertySurfDataQuery.data) {
-        const newMeshData = jsonParseWithUndefined(meshSurfDataQuery.data.mesh_data);
-        const newPropertyData = jsonParseWithUndefined(propertySurfDataQuery.data.mesh_data);
+        // Drop conversion as soon as SubsurfaceViewer accepts typed arrays
+        const newMeshData = Array.from(meshSurfDataQuery.data.valuesFloat32Arr);
+        const newPropertyData = Array.from(propertySurfDataQuery.data.valuesFloat32Arr);
 
         const newSurfaceMetaData: SurfaceMeta = { ...meshSurfDataQuery.data };
         const surfaceLayer: Record<string, unknown> = createSurfaceMeshLayer(

--- a/frontend/src/modules/SubsurfaceMap/view.tsx
+++ b/frontend/src/modules/SubsurfaceMap/view.tsx
@@ -29,10 +29,6 @@ import {
 import { SyncedSubsurfaceViewer } from "./components/SyncedSubsurfaceViewer";
 import { state } from "./state";
 
-const jsonParseWithUndefined = (arrString: string): number[] => {
-    const arr = JSON.parse(arrString);
-    return arr.map((value: number) => (value === null ? undefined : value));
-};
 type Bounds = [number, number, number, number];
 
 const updateViewPortBounds = (

--- a/frontend/src/modules/_shared/Surface/queryDataTransforms.ts
+++ b/frontend/src/modules/_shared/Surface/queryDataTransforms.ts
@@ -12,9 +12,9 @@ export function transformSurfaceData(apiData: SurfaceData_api): SurfaceData_tran
     const startTS = performance.now();
 
     const { values_b64arr, ...untransformedData } = apiData;
-    const dataFloat32Arr = b64DecodeFloatArrayToFloat32(apiData.values_b64arr);
+    const dataFloat32Arr = b64DecodeFloatArrayToFloat32(values_b64arr);
 
-    console.log(`transformSurfaceData elapsed: ${(performance.now() - startTS).toFixed(1)}ms`);
+    console.debug(`transformSurfaceData elapsed: ${(performance.now() - startTS).toFixed(1)}ms`);
 
     return {
         ...untransformedData,

--- a/frontend/src/modules/_shared/Surface/queryDataTransforms.ts
+++ b/frontend/src/modules/_shared/Surface/queryDataTransforms.ts
@@ -1,0 +1,23 @@
+import { SurfaceData_api } from "@api";
+
+import { b64DecodeFloatArrayToFloat32 } from "../base64";
+
+// Data structure for transformed data
+// Remove the base64 encoded data and replace with a Float32Array
+export type SurfaceData_trans = Omit<SurfaceData_api, "values_b64arr"> & {
+    valuesFloat32Arr: Float32Array;
+};
+
+export function transformSurfaceData(apiData: SurfaceData_api): SurfaceData_trans {
+    const startTS = performance.now();
+
+    const { values_b64arr, ...untransformedData } = apiData;
+    const dataFloat32Arr = b64DecodeFloatArrayToFloat32(apiData.values_b64arr);
+
+    console.log(`transformSurfaceData elapsed: ${(performance.now() - startTS).toFixed(1)}ms`);
+
+    return {
+        ...untransformedData,
+        valuesFloat32Arr: dataFloat32Arr,
+    };
+}

--- a/frontend/src/modules/_shared/Surface/queryDataTransforms.ts
+++ b/frontend/src/modules/_shared/Surface/queryDataTransforms.ts
@@ -1,6 +1,6 @@
 import { SurfaceData_api } from "@api";
 
-import { b64DecodeFloatArrayToFloat32 } from "../base64";
+import { b64DecodeFloatArrayToFloat32 } from "@modules_shared/base64";
 
 // Data structure for transformed data
 // Remove the base64 encoded data and replace with a Float32Array
@@ -14,7 +14,7 @@ export function transformSurfaceData(apiData: SurfaceData_api): SurfaceData_tran
     const { values_b64arr, ...untransformedData } = apiData;
     const dataFloat32Arr = b64DecodeFloatArrayToFloat32(values_b64arr);
 
-    console.debug(`transformSurfaceData elapsed: ${(performance.now() - startTS).toFixed(1)}ms`);
+    console.debug(`transformSurfaceData() took: ${(performance.now() - startTS).toFixed(1)}ms`);
 
     return {
         ...untransformedData,

--- a/frontend/src/modules/_shared/Surface/queryHooks.ts
+++ b/frontend/src/modules/_shared/Surface/queryHooks.ts
@@ -2,6 +2,7 @@ import { SurfaceData_api, SurfaceMeta_api } from "@api";
 import { apiService } from "@framework/ApiService";
 import { QueryFunction, QueryKey, UseQueryResult, useQuery } from "@tanstack/react-query";
 
+import { SurfaceData_trans, transformSurfaceData } from "./queryDataTransforms";
 import { SurfaceAddress } from "./surfaceAddress";
 
 const STALE_TIME = 60 * 1000;
@@ -20,8 +21,8 @@ export function useSurfaceDirectoryQuery(
     });
 }
 
-export function useSurfaceDataQueryByAddress(surfAddr: SurfaceAddress | null): UseQueryResult<SurfaceData_api> {
-    function dummyApiCall(): Promise<SurfaceData_api> {
+export function useSurfaceDataQueryByAddress(surfAddr: SurfaceAddress | null): UseQueryResult<SurfaceData_trans> {
+    function dummyApiCall(): Promise<SurfaceData_trans> {
         return new Promise((_resolve, reject) => {
             reject(null);
         });
@@ -87,6 +88,7 @@ export function useSurfaceDataQueryByAddress(surfAddr: SurfaceAddress | null): U
     return useQuery({
         queryKey: queryKey,
         queryFn: queryFn,
+        select: transformSurfaceData,
         staleTime: STALE_TIME,
         cacheTime: CACHE_TIME,
     });

--- a/frontend/src/modules/_shared/base64.ts
+++ b/frontend/src/modules/_shared/base64.ts
@@ -1,0 +1,64 @@
+import { B64FloatArray_api, B64UintArray_api } from "@api";
+
+export function b64DecodeUintArray(base64Arr: B64UintArray_api): Uint16Array | Uint32Array | BigUint64Array {
+    const arrayBuffer = base64StringToArrayBuffer(base64Arr.data_b64str);
+    switch (base64Arr.element_type) {
+        case B64UintArray_api.element_type.UINT16:
+            return new Uint16Array(arrayBuffer);
+        case B64UintArray_api.element_type.UINT32:
+            return new Uint32Array(arrayBuffer);
+        case B64UintArray_api.element_type.UINT64:
+            return new BigUint64Array(arrayBuffer);
+        default:
+            throw new Error(`Unknown element_type: ${base64Arr.element_type}`);
+    }
+}
+
+export function b64DecodeUintArrayToUint32(base64Arr: B64UintArray_api): Uint32Array {
+    const typedArray = b64DecodeUintArray(base64Arr);
+
+    // How should we handle this?
+    // For now, throw an error to make sure we err on the safe side
+    if (typedArray instanceof BigUint64Array) {
+        throw new Error(`Cannot convert BigUint64Array to Uint32Array`);
+    }
+
+    if (typedArray instanceof Uint32Array) {
+        return typedArray;
+    } else {
+        return new Uint32Array(typedArray);
+    }
+}
+
+export function b64DecodeFloatArray(base64Arr: B64FloatArray_api):  Float32Array | Float64Array {
+    const arrayBuffer = base64StringToArrayBuffer(base64Arr.data_b64str);
+    switch (base64Arr.element_type) {
+        case B64FloatArray_api.element_type.FLOAT32:
+            return new Float32Array(arrayBuffer);
+        case B64FloatArray_api.element_type.FLOAT64:
+            return new Float64Array(arrayBuffer);
+        default:
+            throw new Error(`Unknown element_type: ${base64Arr.element_type}`);
+    }
+}
+
+export function b64DecodeFloatArrayToFloat32(base64Arr: B64FloatArray_api): Float32Array {
+    const typedArray = b64DecodeFloatArray(base64Arr);
+    if (typedArray instanceof Float32Array) {
+        return typedArray;
+    } else {
+        return new Float32Array(typedArray);
+    }
+}
+
+function base64StringToArrayBuffer(base64Str: string): ArrayBuffer {
+    const binString = atob(base64Str);
+
+    const ubyteArr = new Uint8Array(binString.length);
+    for (let i = 0; i < binString.length; i++) {
+        ubyteArr[i] = binString.charCodeAt(i);
+    }
+
+    return ubyteArr.buffer;
+}
+


### PR DESCRIPTION
Established utilities and conventions for communicating binary array data embedded in json using base64
Currently transformation from base64 strings to array data is done using React Query's `select` mechanism.

We should probably look into perfroming this conversion as part of the actual data fetching promise instead, see issue #385 
