### PR TITLE
Added overlay in order to prevent images from being draggable

### DIFF
--- a/frontend/src/framework/internal/components/Settings/private-components/modulesList.tsx
+++ b/frontend/src/framework/internal/components/Settings/private-components/modulesList.tsx
@@ -147,7 +147,8 @@ const ModulesListItem: React.FC<ModulesListItemProps> = (props) => {
                         </span>
                     )}
                 </div>
-                <div className="p-4 flex flex-grow items-center justify-center ">
+                <div className="p-4 flex flex-grow items-center justify-center relative">
+                    <div className="absolute w-full h-full z-10 select-none bg-transparent" />
                     {props.drawPreviewFunc
                         ? props.drawPreviewFunc(Math.max(0, itemSize.width - 40), Math.max(0, itemSize.height - 60))
                         : "No preview available"}


### PR DESCRIPTION
With the whole module preview div being draggable now, the user might click on an image and trigger the browser's default image dragging (can e.g. be used for quickly saving images from a website on the local computer by dragging it out of the browser and inside a file explorer instance or to quickly open it in another application). Added an invisible non-selectable layer on top of all preview images in order to suppress this undesired feature.