### PR TITLE
Increase allowed memory during build, also in Radix

### DIFF
--- a/.github/workflows/webviz.yml
+++ b/.github/workflows/webviz.yml
@@ -39,10 +39,7 @@ jobs:
 
       - name: 🏗️ Build JavaScript bundle
         working-directory: ./frontend
-        run: |
-          # Building wsc requires increasing memory allocated to Node
-          export NODE_OPTIONS="--max_old_space_size=4096"
-          npm run build
+        run: npm run build
 
       - name: 🕵️ Check code style, linting & dependencies
         working-directory: ./frontend

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,7 @@
     "type": "module",
     "scripts": {
         "dev": "vite --host",
-        "build": "tsc && vite build",
+        "build": "tsc && NODE_OPTIONS='--max-old-space-size=8192' vite build",
         "preview": "vite preview",
         "generate-api": "openapi --input http://localhost:5000/openapi.json --output ./src/api --client axios --name ApiService --postfixModels _api",
         "typecheck": "tsc --noEmit",


### PR DESCRIPTION
Closes #402. Moved the `NODE_OPTIONS` setting to `package.json` such that it can be reused both in GitHub actions and during e.g. local and Radix build of the docker production container. Also doubled the size, since the current value sometimes is not enough (both in GitHub action and Radix).