### PR TITLE
Proposal for renaming/refactoring of functions/classes/files related to Parameters and Sensitivities

### DIFF
--- a/frontend/src/framework/Ensemble.ts
+++ b/frontend/src/framework/Ensemble.ts
@@ -1,13 +1,13 @@
 import { EnsembleIdent } from "./EnsembleIdent";
 import { EnsembleParameterSet, Parameter } from "./EnsembleParameterSet";
-import { EnsembleSensitivities, Sensitivity } from "./EnsembleSensitivities";
+import { EnsembleSensitivitySet, Sensitivity } from "./EnsembleSensitivities";
 
 export class Ensemble {
     private _ensembleIdent: EnsembleIdent;
     private _caseName: string;
     private _realizationsArr: number[];
     private _parameterSet: EnsembleParameterSet;
-    private _sensitivities: EnsembleSensitivities | null;
+    private _sensitivities: EnsembleSensitivitySet | null;
 
     constructor(
         caseUuid: string,
@@ -24,7 +24,7 @@ export class Ensemble {
 
         this._sensitivities = null;
         if (sensitivityArr && sensitivityArr.length > 0) {
-            this._sensitivities = new EnsembleSensitivities(sensitivityArr);
+            this._sensitivities = new EnsembleSensitivitySet(sensitivityArr);
         }
     }
 
@@ -68,7 +68,7 @@ export class Ensemble {
         return this._parameterSet;
     }
 
-    getSensitivities(): EnsembleSensitivities | null {
+    getSensitivitySet(): EnsembleSensitivitySet | null {
         return this._sensitivities;
     }
 }

--- a/frontend/src/framework/Ensemble.ts
+++ b/frontend/src/framework/Ensemble.ts
@@ -1,12 +1,12 @@
 import { EnsembleIdent } from "./EnsembleIdent";
-import { EnsembleParameters, Parameter } from "./EnsembleParameters";
+import { EnsembleParameterSet, Parameter } from "./EnsembleParameterSet";
 import { EnsembleSensitivities, Sensitivity } from "./EnsembleSensitivities";
 
 export class Ensemble {
     private _ensembleIdent: EnsembleIdent;
     private _caseName: string;
     private _realizationsArr: number[];
-    private _parameters: EnsembleParameters;
+    private _parameterSet: EnsembleParameterSet;
     private _sensitivities: EnsembleSensitivities | null;
 
     constructor(
@@ -20,7 +20,7 @@ export class Ensemble {
         this._ensembleIdent = new EnsembleIdent(caseUuid, ensembleName);
         this._caseName = caseName;
         this._realizationsArr = Array.from(realizationsArr).sort((a, b) => a - b);
-        this._parameters = new EnsembleParameters(parameterArr);
+        this._parameterSet = new EnsembleParameterSet(parameterArr);
 
         this._sensitivities = null;
         if (sensitivityArr && sensitivityArr.length > 0) {
@@ -64,8 +64,8 @@ export class Ensemble {
         return this._realizationsArr[this._realizationsArr.length - 1];
     }
 
-    getParameters(): EnsembleParameters {
-        return this._parameters;
+    getParameterSet(): EnsembleParameterSet {
+        return this._parameterSet;
     }
 
     getSensitivities(): EnsembleSensitivities | null {

--- a/frontend/src/framework/EnsembleParameterSet.ts
+++ b/frontend/src/framework/EnsembleParameterSet.ts
@@ -1,5 +1,7 @@
 import { MinMax } from "@lib/utils/MinMax";
 
+import { ParameterIdent } from "./ParameterIdent";
+
 export enum ParameterType {
     CONTINUOUS,
     DISCRETE,
@@ -28,52 +30,7 @@ export type DiscreteParameter = {
 
 export type Parameter = ContinuousParameter | DiscreteParameter;
 
-export class ParameterIdent {
-    readonly name: string;
-    readonly groupName: string | null;
-
-    constructor(name: string, groupName: string | null) {
-        this.name = name;
-        this.groupName = groupName;
-    }
-
-    static fromNameAndGroup(name: string, groupName: string | null): ParameterIdent {
-        return new ParameterIdent(name, groupName);
-    }
-
-    static fromString(paramIdentString: string): ParameterIdent {
-        const parts = paramIdentString.split("~@@~");
-        if (parts.length === 1) {
-            return new ParameterIdent(parts[0], null);
-        }
-        if (parts.length === 2) {
-            return new ParameterIdent(parts[0], parts[1]);
-        } 
-
-        throw new Error(`Invalid parameter ident string: ${paramIdentString}`);
-    }
-
-    toString(): string {
-        if (this.groupName) {
-            return `${this.name}~@@~${this.groupName}`;
-        } else {
-            return this.name;
-        }
-    }
-
-    equals(otherIdent: ParameterIdent | null): boolean {
-        if (!otherIdent) {
-            return false;
-        }
-        if (otherIdent === this) {
-            return true;
-        }
-
-        return this.name === otherIdent.name && this.groupName === otherIdent.groupName;
-    }
-}
-
-export class EnsembleParameters {
+export class EnsembleParameterSet {
     private _parameterArr: Parameter[];
 
     constructor(parameterArr: Parameter[]) {

--- a/frontend/src/framework/EnsembleSensitivities.ts
+++ b/frontend/src/framework/EnsembleSensitivities.ts
@@ -14,7 +14,7 @@ export type Sensitivity = {
     readonly cases: SensitivityCase[];
 };
 
-export class EnsembleSensitivities {
+export class EnsembleSensitivitySet {
     private _sensitivityArr: Sensitivity[];
 
     constructor(sensitivityArr: Sensitivity[]) {

--- a/frontend/src/framework/ParameterIdent.ts
+++ b/frontend/src/framework/ParameterIdent.ts
@@ -1,0 +1,44 @@
+export class ParameterIdent {
+    readonly name: string;
+    readonly groupName: string | null;
+
+    constructor(name: string, groupName: string | null) {
+        this.name = name;
+        this.groupName = groupName;
+    }
+
+    static fromNameAndGroup(name: string, groupName: string | null): ParameterIdent {
+        return new ParameterIdent(name, groupName);
+    }
+
+    static fromString(paramIdentString: string): ParameterIdent {
+        const parts = paramIdentString.split("~@@~");
+        if (parts.length === 1) {
+            return new ParameterIdent(parts[0], null);
+        }
+        if (parts.length === 2) {
+            return new ParameterIdent(parts[0], parts[1]);
+        }
+
+        throw new Error(`Invalid parameter ident string: ${paramIdentString}`);
+    }
+
+    toString(): string {
+        if (this.groupName) {
+            return `${this.name}~@@~${this.groupName}`;
+        } else {
+            return this.name;
+        }
+    }
+
+    equals(otherIdent: ParameterIdent | null): boolean {
+        if (!otherIdent) {
+            return false;
+        }
+        if (otherIdent === this) {
+            return true;
+        }
+
+        return this.name === otherIdent.name && this.groupName === otherIdent.groupName;
+    }
+}

--- a/frontend/src/framework/internal/EnsembleSetLoader.ts
+++ b/frontend/src/framework/internal/EnsembleSetLoader.ts
@@ -4,7 +4,7 @@ import { QueryClient } from "@tanstack/react-query";
 
 import { Ensemble } from "../Ensemble";
 import { EnsembleIdent } from "../EnsembleIdent";
-import { Parameter, ParameterType, ContinuousParameter, DiscreteParameter } from "../EnsembleParameters";
+import { ContinuousParameter, DiscreteParameter, Parameter, ParameterType } from "../EnsembleParameterSet";
 import { Sensitivity, SensitivityCase } from "../EnsembleSensitivities";
 import { EnsembleSet } from "../EnsembleSet";
 
@@ -141,8 +141,7 @@ function buildParameterArrFromApiResponse(apiParameterArr: EnsembleParameter_api
                 values: apiPar.values as number[],
             };
             retParameterArr.push(retPar);
-        }
-        else {
+        } else {
             const retPar: DiscreteParameter = {
                 type: ParameterType.DISCRETE,
                 name: apiPar.name,

--- a/frontend/src/modules/DbgWorkbenchSpy/implementation.tsx
+++ b/frontend/src/modules/DbgWorkbenchSpy/implementation.tsx
@@ -48,7 +48,10 @@ export function WorkbenchSpyView(props: ModuleFCProps<SharedState>) {
                 <tbody>
                     {makeTableRow("hoverRealization", hoverRealization?.realization, hoverRealization_TS)}
                     {makeTableRow("hoverTimestamp", hoverTimestamp?.timestampUtcMs, hoverTimestamp_TS)}
-                    {makeTableRow("hoverTimestamp isoStr", hoverTimestamp ? timestampUtcMsToIsoString(hoverTimestamp.timestampUtcMs) : "UNDEF")}
+                    {makeTableRow(
+                        "hoverTimestamp isoStr",
+                        hoverTimestamp ? timestampUtcMsToIsoString(hoverTimestamp.timestampUtcMs) : "UNDEF"
+                    )}
                 </tbody>
             </table>
             <br />
@@ -84,7 +87,7 @@ function makeEnsembleSetTable(ensembleSet: EnsembleSet) {
                         <td> {ens.getEnsembleName()} </td>
                         <td> ({ens.getCaseUuid()}) </td>
                         <td> {ens.getRealizations().length} realizations</td>
-                        <td> {ens.getSensitivities() ? "HasSens" : "noSense"}</td>
+                        <td> {ens.getSensitivitySet() ? "HasSens" : "noSense"}</td>
                     </tr>
                 ))}
             </tbody>

--- a/frontend/src/modules/SimulationTimeSeriesMatrix/settings.tsx
+++ b/frontend/src/modules/SimulationTimeSeriesMatrix/settings.tsx
@@ -2,9 +2,10 @@ import React from "react";
 
 import { Frequency_api, StatisticFunction_api } from "@api";
 import { EnsembleIdent } from "@framework/EnsembleIdent";
-import { ParameterIdent, ParameterType } from "@framework/EnsembleParameters";
+import { ParameterType } from "@framework/EnsembleParameterSet";
 import { EnsembleSet } from "@framework/EnsembleSet";
 import { ModuleFCProps } from "@framework/Module";
+import { ParameterIdent } from "@framework/ParameterIdent";
 import { useEnsembleSet } from "@framework/WorkbenchSession";
 import { MultiEnsembleSelect } from "@framework/components/MultiEnsembleSelect";
 import { VectorSelector, createVectorSelectorDataFromVectors } from "@framework/components/VectorSelector";
@@ -86,9 +87,9 @@ export function settings({ moduleContext, workbenchSession }: ModuleFCProps<Stat
         const ensemble = ensembleSet.findEnsemble(ensembleIdent);
         if (ensemble === null) continue;
 
-        for (const parameter of ensemble.getParameters().getParameterIdents(ParameterType.CONTINUOUS)) {
+        for (const parameter of ensemble.getParameterSet().getParameterIdents(ParameterType.CONTINUOUS)) {
             if (continuousAndNonConstantParametersUnion.some((param) => param.equals(parameter))) continue;
-            if (ensemble.getParameters().getParameter(parameter).isConstant) continue;
+            if (ensemble.getParameterSet().getParameter(parameter).isConstant) continue;
 
             continuousAndNonConstantParametersUnion.push(parameter);
         }

--- a/frontend/src/modules/SimulationTimeSeriesMatrix/state.ts
+++ b/frontend/src/modules/SimulationTimeSeriesMatrix/state.ts
@@ -1,6 +1,6 @@
 import { Frequency_api, StatisticFunction_api } from "@api";
 import { EnsembleIdent } from "@framework/EnsembleIdent";
-import { ParameterIdent } from "@framework/EnsembleParameters";
+import { ParameterIdent } from "@framework/ParameterIdent";
 
 export interface VectorSpec {
     ensembleIdent: EnsembleIdent;

--- a/frontend/src/modules/SimulationTimeSeriesMatrix/utils/ensemblesContinuousParameterColoring.ts
+++ b/frontend/src/modules/SimulationTimeSeriesMatrix/utils/ensemblesContinuousParameterColoring.ts
@@ -1,5 +1,6 @@
 import { Ensemble } from "@framework/Ensemble";
-import { ContinuousParameter, ParameterIdent, ParameterType } from "@framework/EnsembleParameters";
+import { ContinuousParameter, ParameterType } from "@framework/EnsembleParameterSet";
+import { ParameterIdent } from "@framework/ParameterIdent";
 import { ColorScale } from "@lib/utils/ColorScale";
 import { MinMax } from "@lib/utils/MinMax";
 
@@ -20,7 +21,7 @@ export class EnsemblesContinuousParameterColoring {
         this._ensembleContinuousParameterSet = {};
         let minMax = MinMax.createInvalid();
         for (const ensemble of selectedEnsembles) {
-            const parameters = ensemble.getParameters();
+            const parameters = ensemble.getParameterSet();
             if (!parameters.hasParameter(parameterIdent)) continue;
 
             const parameter = parameters.getParameter(parameterIdent);

--- a/frontend/src/modules/SimulationTimeSeriesMatrix/view.tsx
+++ b/frontend/src/modules/SimulationTimeSeriesMatrix/view.tsx
@@ -97,7 +97,7 @@ export const view = ({ moduleContext, workbenchSession, workbenchSettings }: Mod
     const doColorByParameter =
         colorRealizationsByParameter &&
         parameterIdent !== null &&
-        selectedEnsembles.some((ensemble) => ensemble.getParameters().findParameter(parameterIdent));
+        selectedEnsembles.some((ensemble) => ensemble.getParameterSet().findParameter(parameterIdent));
     const ensemblesParameterColoring = doColorByParameter
         ? new EnsemblesContinuousParameterColoring(selectedEnsembles, parameterIdent, parameterColorScale)
         : null;

--- a/frontend/src/modules/SimulationTimeSeriesSensitivity/settings.tsx
+++ b/frontend/src/modules/SimulationTimeSeriesSensitivity/settings.tsx
@@ -89,7 +89,7 @@ export function settings({ moduleContext, workbenchSession, workbenchServices }:
     const computedVectorTag = candidateVectorTag;
 
     const computedEnsemble = computedEnsembleIdent ? ensembleSet.findEnsemble(computedEnsembleIdent) : null;
-    const sensitivityNames = computedEnsemble?.getSensitivities()?.getSensitivityNames() ?? [];
+    const sensitivityNames = computedEnsemble?.getSensitivitySet()?.getSensitivityNames() ?? [];
     React.useEffect(
         function setSensitivitiesOnEnsembleChange() {
             if (!isEqual(selectedSensitivities, sensitivityNames)) {

--- a/frontend/src/modules/SimulationTimeSeriesSensitivity/view.tsx
+++ b/frontend/src/modules/SimulationTimeSeriesSensitivity/view.tsx
@@ -107,7 +107,7 @@ export const view = ({
     );
     const colorSet = workbenchSettings.useColorSet();
 
-    const allSensitivityNamesInEnsemble = ensemble?.getSensitivities()?.getSensitivityNames().sort() ?? [];
+    const allSensitivityNamesInEnsemble = ensemble?.getSensitivitySet()?.getSensitivityNames().sort() ?? [];
 
     const traceDataArr: TimeSeriesPlotlyTrace[] = [];
     if (ensemble && selectedSensitivities && selectedSensitivities.length > 0) {
@@ -125,7 +125,7 @@ export const view = ({
             }
 
             // Add realization traces
-            const sensitivity = ensemble.getSensitivities()?.getSensitivityByName(sensitivityName);
+            const sensitivity = ensemble.getSensitivitySet()?.getSensitivityByName(sensitivityName);
             if (showRealizations && realizationsQuery.data && sensitivity) {
                 for (const sensCase of sensitivity.cases) {
                     const realsToInclude = sensCase.realizations;

--- a/frontend/src/modules/TornadoChart/sensitivityResponseCalculator.ts
+++ b/frontend/src/modules/TornadoChart/sensitivityResponseCalculator.ts
@@ -1,4 +1,9 @@
-import { EnsembleSensitivities, Sensitivity, SensitivityCase, SensitivityType } from "@framework/EnsembleSensitivities";
+import {
+    EnsembleSensitivitySet,
+    Sensitivity,
+    SensitivityCase,
+    SensitivityType,
+} from "@framework/EnsembleSensitivities";
 import { computeQuantile } from "@modules_shared/statistics";
 
 export type EnsembleScalarResponse = {
@@ -42,12 +47,12 @@ export class SensitivityResponseCalculator {
      * Class for calculating sensitivities for a given Ensemble response
      */
     private _ensembleResponse: EnsembleScalarResponse;
-    private _sensitivities: EnsembleSensitivities;
+    private _sensitivities: EnsembleSensitivitySet;
     private _referenceSensitivity: string;
     private _referenceAverage: number;
 
     constructor(
-        sensitivities: EnsembleSensitivities,
+        sensitivities: EnsembleSensitivitySet,
         ensembleResponse: EnsembleScalarResponse,
         referenceSensitivity = "rms_seed"
     ) {

--- a/frontend/src/modules/TornadoChart/view.tsx
+++ b/frontend/src/modules/TornadoChart/view.tsx
@@ -89,7 +89,7 @@ export const view = ({
         return unsubscribeFunc;
     }, [responseChannel, ensembleSet]);
 
-    const sensitivities = channelEnsemble?.getSensitivities();
+    const sensitivities = channelEnsemble?.getSensitivitySet();
     const colorSet = workbenchSettings.useColorSet();
     const sensitivitiesColorMap = createSensitivityColorMap(
         sensitivities?.getSensitivityNames().sort() ?? [],

--- a/frontend/tests/unit-tests/EnsembleParameters.test.ts
+++ b/frontend/tests/unit-tests/EnsembleParameters.test.ts
@@ -1,4 +1,5 @@
-import { EnsembleParameterSet, Parameter, ParameterIdent, ParameterType } from "@framework/EnsembleParameters";
+import { EnsembleParameterSet, Parameter, ParameterType } from "@framework/EnsembleParameterSet";
+import { ParameterIdent } from "@framework/ParameterIdent";
 import { MinMax } from "@lib/utils/MinMax";
 
 // prettier-ignore

--- a/frontend/tests/unit-tests/EnsembleParameters.test.ts
+++ b/frontend/tests/unit-tests/EnsembleParameters.test.ts
@@ -1,4 +1,4 @@
-import { EnsembleParameters, Parameter, ParameterIdent, ParameterType } from "@framework/EnsembleParameters";
+import { EnsembleParameterSet, Parameter, ParameterIdent, ParameterType } from "@framework/EnsembleParameters";
 import { MinMax } from "@lib/utils/MinMax";
 
 // prettier-ignore
@@ -12,10 +12,9 @@ const PARAM_ARR: Parameter[] = [
     {type: ParameterType.DISCRETE, name: "dparam_B", groupName: null, description: "descB", isConstant: false, realizations: [1,2,3], values: ["A", "B", "C"]},
 ];
 
-
 describe("EnsembleParameters tests", () => {
     test("Get list of parameter idents", () => {
-        const ensParams = new EnsembleParameters(PARAM_ARR);
+        const ensParams = new EnsembleParameterSet(PARAM_ARR);
         {
             const allIdents = ensParams.getParameterIdents(null);
             expect(allIdents.length).toEqual(6);
@@ -43,7 +42,7 @@ describe("EnsembleParameters tests", () => {
     });
 
     test("Check for parameter existence", () => {
-        const ensParams = new EnsembleParameters(PARAM_ARR);
+        const ensParams = new EnsembleParameterSet(PARAM_ARR);
 
         expect(ensParams.hasParameter(ParameterIdent.fromNameAndGroup("cparam_10", null))).toBe(true);
         expect(ensParams.hasParameter(ParameterIdent.fromNameAndGroup("cparam_50", "grp1"))).toBe(true);
@@ -56,7 +55,7 @@ describe("EnsembleParameters tests", () => {
     });
 
     test("Get parameters", () => {
-        const ensParams = new EnsembleParameters(PARAM_ARR);
+        const ensParams = new EnsembleParameterSet(PARAM_ARR);
         {
             const par = ensParams.getParameter(ParameterIdent.fromNameAndGroup("cparam_10", null));
             expect(par.type).toEqual(ParameterType.CONTINUOUS);
@@ -81,12 +80,12 @@ describe("EnsembleParameters tests", () => {
     });
 
     test("Check that getting non-existing parameter throws", () => {
-        const ensParams = new EnsembleParameters(PARAM_ARR);
+        const ensParams = new EnsembleParameterSet(PARAM_ARR);
         expect(() => ensParams.getParameter(ParameterIdent.fromNameAndGroup("someBogusName", null))).toThrow();
     });
 
     test("Test getting min/max values for continuous parameter", () => {
-        const ensParams = new EnsembleParameters(PARAM_ARR);
+        const ensParams = new EnsembleParameterSet(PARAM_ARR);
         {
             const minMax = ensParams.getContinuousParameterMinMax(ParameterIdent.fromNameAndGroup("cparam_10", null));
             expect(minMax).toEqual(new MinMax(11, 19));
@@ -97,7 +96,6 @@ describe("EnsembleParameters tests", () => {
         }
     });
 });
-
 
 describe("ParameterIdent tests", () => {
     test("Conversion to/from string", () => {


### PR DESCRIPTION
The current function calls for getting a list of parameters from an ensemble does not really add to readability. 

![image](https://github.com/equinor/webviz/assets/69145689/9fb14f4b-50f8-4077-b268-874194b436fc)

I suggest to (in accordance to implemented patterns around `EnsembleSet`):

- Rename `EnsembleParameters` to `EnsembleParameterSet` (also the related getter function and member)
- Moving `ParameterIdent` into its own file