### PR TITLE
Multiple bug fixes and improvements related to initial settings, templates, and `ChannelSelect`

### DIFF
--- a/frontend/src/framework/InitialSettings.ts
+++ b/frontend/src/framework/InitialSettings.ts
@@ -58,17 +58,20 @@ export class InitialSettings {
     isSet(settingName: string, type: keyof InitialSettingsSupportedTypes): boolean {
         return this.get(settingName, type) !== undefined;
     }
+}
 
-    applyToStateOnMount(
-        settingName: string,
-        type: keyof InitialSettingsSupportedTypes,
-        stateSetter: (value: any) => void
-    ): void {
-        React.useEffect(() => {
-            const setting = this.get(settingName, type);
+export function applyToStateOnMount(
+    settingName: string,
+    type: keyof InitialSettingsSupportedTypes,
+    stateSetter: (value: any) => void,
+    initialSettings?: InitialSettings
+): void {
+    React.useEffect(() => {
+        if (initialSettings) {
+            const setting = initialSettings.get(settingName, type);
             if (setting !== undefined) {
                 stateSetter(setting);
             }
-        }, []);
-    }
+        }
+    }, [initialSettings]);
 }

--- a/frontend/src/framework/InitialSettings.ts
+++ b/frontend/src/framework/InitialSettings.ts
@@ -64,7 +64,7 @@ export function applyToStateOnMount(
     settingName: string,
     type: keyof InitialSettingsSupportedTypes,
     stateSetter: (value: any) => void,
-    initialSettings?: InitialSettings
+    initialSettings: InitialSettings | undefined
 ): void {
     React.useEffect(() => {
         if (initialSettings) {

--- a/frontend/src/framework/InitialSettings.ts
+++ b/frontend/src/framework/InitialSettings.ts
@@ -60,7 +60,7 @@ export class InitialSettings {
     }
 }
 
-export function applyToStateOnMount(
+export function applyInitialSettingsToState(
     initialSettings: InitialSettings | undefined,
     settingName: string,
     type: keyof InitialSettingsSupportedTypes,

--- a/frontend/src/framework/InitialSettings.ts
+++ b/frontend/src/framework/InitialSettings.ts
@@ -61,10 +61,10 @@ export class InitialSettings {
 }
 
 export function applyToStateOnMount(
+    initialSettings: InitialSettings | undefined,
     settingName: string,
     type: keyof InitialSettingsSupportedTypes,
-    stateSetter: (value: any) => void,
-    initialSettings: InitialSettings | undefined
+    stateSetter: (value: any) => void
 ): void {
     React.useEffect(() => {
         if (initialSettings) {

--- a/frontend/src/framework/Workbench.ts
+++ b/frontend/src/framework/Workbench.ts
@@ -17,7 +17,6 @@ import { WorkbenchSessionPrivate } from "./internal/WorkbenchSessionPrivate";
 
 export enum WorkbenchEvents {
     ModuleInstancesChanged = "ModuleInstancesChanged",
-    FullModuleRerenderRequested = "FullModuleRerenderRequested",
 }
 
 export type LayoutElement = {
@@ -143,7 +142,8 @@ export class Workbench {
         }
         this._moduleInstances = [];
         this._layout = [];
-        this.notifySubscribers(WorkbenchEvents.FullModuleRerenderRequested);
+        this._perModuleRunningInstanceNumber = {};
+        this.notifySubscribers(WorkbenchEvents.ModuleInstancesChanged);
     }
 
     makeAndAddModuleInstance(moduleName: string, layout: LayoutElement): ModuleInstance<any> {
@@ -178,7 +178,6 @@ export class Workbench {
 
     setLayout(layout: LayoutElement[]): void {
         this._layout = layout;
-        this.notifySubscribers(WorkbenchEvents.FullModuleRerenderRequested);
 
         const modifiedLayout = layout.map((el) => {
             return { ...el, moduleInstanceId: undefined };

--- a/frontend/src/framework/Workbench.ts
+++ b/frontend/src/framework/Workbench.ts
@@ -142,7 +142,6 @@ export class Workbench {
             this._broadcaster.unregisterAllChannelsForModuleInstance(moduleInstance.getId());
         }
         this._moduleInstances = [];
-        this._perModuleRunningInstanceNumber = {};
         this._layout = [];
         this.notifySubscribers(WorkbenchEvents.FullModuleRerenderRequested);
     }

--- a/frontend/src/framework/components/ChannelSelect/channelSelect.tsx
+++ b/frontend/src/framework/components/ChannelSelect/channelSelect.tsx
@@ -20,7 +20,13 @@ export type ChannelSelectProps = {
 export const ChannelSelect: React.FC<ChannelSelectProps> = (props) => {
     const { channelKeyCategory, onChange, broadcaster, ...rest } = props;
     const [channel, setChannel] = React.useState<string>(props.initialChannel ?? "");
+    const [prevInitialChannel, setPrevInitialChannel] = React.useState<string | undefined>(props.initialChannel);
     const [channels, setChannels] = React.useState<string[]>([]);
+
+    if (prevInitialChannel !== props.initialChannel) {
+        setPrevInitialChannel(props.initialChannel);
+        setChannel(props.initialChannel ?? "");
+    }
 
     React.useEffect(() => {
         const handleChannelsChanged = (channels: BroadcastChannel[]) => {
@@ -36,6 +42,7 @@ export const ChannelSelect: React.FC<ChannelSelectProps> = (props) => {
 
             if (channels.length === 0 || !channels.find((el) => el.getName() === channel)) {
                 setChannel("");
+
                 if (onChange) {
                     onChange("");
                 }
@@ -45,7 +52,7 @@ export const ChannelSelect: React.FC<ChannelSelectProps> = (props) => {
         const unsubscribeFunc = broadcaster.subscribeToChannelsChanges(handleChannelsChanged);
 
         return unsubscribeFunc;
-    }, [channelKeyCategory, onChange, broadcaster]);
+    }, [channelKeyCategory, onChange, broadcaster, channel]);
 
     const handleChannelsChanged = (channel: string) => {
         setChannel(channel);

--- a/frontend/src/modules/DistributionPlot/settings.tsx
+++ b/frontend/src/modules/DistributionPlot/settings.tsx
@@ -1,6 +1,7 @@
 import React, { ChangeEvent } from "react";
 
 import { BroadcastChannelKeyCategory } from "@framework/Broadcaster";
+import { applyToStateOnMount } from "@framework/InitialSettings";
 import { ModuleFCProps } from "@framework/Module";
 import { ChannelSelect } from "@framework/components/ChannelSelect";
 import { Dropdown } from "@lib/components/Dropdown";
@@ -62,17 +63,13 @@ export function settings({ moduleContext, workbenchServices, initialSettings }: 
     const [orientation, setOrientation] = moduleContext.useStoreState("orientation");
     const [crossPlottingType, setCrossPlottingType] = React.useState<BroadcastChannelKeyCategory | null>(null);
 
-    initialSettings?.applyToStateOnMount("channelNameX", "string", setChannelNameX);
-    initialSettings?.applyToStateOnMount("channelNameY", "string", setChannelNameY);
-    initialSettings?.applyToStateOnMount("channelNameZ", "string", setChannelNameZ);
-    initialSettings?.applyToStateOnMount("plotType", "string", setPlotType);
-    initialSettings?.applyToStateOnMount("numBins", "number", setNumBins);
-    initialSettings?.applyToStateOnMount("orientation", "string", setOrientation);
-    initialSettings?.applyToStateOnMount("crossPlottingType", "string", setCrossPlottingType);
-    applyToStateOnMount("plotType", "string", setPlotType);
-    applyToStateOnMount("numBins", "number", setNumBins);
-    applyToStateOnMount("orientation", "string", setOrientation);
-    applyToStateOnMount("crossPlottingType", "string", setCrossPlottingType);
+    applyToStateOnMount("channelNameX", "string", setChannelNameX, initialSettings);
+    applyToStateOnMount("channelNameY", "string", setChannelNameY, initialSettings);
+    applyToStateOnMount("channelNameZ", "string", setChannelNameZ, initialSettings);
+    applyToStateOnMount("plotType", "string", setPlotType, initialSettings);
+    applyToStateOnMount("numBins", "number", setNumBins, initialSettings);
+    applyToStateOnMount("orientation", "string", setOrientation, initialSettings);
+    applyToStateOnMount("crossPlottingType", "string", setCrossPlottingType, initialSettings);
 
     const handleChannelXChanged = (channelName: string) => {
         setChannelNameX(channelName);

--- a/frontend/src/modules/DistributionPlot/settings.tsx
+++ b/frontend/src/modules/DistributionPlot/settings.tsx
@@ -69,6 +69,10 @@ export function settings({ moduleContext, workbenchServices, initialSettings }: 
     initialSettings?.applyToStateOnMount("numBins", "number", setNumBins);
     initialSettings?.applyToStateOnMount("orientation", "string", setOrientation);
     initialSettings?.applyToStateOnMount("crossPlottingType", "string", setCrossPlottingType);
+    applyToStateOnMount("plotType", "string", setPlotType);
+    applyToStateOnMount("numBins", "number", setNumBins);
+    applyToStateOnMount("orientation", "string", setOrientation);
+    applyToStateOnMount("crossPlottingType", "string", setCrossPlottingType);
 
     const handleChannelXChanged = (channelName: string) => {
         setChannelNameX(channelName);

--- a/frontend/src/modules/DistributionPlot/settings.tsx
+++ b/frontend/src/modules/DistributionPlot/settings.tsx
@@ -63,13 +63,13 @@ export function settings({ moduleContext, workbenchServices, initialSettings }: 
     const [orientation, setOrientation] = moduleContext.useStoreState("orientation");
     const [crossPlottingType, setCrossPlottingType] = React.useState<BroadcastChannelKeyCategory | null>(null);
 
-    applyToStateOnMount("channelNameX", "string", setChannelNameX, initialSettings);
-    applyToStateOnMount("channelNameY", "string", setChannelNameY, initialSettings);
-    applyToStateOnMount("channelNameZ", "string", setChannelNameZ, initialSettings);
-    applyToStateOnMount("plotType", "string", setPlotType, initialSettings);
-    applyToStateOnMount("numBins", "number", setNumBins, initialSettings);
-    applyToStateOnMount("orientation", "string", setOrientation, initialSettings);
-    applyToStateOnMount("crossPlottingType", "string", setCrossPlottingType, initialSettings);
+    applyToStateOnMount(initialSettings, "channelNameX", "string", setChannelNameX);
+    applyToStateOnMount(initialSettings, "channelNameY", "string", setChannelNameY);
+    applyToStateOnMount(initialSettings, "channelNameZ", "string", setChannelNameZ);
+    applyToStateOnMount(initialSettings, "plotType", "string", setPlotType);
+    applyToStateOnMount(initialSettings, "numBins", "number", setNumBins);
+    applyToStateOnMount(initialSettings, "orientation", "string", setOrientation);
+    applyToStateOnMount(initialSettings, "crossPlottingType", "string", setCrossPlottingType);
 
     const handleChannelXChanged = (channelName: string) => {
         setChannelNameX(channelName);

--- a/frontend/src/modules/DistributionPlot/settings.tsx
+++ b/frontend/src/modules/DistributionPlot/settings.tsx
@@ -1,7 +1,7 @@
 import React, { ChangeEvent } from "react";
 
 import { BroadcastChannelKeyCategory } from "@framework/Broadcaster";
-import { applyToStateOnMount } from "@framework/InitialSettings";
+import { applyInitialSettingsToState } from "@framework/InitialSettings";
 import { ModuleFCProps } from "@framework/Module";
 import { ChannelSelect } from "@framework/components/ChannelSelect";
 import { Dropdown } from "@lib/components/Dropdown";
@@ -63,13 +63,13 @@ export function settings({ moduleContext, workbenchServices, initialSettings }: 
     const [orientation, setOrientation] = moduleContext.useStoreState("orientation");
     const [crossPlottingType, setCrossPlottingType] = React.useState<BroadcastChannelKeyCategory | null>(null);
 
-    applyToStateOnMount(initialSettings, "channelNameX", "string", setChannelNameX);
-    applyToStateOnMount(initialSettings, "channelNameY", "string", setChannelNameY);
-    applyToStateOnMount(initialSettings, "channelNameZ", "string", setChannelNameZ);
-    applyToStateOnMount(initialSettings, "plotType", "string", setPlotType);
-    applyToStateOnMount(initialSettings, "numBins", "number", setNumBins);
-    applyToStateOnMount(initialSettings, "orientation", "string", setOrientation);
-    applyToStateOnMount(initialSettings, "crossPlottingType", "string", setCrossPlottingType);
+    applyInitialSettingsToState(initialSettings, "channelNameX", "string", setChannelNameX);
+    applyInitialSettingsToState(initialSettings, "channelNameY", "string", setChannelNameY);
+    applyInitialSettingsToState(initialSettings, "channelNameZ", "string", setChannelNameZ);
+    applyInitialSettingsToState(initialSettings, "plotType", "string", setPlotType);
+    applyInitialSettingsToState(initialSettings, "numBins", "number", setNumBins);
+    applyInitialSettingsToState(initialSettings, "orientation", "string", setOrientation);
+    applyInitialSettingsToState(initialSettings, "crossPlottingType", "string", setCrossPlottingType);
 
     const handleChannelXChanged = (channelName: string) => {
         setChannelNameX(channelName);

--- a/frontend/src/modules/SimulationTimeSeries/channelDefs.ts
+++ b/frontend/src/modules/SimulationTimeSeries/channelDefs.ts
@@ -9,12 +9,4 @@ export const broadcastChannelsDef = {
         key: BroadcastChannelKeyCategory.Realization,
         value: BroadcastChannelValueType.Numeric,
     },
-    [BroadcastChannelNames.Realization_Value_TEST]: {
-        key: BroadcastChannelKeyCategory.Realization,
-        value: BroadcastChannelValueType.Numeric,
-    },
-    [BroadcastChannelNames.Time_Value]: {
-        key: BroadcastChannelKeyCategory.TimestampMs,
-        value: BroadcastChannelValueType.Numeric,
-    },
 };

--- a/frontend/src/modules/SimulationTimeSeries/channelDefs.ts
+++ b/frontend/src/modules/SimulationTimeSeries/channelDefs.ts
@@ -9,4 +9,12 @@ export const broadcastChannelsDef = {
         key: BroadcastChannelKeyCategory.Realization,
         value: BroadcastChannelValueType.Numeric,
     },
+    [BroadcastChannelNames.Realization_Value_TEST]: {
+        key: BroadcastChannelKeyCategory.Realization,
+        value: BroadcastChannelValueType.Numeric,
+    },
+    [BroadcastChannelNames.Time_Value]: {
+        key: BroadcastChannelKeyCategory.TimestampMs,
+        value: BroadcastChannelValueType.Numeric,
+    },
 };

--- a/frontend/src/modules/TornadoChart/settings.tsx
+++ b/frontend/src/modules/TornadoChart/settings.tsx
@@ -1,5 +1,5 @@
 import { BroadcastChannelKeyCategory } from "@framework/Broadcaster";
-import { applyToStateOnMount } from "@framework/InitialSettings";
+import { applyInitialSettingsToState } from "@framework/InitialSettings";
 import { ModuleFCProps } from "@framework/Module";
 import { ChannelSelect } from "@framework/components/ChannelSelect";
 import { Label } from "@lib/components/Label";
@@ -9,7 +9,7 @@ import { State } from "./state";
 export function settings({ moduleContext, workbenchServices, initialSettings }: ModuleFCProps<State>) {
     const [responseChannelName, setResponseChannelName] = moduleContext.useStoreState("responseChannelName");
 
-    applyToStateOnMount(initialSettings, "responseChannelName", "string", setResponseChannelName);
+    applyInitialSettingsToState(initialSettings, "responseChannelName", "string", setResponseChannelName);
 
     function handleResponseChannelNameChange(channelName: string) {
         setResponseChannelName(channelName);

--- a/frontend/src/modules/TornadoChart/settings.tsx
+++ b/frontend/src/modules/TornadoChart/settings.tsx
@@ -1,4 +1,5 @@
 import { BroadcastChannelKeyCategory } from "@framework/Broadcaster";
+import { applyToStateOnMount } from "@framework/InitialSettings";
 import { ModuleFCProps } from "@framework/Module";
 import { ChannelSelect } from "@framework/components/ChannelSelect";
 import { Label } from "@lib/components/Label";
@@ -8,13 +9,18 @@ import { State } from "./state";
 export function settings({ moduleContext, workbenchServices, initialSettings }: ModuleFCProps<State>) {
     const [responseChannelName, setResponseChannelName] = moduleContext.useStoreState("responseChannelName");
 
-    initialSettings?.applyToStateOnMount("responseChannelName", "string", setResponseChannelName);
+    applyToStateOnMount("responseChannelName", "string", setResponseChannelName, initialSettings);
+
+    function handleResponseChannelNameChange(channelName: string) {
+        console.debug("handleResponseChannelNameChange", responseChannelName, channelName);
+        setResponseChannelName(channelName);
+    }
 
     return (
         <>
             <Label text="Data channel" key="data-channel-x-axis">
                 <ChannelSelect
-                    onChange={setResponseChannelName}
+                    onChange={handleResponseChannelNameChange}
                     channelKeyCategory={BroadcastChannelKeyCategory.Realization}
                     initialChannel={responseChannelName || undefined}
                     broadcaster={workbenchServices.getBroadcaster()}

--- a/frontend/src/modules/TornadoChart/settings.tsx
+++ b/frontend/src/modules/TornadoChart/settings.tsx
@@ -9,7 +9,7 @@ import { State } from "./state";
 export function settings({ moduleContext, workbenchServices, initialSettings }: ModuleFCProps<State>) {
     const [responseChannelName, setResponseChannelName] = moduleContext.useStoreState("responseChannelName");
 
-    applyToStateOnMount("responseChannelName", "string", setResponseChannelName, initialSettings);
+    applyToStateOnMount(initialSettings, "responseChannelName", "string", setResponseChannelName);
 
     function handleResponseChannelNameChange(channelName: string) {
         setResponseChannelName(channelName);

--- a/frontend/src/modules/TornadoChart/settings.tsx
+++ b/frontend/src/modules/TornadoChart/settings.tsx
@@ -12,7 +12,6 @@ export function settings({ moduleContext, workbenchServices, initialSettings }: 
     applyToStateOnMount("responseChannelName", "string", setResponseChannelName, initialSettings);
 
     function handleResponseChannelNameChange(channelName: string) {
-        console.debug("handleResponseChannelNameChange", responseChannelName, channelName);
         setResponseChannelName(channelName);
     }
 

--- a/frontend/src/templates/oatTimeSeries.ts
+++ b/frontend/src/templates/oatTimeSeries.ts
@@ -20,7 +20,7 @@ const template: Template = {
             syncedSettings: [SyncSettingKey.ENSEMBLE],
         },
         {
-            instanceRef: "TorandoChartInstance",
+            instanceRef: "TornadoChartInstance",
             moduleName: "TornadoChart",
             layout: {
                 relHeight: 0.5,


### PR DESCRIPTION
- `Workbench` cannot reset module instance count as it is used as a `key` property for React and would prevent a proper remount of the respective components
- `applyToStateOnMount` needs to be move out of possibly undefined `InitialSettings` and take it as an argument, such that it is always called and the check for `undefined` is moved into the respective `useEffect` (this caused #306)
- `ChannelSelect` did not react to updates to its `initialChannel` property and had a missing dependency in its `useEffect` causing issues when initialising e.g. `TornadoPlot` in a template

Closes #306.