### PR TITLE
`Select` and `Virtualization` fixes

### DIFF
--- a/frontend/src/lib/components/Select/select.tsx
+++ b/frontend/src/lib/components/Select/select.tsx
@@ -60,7 +60,6 @@ export const Select = withDefaults<SelectProps>()(defaultProps, (props) => {
     if (!isEqual(filteredOptions, prevFilteredOptions)) {
         let newCurrentIndex = 0;
         let newStartIndex = 0;
-        const indexOffset = currentIndex - startIndex;
         let oldCurrentValue = prevFilteredOptions[currentIndex]?.value;
         if (props.value?.length >= 1) {
             oldCurrentValue = props.value[0];
@@ -70,7 +69,7 @@ export const Select = withDefaults<SelectProps>()(defaultProps, (props) => {
             const newIndex = filteredOptions.findIndex((option) => option.value === oldCurrentValue);
             if (newIndex !== -1) {
                 newCurrentIndex = newIndex;
-                newStartIndex = Math.max(0, newIndex - indexOffset);
+                newStartIndex = newIndex;
             }
         }
         setCurrentIndex(newCurrentIndex);

--- a/frontend/src/lib/components/Select/select.tsx
+++ b/frontend/src/lib/components/Select/select.tsx
@@ -191,8 +191,6 @@ export const Select = withDefaults<SelectProps>()(defaultProps, (props) => {
         }
     };
 
-    console.debug("startIndex", startIndex, "currentIndex", currentIndex);
-
     return (
         <BaseComponent disabled={props.disabled}>
             <div

--- a/frontend/src/lib/components/Select/select.tsx
+++ b/frontend/src/lib/components/Select/select.tsx
@@ -125,7 +125,6 @@ export const Select = withDefaults<SelectProps>()(defaultProps, (props) => {
             setKeysPressed((keysPressed) => [...keysPressed, e.key]);
 
             if (e.key === "Shift") {
-                console.debug("Shift pressed", currentIndex);
                 setLastShiftIndex(currentIndex);
             }
 

--- a/frontend/src/lib/components/Select/select.tsx
+++ b/frontend/src/lib/components/Select/select.tsx
@@ -3,6 +3,8 @@ import React, { Key } from "react";
 import { resolveClassNames } from "@lib/utils/resolveClassNames";
 import { getTextWidth } from "@lib/utils/textSize";
 
+import { isEqual } from "lodash";
+
 import { BaseComponent, BaseComponentProps } from "../BaseComponent";
 import { Input } from "../Input";
 import { Virtualization } from "../Virtualization";
@@ -45,7 +47,7 @@ export const Select = withDefaults<SelectProps>()(defaultProps, (props) => {
     const [startIndex, setStartIndex] = React.useState<number>(0);
     const [lastShiftIndex, setLastShiftIndex] = React.useState<number>(-1);
     const [currentIndex, setCurrentIndex] = React.useState<number>(0);
-    const [minWidth, setMinWidth] = React.useState<number>(0);
+    const [prevFilteredOptions, setPrevFilteredOptions] = React.useState<SelectOption[]>([]);
 
     const ref = React.useRef<HTMLDivElement>(null);
     const noOptionsText = props.placeholder ?? "No options";
@@ -56,24 +58,25 @@ export const Select = withDefaults<SelectProps>()(defaultProps, (props) => {
         return props.options.filter((option) => option.label.toLowerCase().includes(filter.toLowerCase()));
     }, [props.options, filter]);
 
-    React.useEffect(() => {
-        let longestOptionWidth = props.options.reduce((prev, current) => {
-            const labelWidth = getTextWidth(current.label, document.body);
-            if (labelWidth > prev) {
-                return labelWidth;
-            }
-            return prev;
-        }, 0);
-
-        if (longestOptionWidth === 0) {
-            if (props.options.length === 0 || filter === "") {
-                longestOptionWidth = getTextWidth(noOptionsText, document.body);
-            } else {
-                longestOptionWidth = getTextWidth(noMatchingOptionsText, document.body);
+    if (!isEqual(filteredOptions, prevFilteredOptions)) {
+        let newCurrentIndex = 0;
+        let newStartIndex = 0;
+        const indexOffset = currentIndex - startIndex;
+        let oldCurrentValue = prevFilteredOptions[currentIndex]?.value;
+        if (props.value?.length >= 1) {
+            oldCurrentValue = props.value[0];
+        }
+        setPrevFilteredOptions(filteredOptions);
+        if (oldCurrentValue) {
+            const newIndex = filteredOptions.findIndex((option) => option.value === oldCurrentValue);
+            if (newIndex !== -1) {
+                newCurrentIndex = newIndex;
+                newStartIndex = Math.max(0, newIndex - indexOffset);
             }
         }
-        setMinWidth(longestOptionWidth + 40);
-    }, [props.options, noOptionsText, filter]);
+        setCurrentIndex(newCurrentIndex);
+        setStartIndex(newStartIndex);
+    }
 
     const toggleValue = React.useCallback(
         (option: SelectOption, index: number) => {
@@ -121,10 +124,12 @@ export const Select = withDefaults<SelectProps>()(defaultProps, (props) => {
         const handleKeyDown = (e: KeyboardEvent) => {
             setKeysPressed((keysPressed) => [...keysPressed, e.key]);
 
+            if (e.key === "Shift") {
+                console.debug("Shift pressed", currentIndex);
+                setLastShiftIndex(currentIndex);
+            }
+
             if (hasFocus) {
-                if (e.key === "Shift") {
-                    setLastShiftIndex(currentIndex);
-                }
                 if (e.key === "ArrowUp") {
                     e.preventDefault();
                     const newIndex = Math.max(0, currentIndex - 1);
@@ -186,6 +191,8 @@ export const Select = withDefaults<SelectProps>()(defaultProps, (props) => {
         }
     };
 
+    console.debug("startIndex", startIndex, "currentIndex", currentIndex);
+
     return (
         <BaseComponent disabled={props.disabled}>
             <div
@@ -195,7 +202,7 @@ export const Select = withDefaults<SelectProps>()(defaultProps, (props) => {
                     "pointer-events-none": props.disabled,
                     "opacity-30": props.disabled,
                 })}
-                style={{ width: props.width, minWidth: props.width ?? minWidth }}
+                style={{ width: props.width, minWidth: props.width }}
             >
                 {props.filter && (
                     <Input
@@ -254,8 +261,11 @@ export const Select = withDefaults<SelectProps>()(defaultProps, (props) => {
                                     style={{ height: 24 }}
                                 >
                                     {option.icon}
-                                    <span title={option.label} className="min-w-0 text-ellipsis overflow-hidden whitespace-nowrap">
-                                            {option.label}
+                                    <span
+                                        title={option.label}
+                                        className="min-w-0 text-ellipsis overflow-hidden whitespace-nowrap"
+                                    >
+                                        {option.label}
                                     </span>
                                 </div>
                             );

--- a/frontend/src/lib/components/Select/select.tsx
+++ b/frontend/src/lib/components/Select/select.tsx
@@ -1,7 +1,6 @@
 import React, { Key } from "react";
 
 import { resolveClassNames } from "@lib/utils/resolveClassNames";
-import { getTextWidth } from "@lib/utils/textSize";
 
 import { isEqual } from "lodash";
 

--- a/frontend/src/lib/components/Virtualization/virtualization.tsx
+++ b/frontend/src/lib/components/Virtualization/virtualization.tsx
@@ -2,6 +2,8 @@ import React from "react";
 
 import { useElementSize } from "@lib/hooks/useElementSize";
 
+import { isEqual } from "lodash";
+
 import { withDefaults } from "../_component-utils/components";
 
 export type VirtualizationProps<T = any> = {
@@ -25,26 +27,56 @@ export const Virtualization = withDefaults<VirtualizationProps>()(defaultProps, 
         start: props.startIndex * props.itemSize,
         end: 0,
     });
+    const [prevInitialScrollPositions, setPrevInitialScrollPositions] = React.useState<
+        | {
+              top: number;
+              left: number;
+          }
+        | undefined
+    >(undefined);
 
     const containerSize = useElementSize(props.containerRef);
 
-    React.useEffect(() => {
+    const initialScrollPositions = React.useMemo(() => {
         if (props.containerRef.current) {
+            let top = 0;
+            let left = 0;
             if (props.direction === "vertical") {
-                props.containerRef.current.scrollTop = props.startIndex * props.itemSize;
+                top = props.startIndex * props.itemSize;
             } else {
-                props.containerRef.current.scrollLeft = props.startIndex * props.itemSize;
+                left = props.startIndex * props.itemSize;
             }
+            return { top, left };
         }
-    }, [
-        props.containerRef,
-        props.direction,
-        props.startIndex,
-        props.itemSize,
-        props.items,
-        containerSize.height,
-        containerSize.width,
-    ]);
+    }, [props.containerRef, props.direction, props.itemSize, props.startIndex]);
+
+    if (!isEqual(prevInitialScrollPositions, initialScrollPositions)) {
+        if (props.containerRef.current) {
+            let size = containerSize.height;
+            let scrollPosition = initialScrollPositions?.top || 0;
+            if (props.direction === "horizontal") {
+                size = containerSize.width;
+                scrollPosition = initialScrollPositions?.left || 0;
+            }
+
+            const startIndex = Math.max(0, Math.floor(scrollPosition / props.itemSize) - 1);
+            const endIndex = Math.min(props.items.length - 1, Math.ceil((scrollPosition + size) / props.itemSize) + 1);
+
+            setRange({ start: startIndex, end: endIndex });
+            setPlaceholderSizes({
+                start: startIndex * props.itemSize,
+                end: (props.items.length - 1 - endIndex) * props.itemSize,
+            });
+        }
+        setPrevInitialScrollPositions(initialScrollPositions);
+    }
+
+    React.useEffect(() => {
+        if (props.containerRef.current && initialScrollPositions) {
+            props.containerRef.current.scrollTop = initialScrollPositions.top;
+            props.containerRef.current.scrollLeft = initialScrollPositions.left;
+        }
+    }, [props.containerRef, initialScrollPositions]);
 
     React.useEffect(() => {
         let lastScrollPosition = -1;

--- a/frontend/src/lib/components/Virtualization/virtualization.tsx
+++ b/frontend/src/lib/components/Virtualization/virtualization.tsx
@@ -41,6 +41,7 @@ export const Virtualization = withDefaults<VirtualizationProps>()(defaultProps, 
         props.direction,
         props.startIndex,
         props.itemSize,
+        props.items,
         containerSize.height,
         containerSize.width,
     ]);


### PR DESCRIPTION
- Improved `startIndex` handling in `Virtualization`, fixes #394
- Removed auto `minWidth` handling in `Select`, fixes #373 
- Moved shift handling function out of focus check if statement, fixes #377