### PR TITLE
Allow change of reference sensitivity in TornadoChart/Table

### DIFF
--- a/frontend/src/modules/SimulationTimeSeriesSensitivity/settings.tsx
+++ b/frontend/src/modules/SimulationTimeSeriesSensitivity/settings.tsx
@@ -96,7 +96,7 @@ export function settings({ moduleContext, workbenchSession, workbenchServices }:
                 setSelectedSensitivities(sensitivityNames);
             }
         },
-        [sensitivityNames]
+        [computedEnsemble]
     );
     const sensitivityOptions: SelectOption[] = sensitivityNames.map((name) => ({
         value: name,

--- a/frontend/src/modules/TornadoChart/loadModule.tsx
+++ b/frontend/src/modules/TornadoChart/loadModule.tsx
@@ -6,6 +6,8 @@ import { view } from "./view";
 
 const defaultState: State = {
     plotType: PlotType.TORNADO,
+    referenceSensitivityName: null,
+    sensitivityNames: [],
     selectedSensitivity: null,
     responseChannelName: null,
 };

--- a/frontend/src/modules/TornadoChart/sensitivityResponseCalculator.ts
+++ b/frontend/src/modules/TornadoChart/sensitivityResponseCalculator.ts
@@ -49,11 +49,12 @@ export class SensitivityResponseCalculator {
     constructor(
         sensitivities: EnsembleSensitivities,
         ensembleResponse: EnsembleScalarResponse,
-        referenceSensitivity = "rms_seed"
+        referenceSensitivity: string | null
     ) {
         this._ensembleResponse = ensembleResponse;
         this._sensitivities = sensitivities;
-        if (!this._sensitivities.hasSensitivityName(referenceSensitivity)) {
+
+        if (!referenceSensitivity || !this._sensitivities.hasSensitivityName(referenceSensitivity)) {
             throw new Error(
                 `SensitivityResponseCalculator: Reference sensitivity ${referenceSensitivity} not found in ensemble`
             );

--- a/frontend/src/modules/TornadoChart/sensitivityTable.tsx
+++ b/frontend/src/modules/TornadoChart/sensitivityTable.tsx
@@ -60,7 +60,7 @@ const SensitivityTable: React.FC<SensitivityTableProps> = (props) => {
                 [TableColumns.TRUE_HIGH]: numFormat(sensitivityResponse.highCaseAverage),
                 [TableColumns.LOW_REALS]: sensitivityResponse.lowCaseRealizations.length,
                 [TableColumns.HIGH_REALS]: sensitivityResponse.highCaseRealizations.length,
-                [TableColumns.REFERENCE]: "rms_seed",
+                [TableColumns.REFERENCE]: props.sensitivityResponseDataset.referenceSensitivity,
             }));
         setTableRows(rows);
     }, [props.sensitivityResponseDataset, props.hideZeroY]);

--- a/frontend/src/modules/TornadoChart/settings.tsx
+++ b/frontend/src/modules/TornadoChart/settings.tsx
@@ -1,10 +1,32 @@
+import React from "react";
+
 import { ModuleFCProps } from "@framework/Module";
 import { ChannelSelect } from "@framework/components/ChannelSelect";
+import { Dropdown } from "@lib/components/Dropdown";
 import { Label } from "@lib/components/Label";
+import { R } from "@tanstack/react-query-devtools/build/legacy/devtools-c71c5f06";
 
 import { State } from "./state";
 
 export function settings({ moduleContext, workbenchServices }: ModuleFCProps<State>) {
+    const sensitivityNames = moduleContext.useStoreValue("sensitivityNames");
+    const [referenceSensitivityName, setReferenceSensitivityName] = React.useState<string | null>(null);
+    const setModuleReferenceSensitivityName = moduleContext.useSetStoreValue("referenceSensitivityName");
+    React.useEffect(
+        function propogateReferenceSensitivityName() {
+            setModuleReferenceSensitivityName(referenceSensitivityName);
+        },
+        [referenceSensitivityName]
+    );
+
+    if (!referenceSensitivityName && sensitivityNames.length > 0) {
+        if (sensitivityNames.includes("rms_seed")) {
+            setReferenceSensitivityName("rms_seed");
+        } else {
+            setReferenceSensitivityName(sensitivityNames[0]);
+        }
+    }
+
     return (
         <>
             <Label text="Data channel" key="data-channel-x-axis">
@@ -12,6 +34,13 @@ export function settings({ moduleContext, workbenchServices }: ModuleFCProps<Sta
                     moduleContext={moduleContext}
                     channelName="response"
                     broadcaster={workbenchServices.getBroadcaster()}
+                />
+            </Label>
+            <Label text="Reference sensitivity">
+                <Dropdown
+                    value={referenceSensitivityName ?? ""}
+                    options={sensitivityNames.map((s) => ({ label: s, value: s }))}
+                    onChange={setReferenceSensitivityName}
                 />
             </Label>
             ,

--- a/frontend/src/modules/TornadoChart/settings.tsx
+++ b/frontend/src/modules/TornadoChart/settings.tsx
@@ -4,7 +4,6 @@ import { ModuleFCProps } from "@framework/Module";
 import { ChannelSelect } from "@framework/components/ChannelSelect";
 import { Dropdown } from "@lib/components/Dropdown";
 import { Label } from "@lib/components/Label";
-import { R } from "@tanstack/react-query-devtools/build/legacy/devtools-c71c5f06";
 
 import { State } from "./state";
 

--- a/frontend/src/modules/TornadoChart/state.ts
+++ b/frontend/src/modules/TornadoChart/state.ts
@@ -10,6 +10,8 @@ export type SelectedSensitivity = {
 
 export interface State {
     plotType: PlotType;
+    referenceSensitivityName: string | null;
+    sensitivityNames: string[];
     selectedSensitivity: SelectedSensitivity | null;
     responseChannelName: string | null;
 }


### PR DESCRIPTION
Tries to set to set `rms_seed` as reference, if not picks the first sensitivity found.
The reference can then be changed from a dropdown in the TornadoChart module.

Closes #465 