### PR TITLE
New `eslint` rules for React and adjustments and bug fixes to codebase

### DIFF
--- a/frontend/.eslintrc.cjs
+++ b/frontend/.eslintrc.cjs
@@ -3,7 +3,8 @@ module.exports = {
         browser: true,
         es2021: true
     },
-    extends: ["eslint:recommended", "plugin:react/recommended", "plugin:@typescript-eslint/recommended"],
+    plugins: ["@typescript-eslint", "react"],
+    extends: ["eslint:recommended", "plugin:react/recommended", "plugin:react-hooks/recommended", "plugin:@typescript-eslint/recommended"],
     rules: {
         "@typescript-eslint/no-explicit-any": "off",
         "react/jsx-uses-react": "off", // Import of React is not required anymore in React 17

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -47,6 +47,7 @@
                 "eslint-plugin-import": "^2.27.5",
                 "eslint-plugin-prettier": "^4.2.1",
                 "eslint-plugin-react": "^7.32.2",
+                "eslint-plugin-react-hooks": "^4.6.0",
                 "glob": "^10.3.3",
                 "openapi-typescript-codegen": "^0.24.0",
                 "postcss": "^8.4.21",
@@ -7238,6 +7239,18 @@
             },
             "peerDependencies": {
                 "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
+            }
+        },
+        "node_modules/eslint-plugin-react-hooks": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz",
+            "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "peerDependencies": {
+                "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0"
             }
         },
         "node_modules/eslint-plugin-react/node_modules/doctrine": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -58,6 +58,7 @@
         "eslint-plugin-import": "^2.27.5",
         "eslint-plugin-prettier": "^4.2.1",
         "eslint-plugin-react": "^7.32.2",
+        "eslint-plugin-react-hooks": "^4.6.0",
         "glob": "^10.3.3",
         "openapi-typescript-codegen": "^0.24.0",
         "postcss": "^8.4.21",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -50,6 +50,8 @@ function App() {
 
     React.useEffect(
         function handleMountWhenSignedIn() {
+            const workbenchRef = workbench.current;
+
             if (authState !== AuthState.LoggedIn || isMounted) {
                 return;
             }
@@ -67,11 +69,11 @@ function App() {
             }
 
             return function handleUnmount() {
-                workbench.current.clearLayout();
-                workbench.current.resetModuleInstanceNumbers();
+                workbenchRef.clearLayout();
+                workbenchRef.resetModuleInstanceNumbers();
             };
         },
-        [authState, isMounted]
+        [authState, isMounted, queryClient]
     );
 
     function makeStateMessages() {

--- a/frontend/src/framework/GuiMessageBroker.ts
+++ b/frontend/src/framework/GuiMessageBroker.ts
@@ -200,15 +200,19 @@ export function useGuiState<T extends GuiState>(
         guiMessageBroker.makeStateSnapshotGetter(state)
     );
 
-    function stateSetter(
-        valueOrFunc: GuiStateValueTypes[T] | ((prev: GuiStateValueTypes[T]) => GuiStateValueTypes[T])
-    ): void {
-        if (valueOrFunc instanceof Function) {
-            guiMessageBroker.setState(state, valueOrFunc(stateValue));
-            return;
-        }
-        guiMessageBroker.setState(state, valueOrFunc);
-    }
+    const stateSetter = React.useCallback(
+        function stateSetter(
+            valueOrFunc: GuiStateValueTypes[T] | ((prev: GuiStateValueTypes[T]) => GuiStateValueTypes[T])
+        ): void {
+            if (valueOrFunc instanceof Function) {
+                const value = guiMessageBroker.getState(state);
+                guiMessageBroker.setState(state, valueOrFunc(value));
+                return;
+            }
+            guiMessageBroker.setState(state, valueOrFunc);
+        },
+        [guiMessageBroker, state]
+    );
 
     return [stateValue, stateSetter];
 }

--- a/frontend/src/framework/InitialSettings.ts
+++ b/frontend/src/framework/InitialSettings.ts
@@ -60,7 +60,7 @@ export class InitialSettings {
     }
 }
 
-export function applyInitialSettingsToState(
+export function useApplyInitialSettingsToState(
     initialSettings: InitialSettings | undefined,
     settingName: string,
     type: keyof InitialSettingsSupportedTypes,
@@ -73,5 +73,5 @@ export function applyInitialSettingsToState(
                 stateSetter(setting);
             }
         }
-    }, [initialSettings]);
+    }, [initialSettings, settingName, type, stateSetter]);
 }

--- a/frontend/src/framework/ModuleContext.ts
+++ b/frontend/src/framework/ModuleContext.ts
@@ -1,3 +1,15 @@
+/**
+ * Why are we disbling rules-of-hooks here?
+ *
+ * Well, we are using several hooks in this class, which is not allowed by this rule.
+ * However, we are not using these hooks in a component, but in a utility class.
+ * The important thing to remember is that these functions must be called on every render,
+ * unconditionally (i.e. not in a conditional statement) and not in a loop.
+ * This is exactly what we are doing here. We are only using the class to group the functions together
+ * and give additional context to the functions.
+ */
+
+/* eslint-disable react-hooks/rules-of-hooks */
 import React from "react";
 
 import { BroadcastChannel, InputBroadcastChannelDef } from "./Broadcaster";
@@ -85,7 +97,7 @@ export class ModuleContext<S extends StateBaseType> {
                     this._moduleInstance.setInputChannel(name, setting);
                 }
             }
-        }, [initialSettings]);
+        }, [initialSettings, name]);
 
         React.useEffect(() => {
             function handleNewChannel(newChannel: BroadcastChannel | null) {

--- a/frontend/src/framework/StateStore.ts
+++ b/frontend/src/framework/StateStore.ts
@@ -75,13 +75,17 @@ export function useStoreState<T extends keyof S, S extends StateBaseType>(
         return unsubscribeFunc;
     }, [key, stateStore]);
 
-    function setter(valueOrFunc: S[T] | ((prev: S[T]) => S[T])): void {
-        if (valueOrFunc instanceof Function) {
-            stateStore.setValue(key, valueOrFunc(state));
-            return;
-        }
-        stateStore.setValue(key, valueOrFunc);
-    }
+    const setter = React.useCallback(
+        function setter(valueOrFunc: S[T] | ((prev: S[T]) => S[T])): void {
+            if (valueOrFunc instanceof Function) {
+                const value = stateStore.getValue(key);
+                stateStore.setValue(key, valueOrFunc(value));
+                return;
+            }
+            stateStore.setValue(key, valueOrFunc);
+        },
+        [key, stateStore]
+    );
 
     return [state, setter];
 }

--- a/frontend/src/framework/SyncSettings.ts
+++ b/frontend/src/framework/SyncSettings.ts
@@ -1,5 +1,5 @@
 /**
- * Why are we disbling rules-of-hooks here?
+ * Why are we disabling rules-of-hooks here?
  *
  * Well, we are using several hooks in this class, which is not allowed by this rule.
  * However, we are not using these hooks in a component, but in a utility class.

--- a/frontend/src/framework/SyncSettings.ts
+++ b/frontend/src/framework/SyncSettings.ts
@@ -1,3 +1,15 @@
+/**
+ * Why are we disbling rules-of-hooks here?
+ *
+ * Well, we are using several hooks in this class, which is not allowed by this rule.
+ * However, we are not using these hooks in a component, but in a utility class.
+ * The important thing to remember is that these functions must be called on every render,
+ * unconditionally (i.e. not in a conditional statement) and not in a loop.
+ * This is exactly what we are doing here. We are only using the class to group the functions together
+ * and give additional context to the functions.
+ */
+
+/* eslint-disable react-hooks/rules-of-hooks */
 import { GlobalTopicDefinitions, TopicDefinitionsType } from "@framework/WorkbenchServices";
 import { useSubscribedValueConditionally } from "@framework/WorkbenchServices";
 import { WorkbenchServices } from "@framework/WorkbenchServices";

--- a/frontend/src/framework/WorkbenchSettings.ts
+++ b/frontend/src/framework/WorkbenchSettings.ts
@@ -1,3 +1,15 @@
+/**
+ * Why are we disbling rules-of-hooks here?
+ *
+ * Well, we are using several hooks in this class, which is not allowed by this rule.
+ * However, we are not using these hooks in a component, but in a utility class.
+ * The important thing to remember is that these functions must be called on every render,
+ * unconditionally (i.e. not in a conditional statement) and not in a loop.
+ * This is exactly what we are doing here. We are only using the class to group the functions together
+ * and give additional context to the functions.
+ */
+
+/* eslint-disable react-hooks/rules-of-hooks */
 import React from "react";
 
 import { WorkbenchSettingsEvents } from "@framework/internal/PrivateWorkbenchSettings";
@@ -215,6 +227,9 @@ export class WorkbenchSettings {
             ],
         };
 
+        const divergingSteps = this._steps[ColorScaleDiscreteSteps.Diverging];
+        const sequentialSteps = this._steps[ColorScaleDiscreteSteps.Sequential];
+
         const [adjustedOptions, setAdjustedOptions] = React.useState<ColorScaleOptions>(optionsWithDefaults);
 
         const [colorScale, setColorScale] = React.useState<ColorScale>(new ColorScale(optionsWithDefaults));
@@ -228,11 +243,8 @@ export class WorkbenchSettings {
             const handleColorPalettesChanged = () => {
                 const newColorScale = new ColorScale({
                     ...adjustedOptions,
-                    steps: this._steps[
-                        options.gradientType === ColorScaleGradientType.Sequential
-                            ? ColorScaleDiscreteSteps.Sequential
-                            : ColorScaleDiscreteSteps.Diverging
-                    ],
+                    steps:
+                        options.gradientType === ColorScaleGradientType.Sequential ? sequentialSteps : divergingSteps,
                     colorPalette: this.getSelectedColorPalette(
                         options.gradientType === ColorScaleGradientType.Sequential
                             ? ColorPaletteType.ContinuousSequential
@@ -252,7 +264,7 @@ export class WorkbenchSettings {
             return () => {
                 unsubscribeFunc();
             };
-        }, [adjustedOptions]);
+        }, [adjustedOptions, divergingSteps, sequentialSteps, options.gradientType]);
 
         return colorScale;
     }
@@ -301,7 +313,7 @@ export class WorkbenchSettings {
             return () => {
                 unsubscribeFunc();
             };
-        }, [adjustedOptions]);
+        }, [adjustedOptions, options.gradientType]);
 
         return colorScale;
     }

--- a/frontend/src/framework/components/ParameterListFilter/parameterListFilter.tsx
+++ b/frontend/src/framework/components/ParameterListFilter/parameterListFilter.tsx
@@ -29,6 +29,8 @@ export type ParameterListFilterProps = {
 };
 
 export const ParameterListFilter: React.FC<ParameterListFilterProps> = (props: ParameterListFilterProps) => {
+    const { onChange } = props;
+
     const smartNodeSelectorId = React.useId();
     const [selectedTags, setSelectedTags] = React.useState<string[]>(
         props.initialFilters ?? [ParameterParentNodeNames.IS_NONCONSTANT]
@@ -52,8 +54,8 @@ export const ParameterListFilter: React.FC<ParameterListFilterProps> = (props: P
         function createFilterParameters() {
             if (parameters === null || parameters.length === 0) {
                 setNumberOfMatchingParameters(0);
-                if (props.onChange) {
-                    props.onChange([]);
+                if (onChange) {
+                    onChange([]);
                 }
                 return;
             }
@@ -64,11 +66,11 @@ export const ParameterListFilter: React.FC<ParameterListFilterProps> = (props: P
                 smartNodeSelectorDelimiter
             );
             setNumberOfMatchingParameters(filteredParameters.length);
-            if (props.onChange) {
-                props.onChange(filteredParameters);
+            if (onChange) {
+                onChange(filteredParameters);
             }
         },
-        [selectedNodes, parameters, props.onChange]
+        [selectedNodes, parameters, onChange, smartNodeSelectorDelimiter]
     );
 
     function handleSmartNodeSelectorChange(selection: SmartNodeSelectorSelection) {

--- a/frontend/src/framework/components/RealizationPicker/realizationPicker.tsx
+++ b/frontend/src/framework/components/RealizationPicker/realizationPicker.tsx
@@ -72,7 +72,7 @@ const RealizationRangeTag: React.FC<RealizationRangeTagProps> = (props) => {
         } else if (!props.active && ref.current) {
             ref.current.blur();
         }
-    }, [props.active]);
+    }, [props.active, props.caretPosition, value]);
 
     function handleChange(event: React.ChangeEvent<HTMLInputElement>) {
         const value = event.target.value;

--- a/frontend/src/framework/internal/components/Content/private-components/DataChannelVisualizationLayer/dataChannelVisualizationLayer.tsx
+++ b/frontend/src/framework/internal/components/Content/private-components/DataChannelVisualizationLayer/dataChannelVisualizationLayer.tsx
@@ -227,7 +227,13 @@ export const DataChannelVisualizationLayer: React.FC<DataChannelVisualizationPro
             document.removeEventListener("pointermove", handlePointerMove);
             document.removeEventListener("resize", handleConnectionChange);
         };
-    }, []);
+    }, [
+        forceRerender,
+        guiMessageBroker,
+        props.workbench,
+        setDataChannelConnectionsLayerVisible,
+        setShowDataChannelConnections,
+    ]);
     let midPointY = (originPoint.y + currentPointerPosition.y) / 2;
 
     if (currentPointerPosition.y < originPoint.y + 40 && currentPointerPosition.y > originPoint.y) {

--- a/frontend/src/framework/internal/components/Content/private-components/ViewWrapper/private-components/channelSelector.tsx
+++ b/frontend/src/framework/internal/components/Content/private-components/ViewWrapper/private-components/channelSelector.tsx
@@ -13,6 +13,8 @@ export type ChannelSelectorProps = {
 };
 
 export const ChannelSelector: React.FC<ChannelSelectorProps> = (props) => {
+    const { onCancel } = props;
+
     React.useEffect(() => {
         const handleClickOutside = (e: PointerEvent) => {
             const target = e.target as HTMLElement;
@@ -25,7 +27,7 @@ export const ChannelSelector: React.FC<ChannelSelectorProps> = (props) => {
             if (target.closest("#channel-selector")) {
                 return;
             }
-            props.onCancel();
+            onCancel();
         };
 
         document.addEventListener("pointerdown", handleClickOutside);
@@ -33,7 +35,7 @@ export const ChannelSelector: React.FC<ChannelSelectorProps> = (props) => {
         return () => {
             document.removeEventListener("pointerdown", handleClickOutside);
         };
-    }, [props.onCancel]);
+    }, [onCancel]);
 
     return createPortal(
         <>

--- a/frontend/src/framework/internal/components/Content/private-components/ViewWrapper/private-components/header.tsx
+++ b/frontend/src/framework/internal/components/Content/private-components/ViewWrapper/private-components/header.tsx
@@ -35,24 +35,27 @@ export const Header: React.FC<HeaderProps> = (props) => {
     const ref = React.useRef<HTMLDivElement>(null);
     const boundingRect = useElementBoundingRect(ref);
 
-    React.useEffect(function handleMount() {
-        function handleSyncedSettingsChange(newSyncedSettings: SyncSettingKey[]) {
-            setSyncedSettings([...newSyncedSettings]);
-        }
+    React.useEffect(
+        function handleMount() {
+            function handleSyncedSettingsChange(newSyncedSettings: SyncSettingKey[]) {
+                setSyncedSettings([...newSyncedSettings]);
+            }
 
-        function handleTitleChange(newTitle: string) {
-            setTitle(newTitle);
-        }
+            function handleTitleChange(newTitle: string) {
+                setTitle(newTitle);
+            }
 
-        const unsubscribeFromSyncSettingsChange =
-            props.moduleInstance.subscribeToSyncedSettingKeysChange(handleSyncedSettingsChange);
-        const unsubscribeFromTitleChange = props.moduleInstance.subscribeToTitleChange(handleTitleChange);
+            const unsubscribeFromSyncSettingsChange =
+                props.moduleInstance.subscribeToSyncedSettingKeysChange(handleSyncedSettingsChange);
+            const unsubscribeFromTitleChange = props.moduleInstance.subscribeToTitleChange(handleTitleChange);
 
-        return function handleUnmount() {
-            unsubscribeFromSyncSettingsChange();
-            unsubscribeFromTitleChange();
-        };
-    }, []);
+            return function handleUnmount() {
+                unsubscribeFromSyncSettingsChange();
+                unsubscribeFromTitleChange();
+            };
+        },
+        [props.moduleInstance]
+    );
 
     function handlePointerDown(e: React.PointerEvent<HTMLDivElement>) {
         props.onPointerDown(e);

--- a/frontend/src/framework/internal/components/Content/private-components/ViewWrapper/private-components/inputChannelNodeWrapper.tsx
+++ b/frontend/src/framework/internal/components/Content/private-components/ViewWrapper/private-components/inputChannelNodeWrapper.tsx
@@ -131,7 +131,7 @@ export const InputChannelNodes: React.FC<InputChannelNodesProps> = (props) => {
             props.moduleInstance.setInputChannel(inputName, channelName);
             guiMessageBroker.publishEvent(GuiEvent.HideDataChannelConnectionsRequest);
         },
-        [props.moduleInstance, props.workbench]
+        [props.moduleInstance, props.workbench, guiMessageBroker]
     );
 
     const handleChannelDisconnect = React.useCallback(
@@ -139,7 +139,7 @@ export const InputChannelNodes: React.FC<InputChannelNodesProps> = (props) => {
             props.moduleInstance.removeInputChannel(inputName);
             guiMessageBroker.publishEvent(GuiEvent.DataChannelConnectionsChange);
         },
-        [props.moduleInstance]
+        [props.moduleInstance, guiMessageBroker]
     );
 
     function handleCancelChannelSelection() {

--- a/frontend/src/framework/internal/components/Content/private-components/ViewWrapper/private-components/viewContent.tsx
+++ b/frontend/src/framework/internal/components/Content/private-components/ViewWrapper/private-components/viewContent.tsx
@@ -21,31 +21,34 @@ export const ViewContent = React.memo((props: ViewContentProps) => {
         ModuleInstanceState.INITIALIZING
     );
 
-    React.useEffect(function handleMount() {
-        setModuleInstanceState(props.moduleInstance.getModuleInstanceState());
-        setImportState(props.moduleInstance.getImportState());
-
-        function handleModuleInstanceImportStateChange() {
-            setImportState(props.moduleInstance.getImportState());
-        }
-
-        function handleModuleInstanceStateChange() {
+    React.useEffect(
+        function handleMount() {
             setModuleInstanceState(props.moduleInstance.getModuleInstanceState());
-        }
+            setImportState(props.moduleInstance.getImportState());
 
-        const unsubscribeFromImportStateChange = props.moduleInstance.subscribeToImportStateChange(
-            handleModuleInstanceImportStateChange
-        );
+            function handleModuleInstanceImportStateChange() {
+                setImportState(props.moduleInstance.getImportState());
+            }
 
-        const unsubscribeFromModuleInstanceStateChange = props.moduleInstance.subscribeToModuleInstanceStateChange(
-            handleModuleInstanceStateChange
-        );
+            function handleModuleInstanceStateChange() {
+                setModuleInstanceState(props.moduleInstance.getModuleInstanceState());
+            }
 
-        return function handleUnmount() {
-            unsubscribeFromImportStateChange();
-            unsubscribeFromModuleInstanceStateChange();
-        };
-    }, []);
+            const unsubscribeFromImportStateChange = props.moduleInstance.subscribeToImportStateChange(
+                handleModuleInstanceImportStateChange
+            );
+
+            const unsubscribeFromModuleInstanceStateChange = props.moduleInstance.subscribeToModuleInstanceStateChange(
+                handleModuleInstanceStateChange
+            );
+
+            return function handleUnmount() {
+                unsubscribeFromImportStateChange();
+                unsubscribeFromModuleInstanceStateChange();
+            };
+        },
+        [props.moduleInstance]
+    );
 
     const handleModuleInstanceReload = React.useCallback(
         function handleModuleInstanceReload() {

--- a/frontend/src/framework/internal/components/Content/private-components/ViewWrapper/viewWrapper.tsx
+++ b/frontend/src/framework/internal/components/Content/private-components/ViewWrapper/viewWrapper.tsx
@@ -56,7 +56,7 @@ export const ViewWrapper: React.FC<ViewWrapperProps> = (props) => {
                 });
             }
         },
-        [props.moduleInstance]
+        [props.moduleInstance, guiMessageBroker]
     );
 
     const handleRemoveClick = React.useCallback(
@@ -67,7 +67,7 @@ export const ViewWrapper: React.FC<ViewWrapperProps> = (props) => {
             e.preventDefault();
             e.stopPropagation();
         },
-        [props.moduleInstance]
+        [props.moduleInstance, guiMessageBroker]
     );
 
     function handleModuleClick() {

--- a/frontend/src/framework/internal/components/Content/private-components/layout.tsx
+++ b/frontend/src/framework/internal/components/Content/private-components/layout.tsx
@@ -266,7 +266,7 @@ export const Layout: React.FC<LayoutProps> = (props) => {
                 clearTimeout(delayTimer);
             }
         };
-    }, [size, moduleInstances]);
+    }, [size, moduleInstances, guiMessageBroker, props.workbench]);
 
     const makeTempViewWrapperPlaceholder = () => {
         if (!tempLayoutBoxId) {

--- a/frontend/src/framework/internal/components/NavBar/navBar.tsx
+++ b/frontend/src/framework/internal/components/NavBar/navBar.tsx
@@ -62,7 +62,7 @@ export const NavBar: React.FC<NavBarProps> = (props) => {
                 unsubscribeFunc();
             };
         },
-        [drawerContent]
+        [drawerContent, props.workbench, setDrawerContent]
     );
 
     function ensureSettingsPanelIsVisible() {

--- a/frontend/src/framework/internal/components/SelectEnsemblesDialog/selectEnsemblesDialog.tsx
+++ b/frontend/src/framework/internal/components/SelectEnsemblesDialog/selectEnsemblesDialog.tsx
@@ -210,7 +210,7 @@ export const SelectEnsemblesDialog: React.FC<SelectEnsemblesDialogProps> = (prop
             id: el.uuid,
             values: [
                 { label: el.name },
-                { label: el.user, adornment: <UserAvatar userId={el.user} /> },
+                { label: el.user, adornment: <UserAvatar key={el.uuid} userId={el.user} /> },
                 { label: el.status },
             ],
         })) ?? [];

--- a/frontend/src/framework/internal/components/Settings/private-components/modulesList.tsx
+++ b/frontend/src/framework/internal/components/Settings/private-components/modulesList.tsx
@@ -53,6 +53,7 @@ const ModulesListItem: React.FC<ModulesListItemProps> = (props) => {
     const itemSize = useElementSize(ref);
 
     React.useEffect(() => {
+        const refCurrent = ref.current;
         let pointerDownPoint: Point | null = null;
         let dragging = false;
         let pointerDownElementPosition: Point | null = null;
@@ -116,13 +117,13 @@ const ModulesListItem: React.FC<ModulesListItemProps> = (props) => {
         }
 
         return () => {
-            if (ref.current) {
-                ref.current.removeEventListener("pointerdown", handlePointerDown);
+            if (refCurrent) {
+                refCurrent.removeEventListener("pointerdown", handlePointerDown);
             }
             document.removeEventListener("pointerup", handlePointerUp);
             document.removeEventListener("pointermove", handlePointerMove);
         };
-    }, [props.relContainer]);
+    }, [props.relContainer, props.guiMessageBroker, props.name]);
 
     return (
         <>

--- a/frontend/src/framework/internal/components/Settings/private-components/setting.tsx
+++ b/frontend/src/framework/internal/components/Settings/private-components/setting.tsx
@@ -36,7 +36,7 @@ export const Setting: React.FC<SettingProps> = (props) => {
         );
 
         return unsubscribeFunc;
-    }, []);
+    }, [props.moduleInstance]);
 
     if (importState !== ImportState.Imported || !props.moduleInstance.isInitialised()) {
         return null;

--- a/frontend/src/framework/internal/components/SettingsContentPanels/settingsContentPanels.tsx
+++ b/frontend/src/framework/internal/components/SettingsContentPanels/settingsContentPanels.tsx
@@ -17,10 +17,13 @@ export const SettingsContentPanels: React.FC<SettingsContentPanelsProps> = (prop
         GuiState.SettingsPanelWidthInPercent
     );
 
-    function handleSettingsPanelResize(sizes: number[]) {
-        setSettingsPanelWidth(sizes[0]);
-        localStorage.setItem("settingsPanelWidthInPercent", sizes[0].toString());
-    }
+    const handleSettingsPanelResize = React.useCallback(
+        function handleSettingsPanelResize(sizes: number[]) {
+            setSettingsPanelWidth(sizes[0]);
+            localStorage.setItem("settingsPanelWidthInPercent", sizes[0].toString());
+        },
+        [setSettingsPanelWidth]
+    );
 
     return (
         <ResizablePanels

--- a/frontend/src/framework/internal/hooks/workbenchHooks.ts
+++ b/frontend/src/framework/internal/hooks/workbenchHooks.ts
@@ -17,7 +17,7 @@ export function useModuleInstances(workbench: Workbench): ModuleInstance<any>[] 
         );
 
         return unsubscribeFunc;
-    }, []);
+    }, [workbench]);
 
     return moduleInstances;
 }

--- a/frontend/src/lib/components/Checkbox/checkbox.tsx
+++ b/frontend/src/lib/components/Checkbox/checkbox.tsx
@@ -14,6 +14,8 @@ export type CheckboxProps = {
 } & BaseComponentProps;
 
 export const Checkbox: React.FC<CheckboxProps> = (props) => {
+    const { onChange } = props;
+
     const [checked, setChecked] = React.useState<boolean>(props.checked ?? false);
     const id = React.useRef<string>(props.id ?? `checkbox-${v4()}`);
 
@@ -24,9 +26,9 @@ export const Checkbox: React.FC<CheckboxProps> = (props) => {
     const handleChange = React.useCallback(
         (event: React.ChangeEvent<HTMLInputElement>) => {
             setChecked(event.target.checked);
-            props.onChange && props.onChange(event, event.target.checked);
+            onChange && onChange(event, event.target.checked);
         },
-        [setChecked, props.onChange]
+        [setChecked, onChange]
     );
 
     return (

--- a/frontend/src/lib/components/Dropdown/dropdown.tsx
+++ b/frontend/src/lib/components/Dropdown/dropdown.tsx
@@ -49,6 +49,8 @@ const noMatchingOptionsText = "No matching options";
 const noOptionsText = "No options";
 
 export const Dropdown = withDefaults<DropdownProps>()(defaultProps, (props) => {
+    const { onChange } = props;
+
     const [dropdownVisible, setDropdownVisible] = React.useState<boolean>(false);
     const [dropdownRect, setDropdownRect] = React.useState<DropdownRect>({
         width: 0,
@@ -166,7 +168,15 @@ export const Dropdown = withDefaults<DropdownProps>()(defaultProps, (props) => {
                 setOptionIndexWithFocusToCurrentSelection();
             }
         }
-    }, [inputBoundingRect, dropdownVisible, filteredOptions, selection]);
+    }, [
+        inputBoundingRect,
+        dropdownVisible,
+        filteredOptions,
+        selection,
+        dropdownRect.width,
+        props.options,
+        setOptionIndexWithFocusToCurrentSelection,
+    ]);
 
     const handleOptionClick = React.useCallback(
         (value: string) => {
@@ -175,12 +185,21 @@ export const Dropdown = withDefaults<DropdownProps>()(defaultProps, (props) => {
             setDropdownVisible(false);
             setFilter(null);
             setFilteredOptions(props.options);
-            if (props.onChange) {
-                props.onChange(value);
+            if (onChange) {
+                onChange(value);
             }
             setOptionIndexWithFocus(-1);
         },
-        [props.onChange, selection, props.options]
+        [
+            onChange,
+            props.options,
+            setOptionIndexWithFocus,
+            setSelectionIndex,
+            setDropdownVisible,
+            setFilter,
+            setFilteredOptions,
+            setSelection,
+        ]
     );
 
     React.useEffect(() => {

--- a/frontend/src/lib/components/ResizablePanels/resizablePanels.tsx
+++ b/frontend/src/lib/components/ResizablePanels/resizablePanels.tsx
@@ -29,6 +29,8 @@ function storeConfigurationInLocalStorage(id: string, sizes: number[]) {
 }
 
 export const ResizablePanels: React.FC<ResizablePanelsProps> = (props) => {
+    const { onSizesChange } = props;
+
     if (props.minSizes && props.minSizes.length !== props.children.length) {
         throw new Error("minSizes must have the same length as children");
     }
@@ -123,11 +125,11 @@ export const ResizablePanels: React.FC<ResizablePanelsProps> = (props) => {
             if (!dragging) {
                 return;
             }
-            storeConfigurationInLocalStorage(props.id, sizes);
+            storeConfigurationInLocalStorage(props.id, changedSizes);
             dragging = false;
             setIsDragging(false);
-            if (props.onSizesChange) {
-                props.onSizesChange(changedSizes);
+            if (onSizesChange) {
+                onSizesChange(changedSizes);
             }
             document.body.classList.remove("touch-none");
         }
@@ -143,7 +145,7 @@ export const ResizablePanels: React.FC<ResizablePanelsProps> = (props) => {
             document.removeEventListener("pointerup", handlePointerUp);
             document.removeEventListener("blur", handlePointerUp);
         };
-    }, [props.direction, props.id, props.onSizesChange]);
+    }, [props.direction, props.id, onSizesChange]);
 
     const minSizesToggleVisibilityValue = 100 * (props.direction === "horizontal" ? 50 / totalWidth : 50 / totalHeight);
 

--- a/frontend/src/lib/components/Select/select.tsx
+++ b/frontend/src/lib/components/Select/select.tsx
@@ -39,6 +39,8 @@ const defaultProps = {
 const noMatchingOptionsText = "No matching options";
 
 export const Select = withDefaults<SelectProps>()(defaultProps, (props) => {
+    const { onChange } = props;
+
     const [filter, setFilter] = React.useState<string>("");
     const [hasFocus, setHasFocus] = React.useState<boolean>(false);
     const [selected, setSelected] = React.useState<string[]>([]);
@@ -55,7 +57,7 @@ export const Select = withDefaults<SelectProps>()(defaultProps, (props) => {
             return props.options;
         }
         return props.options.filter((option) => option.label.toLowerCase().includes(filter.toLowerCase()));
-    }, [props.options, filter]);
+    }, [props.options, filter, props.filter]);
 
     if (!isEqual(filteredOptions, prevFilteredOptions)) {
         let newCurrentIndex = 0;
@@ -105,17 +107,17 @@ export const Select = withDefaults<SelectProps>()(defaultProps, (props) => {
             }
             setCurrentIndex(index);
             setSelected(newSelected);
-            if (props.onChange) {
+            if (onChange) {
                 if (props.multiple) {
-                    props.onChange(newSelected);
+                    onChange(newSelected);
                 } else if (!option.disabled) {
-                    props.onChange([option.value]);
+                    onChange([option.value]);
                 } else {
-                    props.onChange([]);
+                    onChange([]);
                 }
             }
         },
-        [props.multiple, props.options, selected, props.onChange, keysPressed, lastShiftIndex]
+        [props.multiple, props.options, selected, onChange, keysPressed, lastShiftIndex, setCurrentIndex, setSelected]
     );
 
     React.useEffect(() => {

--- a/frontend/src/lib/components/Slider/slider.tsx
+++ b/frontend/src/lib/components/Slider/slider.tsx
@@ -33,6 +33,7 @@ export const Slider = React.forwardRef((props: SliderProps, ref: React.Forwarded
     }
 
     React.useEffect(function handleMount() {
+        const divRefCurrent = divRef.current;
         let pointerPressed = false;
         let hovered = false;
 
@@ -110,17 +111,17 @@ export const Slider = React.forwardRef((props: SliderProps, ref: React.Forwarded
             setValueLabelVisible(false);
         };
 
-        if (divRef.current) {
-            divRef.current.addEventListener("pointerover", handlePointerOver);
-            divRef.current.addEventListener("pointerout", handlePointerOut);
-            divRef.current.addEventListener("pointerdown", handlePointerDown);
+        if (divRefCurrent) {
+            divRefCurrent.addEventListener("pointerover", handlePointerOver);
+            divRefCurrent.addEventListener("pointerout", handlePointerOut);
+            divRefCurrent.addEventListener("pointerdown", handlePointerDown);
             document.addEventListener("pointerup", handlePointerUp);
         }
         return () => {
-            if (divRef.current) {
-                divRef.current.removeEventListener("pointerover", handlePointerOver);
-                divRef.current.removeEventListener("pointerout", handlePointerOut);
-                divRef.current.removeEventListener("pointerdown", handlePointerDown);
+            if (divRefCurrent) {
+                divRefCurrent.removeEventListener("pointerover", handlePointerOver);
+                divRefCurrent.removeEventListener("pointerout", handlePointerOut);
+                divRefCurrent.removeEventListener("pointerdown", handlePointerDown);
                 document.removeEventListener("pointerup", handlePointerUp);
             }
         };

--- a/frontend/src/lib/components/Table/table.tsx
+++ b/frontend/src/lib/components/Table/table.tsx
@@ -110,7 +110,7 @@ export const Table: React.FC<TableProps<TableHeading>> = (props) => {
 
     React.useEffect(() => {
         setFilteredData(filterData(preprocessedData, filterValues, props.headings));
-    }, [preprocessedData, filterValues]);
+    }, [preprocessedData, filterValues, props.headings]);
 
     React.useEffect(() => {
         setFilteredData((prev) => sortData(prev, sortColumnAndDirection.col, sortColumnAndDirection.dir));
@@ -129,25 +129,25 @@ export const Table: React.FC<TableProps<TableHeading>> = (props) => {
         }
     }, [props.headings, props.data]);
 
-    const handlePointerOver = (row: TableRow<any>) => {
+    function handlePointerOver(row: TableRow<any>) {
         if (props.onHover) {
             props.onHover(row);
         }
-    };
+    }
 
-    const handlePointerDown = (row: TableRow<any>) => {
+    function handlePointerDown(row: TableRow<any>) {
         if (props.onClick) {
             props.onClick(row);
         }
-    };
+    }
 
-    const handleFilterChange = (col: string, value: string) => {
+    function handleFilterChange(col: string, value: string) {
         setFilterValues({ ...filterValues, [col]: value });
-    };
+    }
 
-    const handleSortDirectionChange = (col: string, dir: SortDirection) => {
+    function handleSortDirectionChange(col: string, dir: SortDirection) {
         setSortColumnAndDirection({ col, dir });
-    };
+    }
 
     if (layoutError.error) {
         return <div>{layoutError.message}</div>;

--- a/frontend/src/lib/components/TableSelect/tableSelect.tsx
+++ b/frontend/src/lib/components/TableSelect/tableSelect.tsx
@@ -2,7 +2,7 @@ import React, { Key } from "react";
 
 import { resolveClassNames } from "@lib/utils/resolveClassNames";
 
-import { differenceWith, isEqual } from "lodash";
+import { isEqual } from "lodash";
 
 import { BaseComponent, BaseComponentProps } from "../BaseComponent";
 import { Input } from "../Input";

--- a/frontend/src/lib/components/TableSelect/tableSelect.tsx
+++ b/frontend/src/lib/components/TableSelect/tableSelect.tsx
@@ -2,7 +2,7 @@ import React, { Key } from "react";
 
 import { resolveClassNames } from "@lib/utils/resolveClassNames";
 
-import { isEqual } from "lodash";
+import { differenceWith, isEqual } from "lodash";
 
 import { BaseComponent, BaseComponentProps } from "../BaseComponent";
 import { Input } from "../Input";
@@ -37,9 +37,24 @@ const defaultProps = {
     multiple: false,
 };
 
+function checkForEqualityWithoutAdornment(a: TableSelectOption[], b: TableSelectOption[]) {
+    return isEqual(
+        a.map((option) => ({
+            ...option,
+            values: option.values.map((value) => value.label),
+        })),
+        b.map((option) => ({
+            ...option,
+            values: option.values.map((value) => value.label),
+        }))
+    );
+}
+
 const noMatchingOptionsText = "No matching options";
 
 export const TableSelect = withDefaults<TableSelectProps>()(defaultProps, (props) => {
+    const { onChange } = props;
+
     const [prevHeaderLabels, setPrevHeaderLabels] = React.useState<string[]>(props.headerLabels);
     const [filters, setFilters] = React.useState<string[]>(props.headerLabels.map(() => ""));
     const [hasFocus, setHasFocus] = React.useState<boolean>(false);
@@ -48,6 +63,7 @@ export const TableSelect = withDefaults<TableSelectProps>()(defaultProps, (props
     const [startIndex, setStartIndex] = React.useState<number>(0);
     const [lastShiftIndex, setLastShiftIndex] = React.useState<number>(-1);
     const [currentIndex, setCurrentIndex] = React.useState<number>(0);
+    const [prevFilteredOptions, setPrevFilteredOptions] = React.useState<TableSelectOption[]>([]);
 
     if (!isEqual(prevHeaderLabels, props.headerLabels)) {
         setPrevHeaderLabels(props.headerLabels);
@@ -62,19 +78,41 @@ export const TableSelect = withDefaults<TableSelectProps>()(defaultProps, (props
 
     const ref = React.useRef<HTMLDivElement>(null);
     const noOptionsText = props.placeholder ?? "No options";
-    const filteredOptions = React.useMemo(() => {
-        if (!props.filter) {
-            return props.options;
-        }
-        return props.options.filter((option) => {
-            return option.values.every((value, index) => {
-                return value.label.toLowerCase().includes(filters[index].toLowerCase());
+    const filteredOptions = React.useMemo(
+        function filterOptions() {
+            if (!props.filter) {
+                return props.options;
+            }
+            return props.options.filter((option) => {
+                return option.values.every((value, index) => {
+                    return value.label.toLowerCase().includes(filters[index].toLowerCase());
+                });
             });
-        });
-    }, [props.options, filters]);
+        },
+        [props.options, filters, props.filter]
+    );
+
+    if (!checkForEqualityWithoutAdornment(filteredOptions, prevFilteredOptions)) {
+        let newCurrentIndex = 0;
+        let newStartIndex = 0;
+        let oldCurrentId = prevFilteredOptions[currentIndex]?.id;
+        if (props.value?.length >= 1) {
+            oldCurrentId = props.value[0];
+        }
+        setPrevFilteredOptions(filteredOptions);
+        if (oldCurrentId) {
+            const newIndex = filteredOptions.findIndex((option) => option.id === oldCurrentId);
+            if (newIndex !== -1) {
+                newCurrentIndex = newIndex;
+                newStartIndex = newIndex;
+            }
+        }
+        setCurrentIndex(newCurrentIndex);
+        setStartIndex(newStartIndex);
+    }
 
     const toggleValue = React.useCallback(
-        (option: TableSelectOption, index: number) => {
+        function toggleValue(option: TableSelectOption, index: number) {
             let newSelected = [...selected];
             if (props.multiple) {
                 if (keysPressed.includes("Shift")) {
@@ -102,82 +140,88 @@ export const TableSelect = withDefaults<TableSelectProps>()(defaultProps, (props
             }
             setCurrentIndex(index);
             setSelected(newSelected);
-            if (props.onChange) {
+            if (onChange) {
                 if (props.multiple) {
-                    props.onChange(newSelected);
+                    onChange(newSelected);
                 } else if (!option.disabled) {
-                    props.onChange([option.id]);
+                    onChange([option.id]);
                 } else {
-                    props.onChange([]);
+                    onChange([]);
                 }
             }
         },
-        [props.multiple, props.options, selected, props.onChange, keysPressed, lastShiftIndex]
+        [props.multiple, props.options, selected, onChange, keysPressed, lastShiftIndex]
     );
 
-    React.useEffect(() => {
-        const handleKeyDown = (e: KeyboardEvent) => {
-            setKeysPressed((keysPressed) => [...keysPressed, e.key]);
+    React.useEffect(
+        function handleKeyActions() {
+            const handleKeyDown = (e: KeyboardEvent) => {
+                setKeysPressed((keysPressed) => [...keysPressed, e.key]);
 
-            if (hasFocus) {
-                if (e.key === "Shift") {
-                    setLastShiftIndex(currentIndex);
-                }
-                if (e.key === "ArrowUp") {
-                    e.preventDefault();
-                    const newIndex = Math.max(0, currentIndex - 1);
-                    toggleValue(filteredOptions[newIndex], newIndex);
-                    if (newIndex < startIndex) {
-                        setStartIndex(newIndex);
+                if (hasFocus) {
+                    if (e.key === "Shift") {
+                        setLastShiftIndex(currentIndex);
+                    }
+                    if (e.key === "ArrowUp") {
+                        e.preventDefault();
+                        const newIndex = Math.max(0, currentIndex - 1);
+                        toggleValue(filteredOptions[newIndex], newIndex);
+                        if (newIndex < startIndex) {
+                            setStartIndex(newIndex);
+                        }
+                    }
+                    if (e.key === "ArrowDown") {
+                        e.preventDefault();
+                        const newIndex = Math.min(filteredOptions.length - 1, currentIndex + 1);
+                        toggleValue(filteredOptions[newIndex], newIndex);
+                        if (newIndex >= startIndex + props.size - 1) {
+                            setStartIndex(Math.max(0, newIndex - props.size + 1));
+                        }
+                    }
+                    if (e.key === "PageUp") {
+                        e.preventDefault();
+                        const newIndex = Math.max(0, currentIndex - props.size);
+                        toggleValue(filteredOptions[newIndex], newIndex);
+                        if (newIndex < startIndex) {
+                            setStartIndex(newIndex);
+                        }
+                    }
+                    if (e.key === "PageDown") {
+                        e.preventDefault();
+                        const newIndex = Math.min(filteredOptions.length - 1, currentIndex + props.size);
+                        toggleValue(filteredOptions[newIndex], newIndex);
+                        if (newIndex >= startIndex + props.size - 1) {
+                            setStartIndex(Math.max(0, newIndex - props.size + 1));
+                        }
                     }
                 }
-                if (e.key === "ArrowDown") {
-                    e.preventDefault();
-                    const newIndex = Math.min(filteredOptions.length - 1, currentIndex + 1);
-                    toggleValue(filteredOptions[newIndex], newIndex);
-                    if (newIndex >= startIndex + props.size - 1) {
-                        setStartIndex(Math.max(0, newIndex - props.size + 1));
-                    }
-                }
-                if (e.key === "PageUp") {
-                    e.preventDefault();
-                    const newIndex = Math.max(0, currentIndex - props.size);
-                    toggleValue(filteredOptions[newIndex], newIndex);
-                    if (newIndex < startIndex) {
-                        setStartIndex(newIndex);
-                    }
-                }
-                if (e.key === "PageDown") {
-                    e.preventDefault();
-                    const newIndex = Math.min(filteredOptions.length - 1, currentIndex + props.size);
-                    toggleValue(filteredOptions[newIndex], newIndex);
-                    if (newIndex >= startIndex + props.size - 1) {
-                        setStartIndex(Math.max(0, newIndex - props.size + 1));
-                    }
-                }
+            };
+
+            const handleKeyUp = (e: KeyboardEvent) => {
+                setKeysPressed((keysPressed) => keysPressed.filter((key) => key !== e.key));
+            };
+
+            window.addEventListener("keydown", handleKeyDown);
+            window.addEventListener("keyup", handleKeyUp);
+
+            return () => {
+                window.removeEventListener("keydown", handleKeyDown);
+                window.removeEventListener("keyup", handleKeyUp);
+            };
+        },
+        [currentIndex, selected, filteredOptions, props.size, hasFocus, startIndex, toggleValue]
+    );
+
+    React.useLayoutEffect(
+        function handleInitialSelection() {
+            if (props.value) {
+                setSelected(props.value);
             }
-        };
+        },
+        [props.value]
+    );
 
-        const handleKeyUp = (e: KeyboardEvent) => {
-            setKeysPressed((keysPressed) => keysPressed.filter((key) => key !== e.key));
-        };
-
-        window.addEventListener("keydown", handleKeyDown);
-        window.addEventListener("keyup", handleKeyUp);
-
-        return () => {
-            window.removeEventListener("keydown", handleKeyDown);
-            window.removeEventListener("keyup", handleKeyUp);
-        };
-    }, [currentIndex, selected, filteredOptions, props.size, hasFocus, startIndex, toggleValue]);
-
-    React.useLayoutEffect(() => {
-        if (props.value) {
-            setSelected(props.value);
-        }
-    }, [props.value]);
-
-    const handleFilterChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>, index: number) => {
+    function handleFilterChange(e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>, index: number) {
         setFilters((prev) => {
             const newFilters = [...prev];
             prev[index] = e.target.value;
@@ -186,7 +230,7 @@ export const TableSelect = withDefaults<TableSelectProps>()(defaultProps, (props
         if (ref.current) {
             ref.current.scrollTop = 0;
         }
-    };
+    }
 
     return (
         <BaseComponent disabled={props.disabled}>

--- a/frontend/src/lib/components/ToggleButton/toggleButton.tsx
+++ b/frontend/src/lib/components/ToggleButton/toggleButton.tsx
@@ -16,7 +16,7 @@ export const ToggleButton = React.forwardRef((props: ToggleButtonProps, ref: Rea
     const handleClick = React.useCallback(() => {
         setIsActive(!isActive);
         onToggle(!active);
-    }, [active, onToggle]);
+    }, [active, onToggle, isActive]);
 
     return (
         <BaseComponent disabled={props.disabled}>

--- a/frontend/src/lib/components/Virtualization/virtualization.tsx
+++ b/frontend/src/lib/components/Virtualization/virtualization.tsx
@@ -22,19 +22,10 @@ const defaultProps = {
 type VirtualizationPropsSubset = Pick<VirtualizationProps, "items" | "startIndex" | "direction" | "itemSize"> | null;
 
 function checkEqualityOfProps(a: VirtualizationPropsSubset, b: VirtualizationPropsSubset): boolean {
-    if (a === null && b !== null) {
-        return false;
-    }
-
-    if (a !== null && b === null) {
-        return false;
-    }
-
     if (a === null && b === null) {
         return true;
     }
 
-    // This seems to be an unnecessary check?
     if (a === null || b === null) {
         return false;
     }

--- a/frontend/src/lib/components/Virtualization/virtualization.tsx
+++ b/frontend/src/lib/components/Virtualization/virtualization.tsx
@@ -2,8 +2,6 @@ import React from "react";
 
 import { useElementSize } from "@lib/hooks/useElementSize";
 
-import { isEqual } from "lodash";
-
 import { withDefaults } from "../_component-utils/components";
 
 export type VirtualizationProps<T = any> = {
@@ -21,12 +19,37 @@ const defaultProps = {
     startIndex: 0,
 };
 
+type VirtualizationPropsSubset = Pick<VirtualizationProps, "items" | "startIndex" | "direction" | "itemSize"> | null;
+
+function checkEqualityOfProps(a: VirtualizationPropsSubset, b: VirtualizationPropsSubset): boolean {
+    if (a === null && b !== null) {
+        return false;
+    }
+
+    if (a !== null && b === null) {
+        return false;
+    }
+
+    if (a === null && b === null) {
+        return true;
+    }
+
+    // This seems to be an unnecessary check?
+    if (a === null || b === null) {
+        return false;
+    }
+
+    return (
+        a.itemSize === b.itemSize &&
+        a.direction === b.direction &&
+        a.startIndex === b.startIndex &&
+        a.items.length === b.items.length
+    );
+}
+
 export const Virtualization = withDefaults<VirtualizationProps>()(defaultProps, (props) => {
     const [range, setRange] = React.useState<{ start: number; end: number }>({ start: props.startIndex, end: 0 });
-    const [prevPropsSubset, setPrevPropsSubset] = React.useState<Pick<
-        VirtualizationProps,
-        "items" | "startIndex" | "direction" | "itemSize"
-    > | null>(null);
+    const [prevPropsSubset, setPrevPropsSubset] = React.useState<VirtualizationPropsSubset>(null);
     const [placeholderSizes, setPlaceholderSizes] = React.useState<{ start: number; end: number }>({
         start: props.startIndex * props.itemSize,
         end: 0,
@@ -48,7 +71,7 @@ export const Virtualization = withDefaults<VirtualizationProps>()(defaultProps, 
         itemSize: props.itemSize,
     };
 
-    if (!isEqual(prevPropsSubset, currentPropsSubset)) {
+    if (!checkEqualityOfProps(prevPropsSubset, currentPropsSubset)) {
         if (props.containerRef.current) {
             const newInitialScrollPositions = {
                 top: props.startIndex * props.itemSize,

--- a/frontend/src/modules/DistributionPlot/loadModule.tsx
+++ b/frontend/src/modules/DistributionPlot/loadModule.tsx
@@ -1,8 +1,8 @@
 import { ModuleRegistry } from "@framework/ModuleRegistry";
 
-import { settings } from "./settings";
+import { Settings } from "./settings";
 import { PlotType, State } from "./state";
-import { view } from "./view";
+import { View } from "./view";
 
 const defaultState: State = {
     plotType: PlotType.Histogram,
@@ -12,5 +12,5 @@ const defaultState: State = {
 
 const module = ModuleRegistry.initModule<State>("DistributionPlot", defaultState);
 
-module.viewFC = view;
-module.settingsFC = settings;
+module.viewFC = View;
+module.settingsFC = Settings;

--- a/frontend/src/modules/DistributionPlot/settings.tsx
+++ b/frontend/src/modules/DistributionPlot/settings.tsx
@@ -1,7 +1,7 @@
 import React, { ChangeEvent } from "react";
 
 import { BroadcastChannelKeyCategory } from "@framework/Broadcaster";
-import { applyInitialSettingsToState } from "@framework/InitialSettings";
+import { useApplyInitialSettingsToState } from "@framework/InitialSettings";
 import { ModuleFCProps } from "@framework/Module";
 import { ChannelSelect } from "@framework/components/ChannelSelect";
 import { Dropdown } from "@lib/components/Dropdown";
@@ -64,10 +64,10 @@ export function settings({ moduleContext, workbenchServices, initialSettings }: 
     const [orientation, setOrientation] = moduleContext.useStoreState("orientation");
     const [crossPlottingType, setCrossPlottingType] = React.useState<BroadcastChannelKeyCategory | null>(null);
 
-    applyInitialSettingsToState(initialSettings, "plotType", "string", setPlotType);
-    applyInitialSettingsToState(initialSettings, "numBins", "number", setNumBins);
-    applyInitialSettingsToState(initialSettings, "orientation", "string", setOrientation);
-    applyInitialSettingsToState(initialSettings, "crossPlottingType", "string", setCrossPlottingType);
+    useApplyInitialSettingsToState(initialSettings, "plotType", "string", setPlotType);
+    useApplyInitialSettingsToState(initialSettings, "numBins", "number", setNumBins);
+    useApplyInitialSettingsToState(initialSettings, "orientation", "string", setOrientation);
+    useApplyInitialSettingsToState(initialSettings, "crossPlottingType", "string", setCrossPlottingType);
 
     const channelX = moduleContext.useInputChannel("channelX", initialSettings);
     const channelY = moduleContext.useInputChannel("channelY", initialSettings);

--- a/frontend/src/modules/DistributionPlot/settings.tsx
+++ b/frontend/src/modules/DistributionPlot/settings.tsx
@@ -54,7 +54,7 @@ const crossPlottingTypes = [
 ];
 
 //-----------------------------------------------------------------------------------------------------------
-export function settings({ moduleContext, workbenchServices, initialSettings }: ModuleFCProps<State>) {
+export function Settings({ moduleContext, workbenchServices, initialSettings }: ModuleFCProps<State>) {
     const [prevChannelXName, setPrevChannelXName] = React.useState<string | null>(null);
     const [prevChannelYName, setPrevChannelYName] = React.useState<string | null>(null);
     const [prevChannelColorName, setPrevChannelColorName] = React.useState<string | null>(null);

--- a/frontend/src/modules/DistributionPlot/view.tsx
+++ b/frontend/src/modules/DistributionPlot/view.tsx
@@ -32,7 +32,7 @@ function nFormatter(num: number, digits: number): string {
     return item ? (num / item.value).toFixed(digits).replace(rx, "$1") + item.symbol : "0";
 }
 
-export const view = ({
+export const View = ({
     moduleContext,
     workbenchServices,
     initialSettings,
@@ -86,10 +86,6 @@ export const view = ({
             return;
         }
 
-        if (plotType !== PlotType.ScatterWithColorMapping && plotType !== PlotType.Scatter) {
-            setPlotType(PlotType.Scatter);
-        }
-
         const handleChannelYChanged = (data: any | null, metaData: BroadcastChannelMeta | null) => {
             setDataY(data);
             setMetaDataY(metaData);
@@ -105,10 +101,6 @@ export const view = ({
             setDataColor(null);
             setMetaDataColor(null);
             return;
-        }
-
-        if (plotType !== PlotType.ScatterWithColorMapping) {
-            setPlotType(PlotType.ScatterWithColorMapping);
         }
 
         const handleChannelColorChanged = (data: any | null, metaData: BroadcastChannelMeta | null) => {

--- a/frontend/src/modules/DistributionPlot/view.tsx
+++ b/frontend/src/modules/DistributionPlot/view.tsx
@@ -38,7 +38,7 @@ export const View = ({
     initialSettings,
     workbenchSettings,
 }: ModuleFCProps<State>) => {
-    const [plotType, setPlotType] = moduleContext.useStoreState("plotType");
+    const plotType = moduleContext.useStoreValue("plotType");
     const numBins = moduleContext.useStoreValue("numBins");
     const orientation = moduleContext.useStoreValue("orientation");
 

--- a/frontend/src/modules/Grid3D/loadModule.tsx
+++ b/frontend/src/modules/Grid3D/loadModule.tsx
@@ -1,8 +1,8 @@
 import { ModuleRegistry } from "@framework/ModuleRegistry";
 
-import { settings } from "./settings";
+import { Settings } from "./settings";
 import state from "./state";
-import { view } from "./view";
+import { View } from "./view";
 
 const defaultState: state = {
     gridName: "Simgrid",
@@ -14,5 +14,5 @@ const defaultState: state = {
 
 const module = ModuleRegistry.initModule<state>("Grid3D", defaultState, {});
 
-module.viewFC = view;
-module.settingsFC = settings;
+module.viewFC = View;
+module.settingsFC = Settings;

--- a/frontend/src/modules/Grid3D/settings.tsx
+++ b/frontend/src/modules/Grid3D/settings.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React from "react";
 
 import { EnsembleIdent } from "@framework/EnsembleIdent";
 import { ModuleFCProps } from "@framework/Module";
@@ -18,7 +18,7 @@ import { useGridModelNames, useGridParameterNames } from "./queryHooks";
 import state from "./state";
 
 //-----------------------------------------------------------------------------------------------------------
-export function settings({ moduleContext, workbenchServices, workbenchSession }: ModuleFCProps<state>) {
+export function Settings({ moduleContext, workbenchServices, workbenchSession }: ModuleFCProps<state>) {
     // From Workbench
 
     const ensembleSet = useEnsembleSet(workbenchSession);
@@ -46,7 +46,7 @@ export function settings({ moduleContext, workbenchServices, workbenchSession }:
     const parameterNamesQuery = useGridParameterNames(firstCaseUuid, firstEnsembleName, gridName);
     const wellHeadersQuery = useWellHeadersQuery(computedEnsembleIdent?.getCaseUuid());
     // Handle Linked query
-    useEffect(() => {
+    React.useEffect(() => {
         if (parameterNamesQuery.data) {
             if (gridName && parameterNamesQuery.data.find((name) => name === parameterName)) {
                 // New grid has same parameter
@@ -55,7 +55,7 @@ export function settings({ moduleContext, workbenchServices, workbenchSession }:
                 setParameterName(parameterNamesQuery.data[0]);
             }
         }
-    }, [parameterNamesQuery.data, parameterName]);
+    }, [parameterNamesQuery.data, parameterName, gridName, setParameterName]);
 
     const parameterNames = parameterNamesQuery.data ? parameterNamesQuery.data : [];
     const allRealizations = computedEnsembleIdent

--- a/frontend/src/modules/Grid3D/view.tsx
+++ b/frontend/src/modules/Grid3D/view.tsx
@@ -17,7 +17,7 @@ import { useGridParameter, useGridSurface, useStatisticalGridParameter } from ".
 import state from "./state";
 
 //-----------------------------------------------------------------------------------------------------------
-export function view({ moduleContext, workbenchSettings, workbenchSession }: ModuleFCProps<state>) {
+export function View({ moduleContext, workbenchSettings, workbenchSession }: ModuleFCProps<state>) {
     const myInstanceIdStr = moduleContext.getInstanceIdString();
     const viewIds = {
         view: `${myInstanceIdStr}--view`,

--- a/frontend/src/modules/Grid3DIntersection/loadModule.tsx
+++ b/frontend/src/modules/Grid3DIntersection/loadModule.tsx
@@ -1,20 +1,17 @@
 import { ModuleRegistry } from "@framework/ModuleRegistry";
 
-import { settings } from "./settings";
+import { Settings } from "./settings";
 import state from "./state";
-import { view } from "./view";
+import { View } from "./view";
 
 const defaultState: state = {
     gridName: "Simgrid",
     parameterName: "PORO",
     realizations: ["1"],
     useStatistics: false,
-
 };
 
-const module = ModuleRegistry.initModule<state>("Grid3DIntersection", defaultState, {
+const module = ModuleRegistry.initModule<state>("Grid3DIntersection", defaultState, {});
 
-});
-
-module.viewFC = view;
-module.settingsFC = settings;
+module.viewFC = View;
+module.settingsFC = Settings;

--- a/frontend/src/modules/Grid3DIntersection/settings.tsx
+++ b/frontend/src/modules/Grid3DIntersection/settings.tsx
@@ -1,17 +1,18 @@
-import React, { useEffect } from "react";
+import React from "react";
 
 import { ModuleFCProps } from "@framework/Module";
 import { useFirstEnsembleInEnsembleSet } from "@framework/WorkbenchSession";
 import { ApiStateWrapper } from "@lib/components/ApiStateWrapper";
-import { useGridModelNames, useGridParameterNames } from "./queryHooks";
-import { CircularProgress } from "@lib/components/CircularProgress";
 import { Checkbox } from "@lib/components/Checkbox";
+import { CircularProgress } from "@lib/components/CircularProgress";
 import { Label } from "@lib/components/Label";
 import { Select, SelectOption } from "@lib/components/Select";
 
+import { useGridModelNames, useGridParameterNames } from "./queryHooks";
 import state from "./state";
+
 //-----------------------------------------------------------------------------------------------------------
-export function settings({ moduleContext, workbenchSession }: ModuleFCProps<state>) {
+export function Settings({ moduleContext, workbenchSession }: ModuleFCProps<state>) {
     // From Workbench
     const firstEnsemble = useFirstEnsembleInEnsembleSet(workbenchSession);
 
@@ -26,25 +27,28 @@ export function settings({ moduleContext, workbenchSession }: ModuleFCProps<stat
     const firstEnsembleName = firstEnsemble?.getEnsembleName() ?? null;
     const gridNamesQuery = useGridModelNames(firstCaseUuid, firstEnsembleName);
     const parameterNamesQuery = useGridParameterNames(firstCaseUuid, firstEnsembleName, gridName);
- 
+
     // Handle Linked query
-    useEffect(() => {
+    React.useEffect(() => {
         if (parameterNamesQuery.data) {
-            if (gridName && parameterNamesQuery.data.find(name => name === parameterName)) {
+            if (gridName && parameterNamesQuery.data.find((name) => name === parameterName)) {
                 // New grid has same parameter
             } else {
                 // New grid has different parameter. Set to first
-                setParameterName(parameterNamesQuery.data[0])
+                setParameterName(parameterNamesQuery.data[0]);
             }
         }
-    }, [parameterNamesQuery.data, parameterName])
+    }, [parameterNamesQuery.data, parameterName, gridName, setParameterName]);
 
     // If no grid names, stop here
-    if (!gridNamesQuery.data) { return (<div>Select case: upscaled_grids_realistic_no_unc</div>) }
+    if (!gridNamesQuery.data) {
+        return <div>Select case: upscaled_grids_realistic_no_unc</div>;
+    }
 
-    const parameterNames = parameterNamesQuery.data ? parameterNamesQuery.data : []
-    const allRealizations: string[] = firstEnsemble ? firstEnsemble.getRealizations().map(real => JSON.stringify(real)) : []
-
+    const parameterNames = parameterNamesQuery.data ? parameterNamesQuery.data : [];
+    const allRealizations: string[] = firstEnsemble
+        ? firstEnsemble.getRealizations().map((real) => JSON.stringify(real))
+        : [];
 
     return (
         <div>
@@ -53,9 +57,7 @@ export function settings({ moduleContext, workbenchSession }: ModuleFCProps<stat
                 errorComponent={"Error loading vector names"}
                 loadingComponent={<CircularProgress />}
             >
-                <Label
-                    text="Grid model"
-                >
+                <Label text="Grid model">
                     <Select
                         options={stringToOptions(gridNamesQuery.data)}
                         value={[gridName || gridNamesQuery.data[0]]}
@@ -65,24 +67,19 @@ export function settings({ moduleContext, workbenchSession }: ModuleFCProps<stat
                     />
                 </Label>
 
-                <Label
-                    text="Grid parameter"
-                >
+                <Label text="Grid parameter">
                     <Select
                         options={stringToOptions(parameterNames || [])}
                         value={[parameterName || parameterNames[0]]}
                         onChange={(pnames) => setParameterName(pnames[0])}
                         filter={true}
                         size={5}
-
                     />
                 </Label>
 
-                <Label
-                    text="Realizations"
-                >
+                <Label text="Realizations">
                     <Select
-                        options={stringToOptions(allRealizations as any || [])}
+                        options={stringToOptions((allRealizations as any) || [])}
                         value={realizations ? realizations : [allRealizations[0]]}
                         onChange={(reals) => setRealizations(reals)}
                         filter={true}
@@ -90,9 +87,12 @@ export function settings({ moduleContext, workbenchSession }: ModuleFCProps<stat
                         multiple={useStatistics}
                     />
                 </Label>
-                <Checkbox label="Show mean parameter" checked={useStatistics} onChange={(event: React.ChangeEvent<HTMLInputElement>) => setUseStatistics(event.target.checked)} />
+                <Checkbox
+                    label="Show mean parameter"
+                    checked={useStatistics}
+                    onChange={(event: React.ChangeEvent<HTMLInputElement>) => setUseStatistics(event.target.checked)}
+                />
                 {"(Select multiple realizations)"}
-
             </ApiStateWrapper>
         </div>
     );
@@ -100,4 +100,4 @@ export function settings({ moduleContext, workbenchSession }: ModuleFCProps<stat
 
 const stringToOptions = (strings: string[]): SelectOption[] => {
     return strings.map((string) => ({ label: string, value: string }));
-}
+};

--- a/frontend/src/modules/Grid3DIntersection/view.tsx
+++ b/frontend/src/modules/Grid3DIntersection/view.tsx
@@ -1,16 +1,15 @@
 import React from "react";
 
 import { ModuleFCProps } from "@framework/Module";
-import { useElementSize } from "@lib/hooks/useElementSize";
 import { useFirstEnsembleInEnsembleSet } from "@framework/WorkbenchSession";
+import { useElementSize } from "@lib/hooks/useElementSize";
 
+import PlotlyGridIntersection from "./plotlyGridIntersection";
 import { useGridIntersection, useStatisticalGridIntersection } from "./queryHooks";
 import state from "./state";
-import PlotlyGridIntersection from "./plotlyGridIntersection";
-
 
 //-----------------------------------------------------------------------------------------------------------
-export function view({ moduleContext, workbenchSession }: ModuleFCProps<state>) {
+export function View({ moduleContext, workbenchSession }: ModuleFCProps<state>) {
     // Viewport size
     const wrapperDivRef = React.useRef<HTMLDivElement>(null);
     const wrapperDivSize = useElementSize(wrapperDivRef);
@@ -27,25 +26,42 @@ export function view({ moduleContext, workbenchSession }: ModuleFCProps<state>) 
     // Queries
     const firstCaseUuid = firstEnsemble?.getCaseUuid() ?? null;
     const firstEnsembleName = firstEnsemble?.getEnsembleName() ?? null;
-    const gridIntersectionQuery = useGridIntersection(firstCaseUuid, firstEnsembleName, gridName, parameterName, realizations ? realizations[0] : "0", useStatistics);
-    const statisticalGridIntersectionQuery = useStatisticalGridIntersection(firstCaseUuid,firstEnsembleName, gridName, parameterName, realizations, useStatistics);
+    const gridIntersectionQuery = useGridIntersection(
+        firstCaseUuid,
+        firstEnsembleName,
+        gridName,
+        parameterName,
+        realizations ? realizations[0] : "0",
+        useStatistics
+    );
+    const statisticalGridIntersectionQuery = useStatisticalGridIntersection(
+        firstCaseUuid,
+        firstEnsembleName,
+        gridName,
+        parameterName,
+        realizations,
+        useStatistics
+    );
 
+    if (!gridIntersectionQuery.data && !statisticalGridIntersectionQuery.data) {
+        return <div>no grid geometry</div>;
+    }
 
-
-    if (!gridIntersectionQuery.data && !statisticalGridIntersectionQuery.data) { return (<div>no grid geometry</div>) }
-
-    let intersectionData: any = []
+    let intersectionData: any = [];
     if (!useStatistics && gridIntersectionQuery?.data) {
-        intersectionData = gridIntersectionQuery.data
+        intersectionData = gridIntersectionQuery.data;
+    } else if (useStatistics && statisticalGridIntersectionQuery?.data) {
+        intersectionData = statisticalGridIntersectionQuery.data;
+    } else {
+        return <div>Fetching data...</div>;
     }
-    else if (useStatistics && statisticalGridIntersectionQuery?.data) {
-        intersectionData = statisticalGridIntersectionQuery.data
-    }
-    else { return <div>Fetching data...</div> }
     return (
         <div className="relative w-full h-full flex flex-col" ref={wrapperDivRef}>
-            <PlotlyGridIntersection data={intersectionData} width={wrapperDivSize.width}
-                height={wrapperDivSize.height} />
+            <PlotlyGridIntersection
+                data={intersectionData}
+                width={wrapperDivSize.width}
+                height={wrapperDivSize.height}
+            />
             <div className="absolute bottom-5 right-5 italic text-pink-400">{moduleContext.getInstanceIdString()}</div>
         </div>
     );

--- a/frontend/src/modules/InplaceVolumetrics/loadModule.tsx
+++ b/frontend/src/modules/InplaceVolumetrics/loadModule.tsx
@@ -1,8 +1,8 @@
 import { ModuleRegistry } from "@framework/ModuleRegistry";
 
-import { settings } from "./settings";
+import { Settings } from "./settings";
 import { State } from "./state";
-import { view } from "./view";
+import { View } from "./view";
 
 const defaultState: State = {
     ensembleIdent: null,
@@ -15,5 +15,5 @@ const defaultState: State = {
 
 const module = ModuleRegistry.initModule<State>("InplaceVolumetrics", defaultState);
 
-module.viewFC = view;
-module.settingsFC = settings;
+module.viewFC = View;
+module.settingsFC = Settings;

--- a/frontend/src/modules/InplaceVolumetrics/settings.tsx
+++ b/frontend/src/modules/InplaceVolumetrics/settings.tsx
@@ -117,7 +117,6 @@ export function Settings({ moduleContext, workbenchSession }: ModuleFCProps<Stat
 
     React.useEffect(
         function selectDefaultTable() {
-            console.debug("selectDefaultTable()");
             if (tableDescriptionsQuery.data) {
                 setTableName(tableDescriptionsQuery.data[0].name);
                 const responses = tableDescriptionsQuery.data[0].numerical_column_names;
@@ -131,21 +130,17 @@ export function Settings({ moduleContext, workbenchSession }: ModuleFCProps<Stat
     );
 
     function handleEnsembleSelectionChange(newEnsembleIdent: EnsembleIdent | null) {
-        console.debug("handleEnsembleSelectionChange()");
         setEnsembleIdent(newEnsembleIdent);
     }
     function handleTableChange(tableName: string) {
-        console.debug("handleTableChange()");
         setTableName(tableName);
     }
     function handleResponseChange(responseName: string) {
-        console.debug("handleResponseChange()");
         setResponseName(responseName);
     }
 
     const handleSelectionChange = React.useCallback(
-        (categoryName: string, categoryValues: string[]) => {
-            console.debug("handleSelectionChange()");
+        function handleSelectionChange(categoryName: string, categoryValues: string[]) {
             let currentCategoryFilter = categoricalFilter;
             if (currentCategoryFilter) {
                 const categoryIndex = currentCategoryFilter.findIndex((category) => category.name === categoryName);

--- a/frontend/src/modules/InplaceVolumetrics/settings.tsx
+++ b/frontend/src/modules/InplaceVolumetrics/settings.tsx
@@ -96,7 +96,7 @@ function getTableResponseOptions(
     return responsesToSelectOptions(responses);
 }
 
-export function settings({ moduleContext, workbenchSession }: ModuleFCProps<State>) {
+export function Settings({ moduleContext, workbenchSession }: ModuleFCProps<State>) {
     const ensembleSet = useEnsembleSet(workbenchSession);
     const [ensembleIdent, setEnsembleIdent] = moduleContext.useStoreState("ensembleIdent");
     const [tableName, setTableName] = moduleContext.useStoreState("tableName");
@@ -112,7 +112,7 @@ export function settings({ moduleContext, workbenchSession }: ModuleFCProps<Stat
                 setEnsembleIdent(fixedEnsembleIdent);
             }
         },
-        [ensembleSet, ensembleIdent]
+        [ensembleSet, ensembleIdent, setEnsembleIdent]
     );
 
     React.useEffect(
@@ -127,7 +127,7 @@ export function settings({ moduleContext, workbenchSession }: ModuleFCProps<Stat
                 setResponseName(null);
             }
         },
-        [tableDescriptionsQuery.data]
+        [tableDescriptionsQuery.data, setTableName, setResponseName]
     );
 
     function handleEnsembleSelectionChange(newEnsembleIdent: EnsembleIdent | null) {
@@ -143,23 +143,26 @@ export function settings({ moduleContext, workbenchSession }: ModuleFCProps<Stat
         setResponseName(responseName);
     }
 
-    const handleSelectionChange = React.useCallback((categoryName: string, categoryValues: string[]) => {
-        console.debug("handleSelectionChange()");
-        let currentCategoryFilter = categoricalFilter;
-        if (currentCategoryFilter) {
-            const categoryIndex = currentCategoryFilter.findIndex((category) => category.name === categoryName);
-            if (categoryIndex > -1) {
-                currentCategoryFilter[categoryIndex].unique_values = categoryValues;
+    const handleSelectionChange = React.useCallback(
+        (categoryName: string, categoryValues: string[]) => {
+            console.debug("handleSelectionChange()");
+            let currentCategoryFilter = categoricalFilter;
+            if (currentCategoryFilter) {
+                const categoryIndex = currentCategoryFilter.findIndex((category) => category.name === categoryName);
+                if (categoryIndex > -1) {
+                    currentCategoryFilter[categoryIndex].unique_values = categoryValues;
+                } else {
+                    currentCategoryFilter.push({ name: categoryName, unique_values: categoryValues });
+                }
             } else {
+                currentCategoryFilter = [];
                 currentCategoryFilter.push({ name: categoryName, unique_values: categoryValues });
             }
-        } else {
-            currentCategoryFilter = [];
-            currentCategoryFilter.push({ name: categoryName, unique_values: categoryValues });
-        }
 
-        setCategoricalFilter(currentCategoryFilter);
-    }, []);
+            setCategoricalFilter(currentCategoryFilter);
+        },
+        [categoricalFilter, setCategoricalFilter]
+    );
 
     const tableNameOptions = getTableNameOptions(tableDescriptionsQuery);
     const tableCategoricalOptions = getTableCategoricalOptions(tableDescriptionsQuery, tableName);

--- a/frontend/src/modules/InplaceVolumetrics/view.tsx
+++ b/frontend/src/modules/InplaceVolumetrics/view.tsx
@@ -16,7 +16,7 @@ import { useRealizationsResponseQuery } from "./queryHooks";
 import { VolumetricResponseAbbreviations } from "./settings";
 import { State } from "./state";
 
-export const view = (props: ModuleFCProps<State>) => {
+export const View = (props: ModuleFCProps<State>) => {
     const wrapperDivRef = React.useRef<HTMLDivElement>(null);
     const wrapperDivSize = useElementSize(wrapperDivRef);
     const ensembleIdent = props.moduleContext.useStoreValue("ensembleIdent");
@@ -104,7 +104,7 @@ export const view = (props: ModuleFCProps<State>) => {
 
             props.moduleContext.getChannel(BroadcastChannelNames.Response).broadcast(channelMeta, dataGenerator);
         },
-        [realizationsResponseQuery.data, ensemble, tableName, responseName]
+        [realizationsResponseQuery.data, ensemble, tableName, responseName, props.moduleContext]
     );
 
     const layout: Partial<Layout> = {

--- a/frontend/src/modules/MyModule/loadModule.tsx
+++ b/frontend/src/modules/MyModule/loadModule.tsx
@@ -3,7 +3,7 @@ import { ColorScaleGradientType, ColorScaleType } from "@lib/utils/ColorScale";
 
 import { settings } from "./settings";
 import { State } from "./state";
-import { view } from "./view";
+import { View } from "./view";
 
 const defaultState: State = {
     type: ColorScaleType.Discrete,
@@ -15,5 +15,5 @@ const defaultState: State = {
 
 const module = ModuleRegistry.initModule<State>("MyModule", defaultState);
 
-module.viewFC = view;
+module.viewFC = View;
 module.settingsFC = settings;

--- a/frontend/src/modules/MyModule/view.tsx
+++ b/frontend/src/modules/MyModule/view.tsx
@@ -402,7 +402,7 @@ for (let i = 0; i < countryData.length; i += 2) {
     alcConsumption.push(countryData[i + 1] as number);
 }
 
-export const view = (props: ModuleFCProps<State>) => {
+export const View = (props: ModuleFCProps<State>) => {
     const type = props.moduleContext.useStoreValue("type");
     const gradientType = props.moduleContext.useStoreValue("gradientType");
     const min = props.moduleContext.useStoreValue("min");

--- a/frontend/src/modules/ParameterDistributionMatrix/loadModule.tsx
+++ b/frontend/src/modules/ParameterDistributionMatrix/loadModule.tsx
@@ -1,12 +1,12 @@
 import { ModuleRegistry } from "@framework/ModuleRegistry";
 
-import { settings } from "./settings";
+import { Settings } from "./settings";
 import { State } from "./state";
-import { view } from "./view";
+import { View } from "./view";
 
 const defaultState: State = { ensembleSetParameterIdents: [] };
 
 const module = ModuleRegistry.initModule<State>("ParameterDistributionMatrix", defaultState);
 
-module.viewFC = view;
-module.settingsFC = settings;
+module.viewFC = View;
+module.settingsFC = Settings;

--- a/frontend/src/modules/ParameterDistributionMatrix/settings.tsx
+++ b/frontend/src/modules/ParameterDistributionMatrix/settings.tsx
@@ -16,7 +16,7 @@ import { isEqual } from "lodash";
 import { EnsembleSetParameterIdents, State } from "./state";
 
 const MAX_PARAMETERS = 50;
-export function settings({ moduleContext, workbenchSession }: ModuleFCProps<State>) {
+export function Settings({ moduleContext, workbenchSession }: ModuleFCProps<State>) {
     const statusWriter = useSettingsStatusWriter(moduleContext);
 
     const ensembleSet = useEnsembleSet(workbenchSession);
@@ -136,7 +136,13 @@ export function settings({ moduleContext, workbenchSession }: ModuleFCProps<Stat
 
             setEnsembleSetParameterIdents(newEnsembleSetParameterIdents);
         },
-        [selectedEnsembleIdents, selectedParameterIdentsStrings]
+        [
+            selectedEnsembleIdents,
+            selectedParameterIdentsStrings,
+            filteredParameterIdentList,
+            workbenchSession,
+            setEnsembleSetParameterIdents,
+        ]
     );
 
     return (

--- a/frontend/src/modules/ParameterDistributionMatrix/view.tsx
+++ b/frontend/src/modules/ParameterDistributionMatrix/view.tsx
@@ -6,7 +6,7 @@ import { useElementSize } from "@lib/hooks/useElementSize";
 import { ParameterDistributionPlot } from "./components/ParameterDistributionPlot";
 import { EnsembleParameterValues, ParameterDataArr, State } from "./state";
 
-export function view({ moduleContext, workbenchSession, workbenchSettings }: ModuleFCProps<State>) {
+export function View({ moduleContext, workbenchSession, workbenchSettings }: ModuleFCProps<State>) {
     const wrapperDivRef = React.useRef<HTMLDivElement>(null);
     const wrapperDivSize = useElementSize(wrapperDivRef);
 

--- a/frontend/src/modules/Pvt/loadModule.tsx
+++ b/frontend/src/modules/Pvt/loadModule.tsx
@@ -1,8 +1,8 @@
 import { ModuleRegistry } from "@framework/ModuleRegistry";
 
-import { settings } from "./settings";
+import { Settings } from "./settings";
 import state from "./state";
-import { view } from "./view";
+import { View } from "./view";
 
 const defaultState: state = {
     pvtVisualizations: ["volumefactor", "viscosity", "density", "ratio"],
@@ -10,13 +10,10 @@ const defaultState: state = {
     pvtName: "Oil (PVTO)",
     groupBy: "ENSEMBLE",
     realization: 0,
-    activeDataSet: null
-
+    activeDataSet: null,
 };
 
-const module = ModuleRegistry.initModule<state>("Pvt", defaultState, {
+const module = ModuleRegistry.initModule<state>("Pvt", defaultState, {});
 
-});
-
-module.viewFC = view;
-module.settingsFC = settings;
+module.viewFC = View;
+module.settingsFC = Settings;

--- a/frontend/src/modules/Pvt/settings.tsx
+++ b/frontend/src/modules/Pvt/settings.tsx
@@ -1,33 +1,28 @@
 import React, { useEffect } from "react";
+
 import { ModuleFCProps } from "@framework/Module";
 import { useFirstEnsembleInEnsembleSet } from "@framework/WorkbenchSession";
 import { ApiStateWrapper } from "@lib/components/ApiStateWrapper";
-
-import { usePvtDataQuery } from "./queryHooks";
-
 import { Checkbox } from "@lib/components/Checkbox";
-import { Label } from "@lib/components/Label";
 import { Dropdown, DropdownOption } from "@lib/components/Dropdown";
+import { Label } from "@lib/components/Label";
 
+import { PlotOptionType, getAvailablePlotsForPhase } from "./pvtPlotDataAccessor";
+import { PvtQueryDataAccessor } from "./pvtQueryDataAccessor";
+import { usePvtDataQuery } from "./queryHooks";
 import state, { PvtPlotData } from "./state";
 
-import { PvtQueryDataAccessor } from "./pvtQueryDataAccessor";
-import { getAvailablePlotsForPhase, PlotOptionType } from "./pvtPlotDataAccessor";
 //-----------------------------------------------------------------------------------------------------------
-
-
-
-
 
 //Helpers to populate dropdowns
 const stringToOptions = (strings: string[]): DropdownOption[] => {
     return strings.map((string) => ({ label: string, value: string }));
-}
+};
 const numberToOptions = (numbers: number[]): DropdownOption[] => {
     return numbers.map((number) => ({ label: number.toString(), value: number.toString() }));
-}
+};
 
-export function settings({ moduleContext, workbenchSession }: ModuleFCProps<state>) {
+export function Settings({ moduleContext, workbenchSession }: ModuleFCProps<state>) {
     //Just using the first ensemble for now
     const firstEnsemble = useFirstEnsembleInEnsembleSet(workbenchSession);
 
@@ -46,46 +41,55 @@ export function settings({ moduleContext, workbenchSession }: ModuleFCProps<stat
     const [availablePlots, setAvailablePlots] = React.useState<PlotOptionType[]>([]);
 
     // Queries
-    const pvtDataQuery = usePvtDataQuery(firstEnsemble?.getCaseUuid() ?? null, firstEnsemble?.getEnsembleName() ?? null, activeRealization);
-
+    const pvtDataQuery = usePvtDataQuery(
+        firstEnsemble?.getCaseUuid() ?? null,
+        firstEnsemble?.getEnsembleName() ?? null,
+        activeRealization
+    );
 
     // effect triggered by changing pvtName(phase). Updates available pvtNums, available plots and check if currently selected plots are still valid
     useEffect(() => {
         if (pvtDataQuery.data && activePvtName) {
             // Find the data for the selected phase
-            const pvtDataAccessor = new PvtQueryDataAccessor(pvtDataQuery.data)
+            const pvtDataAccessor = new PvtQueryDataAccessor(pvtDataQuery.data);
 
             // const pvtNameData = pvtDataQuery.data.filter((pvtData) => pvtData.name === activePvtName)[0]
-            const uniquePvtNums = pvtDataAccessor.getPvtNums(activePvtName)
+            const uniquePvtNums = pvtDataAccessor.getPvtNums(activePvtName);
 
             // Set available pvtNums and set activePvtNum to first available pvtNum if the current one is not available
-            setAvailablePvtNums(uniquePvtNums)
-            let newActivePvtNum = activePvtNum
+            setAvailablePvtNums(uniquePvtNums);
+            let newActivePvtNum = activePvtNum;
             if (!newActivePvtNum || !uniquePvtNums.includes(newActivePvtNum)) {
-                newActivePvtNum = uniquePvtNums[0]
+                newActivePvtNum = uniquePvtNums[0];
             }
-
 
             // Set available plots
-            const currentPvtData = pvtDataAccessor.getPvtData(activePvtName, newActivePvtNum)
+            const currentPvtData = pvtDataAccessor.getPvtData(activePvtName, newActivePvtNum);
 
-            const newAvailablePlots = getAvailablePlotsForPhase(currentPvtData.phase)
+            const newAvailablePlots = getAvailablePlotsForPhase(currentPvtData.phase);
             // Check if currently selected plots are still valid. Either filter current selections or set to all available plots if none are selected/valid
-            let newAvailablePlotValues = newAvailablePlots.map((plot) => plot.value)
+            let newAvailablePlotValues = newAvailablePlots.map((plot) => plot.value);
 
-            if (activePvtPlots && !activePvtPlots.every(value => newAvailablePlotValues.includes(value))) {
-                const intersectedPlotValues = activePvtPlots.filter(value => newAvailablePlotValues.includes(value));
+            if (activePvtPlots && !activePvtPlots.every((value) => newAvailablePlotValues.includes(value))) {
+                const intersectedPlotValues = activePvtPlots.filter((value) => newAvailablePlotValues.includes(value));
 
                 if (intersectedPlotValues.length >= 0) {
-                    newAvailablePlotValues = intersectedPlotValues
+                    newAvailablePlotValues = intersectedPlotValues;
                 }
             }
-            setActivePvtNum(newActivePvtNum)
-            setAvailablePlots(newAvailablePlots)
-            setActivePvtPlots(newAvailablePlotValues)
-
+            setActivePvtNum(newActivePvtNum);
+            setAvailablePlots(newAvailablePlots);
+            setActivePvtPlots(newAvailablePlotValues);
         }
-    }, [pvtDataQuery.data, activePvtName])
+    }, [
+        pvtDataQuery.data,
+        activePvtName,
+        activePvtNum,
+        activePvtPlots,
+        setActivePvtNum,
+        setActivePvtPlots,
+        setAvailablePlots,
+    ]);
 
     // effect triggered by changing any setting. Updates list of plot data sent to view
     // Split up? Have in view instead?
@@ -94,41 +98,38 @@ export function settings({ moduleContext, workbenchSession }: ModuleFCProps<stat
             // Find the data for the selected phase
             // const currentPvtData = pvtDataQuery.data.filter((pvtData) => (pvtData.name === activePvtName) && (pvtData.pvtnum === activePvtNum))[0]
 
-            const pvtPlotData: PvtPlotData[] = []
+            const pvtPlotData: PvtPlotData[] = [];
 
             // Loop through each of the active visualizations and add the relevant data for the y-axis to the plot data
             for (const pvtPlot of activePvtPlots) {
-                pvtPlotData.push({ pvtNum: activePvtNum, pvtName: activePvtName, pvtPlot: pvtPlot })
+                pvtPlotData.push({ pvtNum: activePvtNum, pvtName: activePvtName, pvtPlot: pvtPlot });
             }
-            setPvtPlotDataSet(pvtPlotData)
+            setPvtPlotDataSet(pvtPlotData);
         }
-    },
-        [activePvtNum, activePvtName, activePvtPlots, pvtDataQuery.data]
-    )
+    }, [activePvtNum, activePvtName, activePvtPlots, pvtDataQuery.data, setPvtPlotDataSet]);
 
     // Handle failed query
-    if (!pvtDataQuery.data) { return (<div>No pvt data</div>) }
-
+    if (!pvtDataQuery.data) {
+        return <div>No pvt data</div>;
+    }
 
     // Get available PvtNames from query
     // Guess "new" will trigger a re-render?
-    const pvtDataAccessor = new PvtQueryDataAccessor(pvtDataQuery.data)
+    const pvtDataAccessor = new PvtQueryDataAccessor(pvtDataQuery.data);
 
-    const availablePvtNames = pvtDataAccessor.getPvtNames()
-
+    const availablePvtNames = pvtDataAccessor.getPvtNames();
 
     // Handle toggling of visualization checkboxes
     const handleToggledVisualization = (checked: boolean, triggeredPlot: string) => {
         if (!activePvtPlots) {
-            return
+            return;
         }
         if (checked) {
-            setActivePvtPlots([...activePvtPlots, triggeredPlot])
+            setActivePvtPlots([...activePvtPlots, triggeredPlot]);
+        } else {
+            setActivePvtPlots(activePvtPlots.filter((plot) => plot !== triggeredPlot));
         }
-        else {
-            setActivePvtPlots(activePvtPlots.filter((plot) => plot !== triggeredPlot))
-        }
-    }
+    };
     return (
         <div>
             <ApiStateWrapper
@@ -163,18 +164,16 @@ export function settings({ moduleContext, workbenchSession }: ModuleFCProps<stat
                 <Label text="Visualization">
                     <>
                         {availablePlots?.map((plot) => (
-                            <Checkbox key={plot.value}
+                            <Checkbox
+                                key={plot.value}
                                 label={plot.value}
                                 checked={activePvtPlots ? activePvtPlots.includes(plot.value) : false}
                                 onChange={(_, checked) => handleToggledVisualization(checked, plot.value)}
-
-                            />))
-
-                        }
+                            />
+                        ))}
                     </>
                 </Label>
             </ApiStateWrapper>
         </div>
     );
 }
-

--- a/frontend/src/modules/Pvt/view.tsx
+++ b/frontend/src/modules/Pvt/view.tsx
@@ -1,17 +1,18 @@
 import React, { useEffect } from "react";
-import { useFirstEnsembleInEnsembleSet } from "@framework/WorkbenchSession";
+
 import { ModuleFCProps } from "@framework/Module";
+import { useFirstEnsembleInEnsembleSet } from "@framework/WorkbenchSession";
 import { useElementSize } from "@lib/hooks/useElementSize";
+
+import PlotlyPvtScatter from "./plotlyPvtScatter";
+import { PlotDataType, PvtPlotAccessor } from "./pvtPlotDataAccessor";
+import { PvtQueryDataAccessor } from "./pvtQueryDataAccessor";
 import { usePvtDataQuery } from "./queryHooks";
 import state from "./state";
 
-import { PvtQueryDataAccessor } from "./pvtQueryDataAccessor";
-import { PvtPlotAccessor, PlotDataType } from "./pvtPlotDataAccessor";
-import PlotlyPvtScatter from "./plotlyPvtScatter";
 //-----------------------------------------------------------------------------------------------------------
 
-
-export function view({ moduleContext, workbenchSession }: ModuleFCProps<state>) {
+export function View({ moduleContext, workbenchSession }: ModuleFCProps<state>) {
     const wrapperDivRef = React.useRef<HTMLDivElement>(null);
     const wrapperDivSize = useElementSize(wrapperDivRef);
 
@@ -21,28 +22,28 @@ export function view({ moduleContext, workbenchSession }: ModuleFCProps<state>) 
     const activeDataSet = moduleContext.useStoreValue("activeDataSet");
     const activeRealization = moduleContext.useStoreValue("realization");
 
-    const [plotData, setPlotData] = React.useState<PlotDataType[]>([])
-    const pvtDataQuery = usePvtDataQuery(firstEnsemble?.getCaseUuid() ?? null, firstEnsemble?.getEnsembleName() ?? null, activeRealization);
-
+    const [plotData, setPlotData] = React.useState<PlotDataType[]>([]);
+    const pvtDataQuery = usePvtDataQuery(
+        firstEnsemble?.getCaseUuid() ?? null,
+        firstEnsemble?.getEnsembleName() ?? null,
+        activeRealization
+    );
 
     useEffect(() => {
         if (activeDataSet && pvtDataQuery.data) {
-            const pvtQueryDataAccessor = new PvtQueryDataAccessor(pvtDataQuery.data)
-            const PvtPlotData = []
+            const pvtQueryDataAccessor = new PvtQueryDataAccessor(pvtDataQuery.data);
+            const PvtPlotData = [];
             for (const pvtPlotData of activeDataSet) {
-                const pvtData = pvtQueryDataAccessor.getPvtData(pvtPlotData.pvtName, pvtPlotData.pvtNum)
-                const pvtPlotAccessor = new PvtPlotAccessor(pvtData)
-                PvtPlotData.push(pvtPlotAccessor.getPlotData(pvtPlotData.pvtPlot))
+                const pvtData = pvtQueryDataAccessor.getPvtData(pvtPlotData.pvtName, pvtPlotData.pvtNum);
+                const pvtPlotAccessor = new PvtPlotAccessor(pvtData);
+                PvtPlotData.push(pvtPlotAccessor.getPlotData(pvtPlotData.pvtPlot));
             }
-            setPlotData(PvtPlotData)
+            setPlotData(PvtPlotData);
         }
-    },
-        [activeDataSet, pvtDataQuery.data]
-    )
-    if (!pvtDataQuery.data || !activeDataSet || activeDataSet.length == 0) { return (<div>no pvt data</div>) }
-
-
-
+    }, [activeDataSet, pvtDataQuery.data]);
+    if (!pvtDataQuery.data || !activeDataSet || activeDataSet.length == 0) {
+        return <div>no pvt data</div>;
+    }
 
     return (
         <div className="flex flex-wrap h-full w-full" ref={wrapperDivRef}>
@@ -58,4 +59,3 @@ export function view({ moduleContext, workbenchSession }: ModuleFCProps<state>) 
         </div>
     );
 }
-

--- a/frontend/src/modules/Rft/loadModule.tsx
+++ b/frontend/src/modules/Rft/loadModule.tsx
@@ -1,17 +1,14 @@
 import { ModuleRegistry } from "@framework/ModuleRegistry";
 
-import { settings } from "./settings";
+import { Settings } from "./settings";
 import State from "./state";
-import { view } from "./view";
+import { View } from "./view";
 
 const defaultState: State = {
-    rftWellAddress: null
-
+    rftWellAddress: null,
 };
 
-const module = ModuleRegistry.initModule<State>("Rft", defaultState, {
+const module = ModuleRegistry.initModule<State>("Rft", defaultState, {});
 
-});
-
-module.viewFC = view;
-module.settingsFC = settings;
+module.viewFC = View;
+module.settingsFC = Settings;

--- a/frontend/src/modules/Rft/settings.tsx
+++ b/frontend/src/modules/Rft/settings.tsx
@@ -3,14 +3,11 @@ import React from "react";
 import { EnsembleIdent } from "@framework/EnsembleIdent";
 import { ModuleFCProps } from "@framework/Module";
 import { SyncSettingKey, SyncSettingsHelper } from "@framework/SyncSettings";
-
 import { useEnsembleSet } from "@framework/WorkbenchSession";
 import { SingleEnsembleSelect } from "@framework/components/SingleEnsembleSelect";
 import { fixupEnsembleIdent, maybeAssignFirstSyncedEnsemble } from "@framework/utils/ensembleUiHelpers";
 import { timestampUtcMsToCompactIsoString } from "@framework/utils/timestampUtils";
-
 import { CollapsibleGroup } from "@lib/components/CollapsibleGroup";
-
 import { Select, SelectOption } from "@lib/components/Select";
 
 import { isEqual } from "lodash";
@@ -29,7 +26,7 @@ const timepointOptions = (timePoints: number[]): SelectOption[] => {
     }));
 };
 
-export function settings({ moduleContext, workbenchServices, workbenchSession }: ModuleFCProps<state>) {
+export function Settings({ moduleContext, workbenchServices, workbenchSession }: ModuleFCProps<state>) {
     const ensembleSet = useEnsembleSet(workbenchSession);
     const [rftWellAddress, setRftWellAddress] = moduleContext.useStoreState("rftWellAddress");
     const [selectedEnsembleIdent, setSelectedEnsembleIdent] = React.useState<EnsembleIdent | null>(null);
@@ -88,7 +85,9 @@ export function settings({ moduleContext, workbenchServices, workbenchSession }:
                     setRftWellAddress(addr);
                 }
             }
-        }, [computedTimePoint, selectedWellName, selectedEnsembleIdent]);
+        },
+        [computedTimePoint, selectedWellName, selectedEnsembleIdent, setRftWellAddress, rftWellAddress]
+    );
     function handleEnsembleSelectionChange(newEnsembleIdent: EnsembleIdent | null) {
         console.debug("handleEnsembleSelectionChange()");
         setSelectedEnsembleIdent(newEnsembleIdent);

--- a/frontend/src/modules/Rft/view.tsx
+++ b/frontend/src/modules/Rft/view.tsx
@@ -2,8 +2,8 @@ import React from "react";
 import Plot from "react-plotly.js";
 
 import { RftRealizationData_api } from "@api";
-import { timestampUtcMsToCompactIsoString } from "@framework/utils/timestampUtils";
 import { ModuleFCProps } from "@framework/Module";
+import { timestampUtcMsToCompactIsoString } from "@framework/utils/timestampUtils";
 import { useElementSize } from "@lib/hooks/useElementSize";
 
 import { PlotData } from "plotly.js";
@@ -11,7 +11,7 @@ import { PlotData } from "plotly.js";
 import { useRftRealizationData } from "./queryHooks";
 import State from "./state";
 
-export const view = ({ moduleContext }: ModuleFCProps<State>) => {
+export const View = ({ moduleContext }: ModuleFCProps<State>) => {
     const wrapperDivRef = React.useRef<HTMLDivElement>(null);
     const wrapperDivSize = useElementSize(wrapperDivRef);
     const rftWellAddress = moduleContext.useStoreValue("rftWellAddress");
@@ -38,7 +38,10 @@ export const view = ({ moduleContext }: ModuleFCProps<State>) => {
     realizationDataForTimePoint.forEach((realizationData) => {
         plotData.push(createRftRealizationTrace(realizationData));
     });
-    const title = rftWellAddress && timePoint ? `RFT for ${rftWellAddress.wellName}, ${timestampUtcMsToCompactIsoString(timePoint)}` : "";
+    const title =
+        rftWellAddress && timePoint
+            ? `RFT for ${rftWellAddress.wellName}, ${timestampUtcMsToCompactIsoString(timePoint)}`
+            : "";
     return (
         <div className="w-full h-full" ref={wrapperDivRef}>
             <Plot
@@ -65,10 +68,10 @@ function createRftRealizationTrace(rftRealizationData: RftRealizationData_api): 
         type: "scatter",
         mode: "lines",
         hovertemplate:
-            '<br><b>Pressure</b>: %{x}' +
-            '<br><b>Depth</b>: %{y}' +
+            "<br><b>Pressure</b>: %{x}" +
+            "<br><b>Depth</b>: %{y}" +
             `<br><b>Realization</b>: ${rftRealizationData.realization}` +
-            '<extra></extra>',
+            "<extra></extra>",
         showlegend: false,
         line: {
             color: "red",

--- a/frontend/src/modules/SeismicIntersection/loadModule.tsx
+++ b/frontend/src/modules/SeismicIntersection/loadModule.tsx
@@ -1,8 +1,8 @@
 import { ModuleRegistry } from "@framework/ModuleRegistry";
 
-import { settings } from "./settings";
+import { Settings } from "./settings";
 import { State } from "./state";
-import { view } from "./view";
+import { View } from "./view";
 
 const defaultState: State = {
     wellboreAddress: null,
@@ -13,5 +13,5 @@ const defaultState: State = {
 
 const module = ModuleRegistry.initModule<State>("SeismicIntersection", defaultState);
 
-module.viewFC = view;
-module.settingsFC = settings;
+module.viewFC = View;
+module.settingsFC = Settings;

--- a/frontend/src/modules/SeismicIntersection/settings.tsx
+++ b/frontend/src/modules/SeismicIntersection/settings.tsx
@@ -45,7 +45,7 @@ const WELLBORE_TYPE = "smda";
 const EXTENSION_LIMITS = { min: 100, max: 100000 }; // Min/max extension in meters outside both sides of the well path [m]
 const Z_SCALE_LIMITS = { min: 1, max: 100 }; // Minimum z-scale factor
 
-export function settings({ moduleContext, workbenchSession, workbenchServices }: ModuleFCProps<State>) {
+export function Settings({ moduleContext, workbenchSession, workbenchServices }: ModuleFCProps<State>) {
     const syncedSettingKeys = moduleContext.useSyncedSettingKeys();
     const syncHelper = new SyncSettingsHelper(syncedSettingKeys, workbenchServices);
     const syncedValueEnsembles = syncHelper.useValue(SyncSettingKey.ENSEMBLE, "global.syncValue.ensembles");
@@ -145,14 +145,21 @@ export function settings({ moduleContext, workbenchSession, workbenchServices }:
             }
             setSeismicAddress(seismicAddress);
         },
-        [computedEnsembleIdent, selectedSeismicAttribute, selectedTime, isObserved, realizationNumber]
+        [
+            computedEnsembleIdent,
+            selectedSeismicAttribute,
+            selectedTime,
+            isObserved,
+            realizationNumber,
+            setSeismicAddress,
+        ]
     );
 
     React.useEffect(
         function propagateWellBoreAddressToView() {
             setWellboreAddress(selectedWellboreAddress);
         },
-        [selectedWellboreAddress]
+        [selectedWellboreAddress, setWellboreAddress]
     );
 
     function handleEnsembleSelectionChange(newEnsembleIdent: EnsembleIdent | null) {

--- a/frontend/src/modules/SeismicIntersection/view.tsx
+++ b/frontend/src/modules/SeismicIntersection/view.tsx
@@ -1,7 +1,7 @@
-import React, { useId } from "react";
+import React from "react";
 
 import { SeismicFencePolyline_api } from "@api";
-import { Controller, GridLayer, IntersectionReferenceSystem, Trajectory } from "@equinor/esv-intersection";
+import { Controller, IntersectionReferenceSystem, Trajectory } from "@equinor/esv-intersection";
 import { ModuleFCProps } from "@framework/Module";
 import { useViewStatusWriter } from "@framework/StatusWriter";
 import { useElementSize } from "@lib/hooks/useElementSize";
@@ -33,7 +33,6 @@ export const View = ({ moduleContext, workbenchSettings }: ModuleFCProps<State>)
     const esvIntersectionContainerRef = React.useRef<HTMLDivElement | null>(null);
     const esvIntersectionControllerRef = React.useRef<Controller | null>(null);
 
-    const gridLayerUuid = useId();
     const statusWriter = useViewStatusWriter(moduleContext);
 
     const seismicAddress = moduleContext.useStoreValue("seismicAddress");
@@ -66,28 +65,23 @@ export const View = ({ moduleContext, workbenchSettings }: ModuleFCProps<State>)
         React.useState<SeismicSliceImageOptions | null>(null);
     const generatedSeismicSliceImageData = useGenerateSeismicSliceImageData(generateSeismicSliceImageOptions);
 
-    React.useEffect(
-        function initializeEsvIntersectionController() {
-            if (esvIntersectionContainerRef.current) {
-                const axisOptions = { xLabel: "x", yLabel: "y", unitOfMeasure: "m" };
-                esvIntersectionControllerRef.current = new Controller({
-                    container: esvIntersectionContainerRef.current,
-                    axisOptions,
-                });
+    React.useEffect(function initializeEsvIntersectionController() {
+        if (esvIntersectionContainerRef.current) {
+            const axisOptions = { xLabel: "x", yLabel: "y", unitOfMeasure: "m" };
+            esvIntersectionControllerRef.current = new Controller({
+                container: esvIntersectionContainerRef.current,
+                axisOptions,
+            });
 
-                // Initialize/configure controller
-                addMDOverlay(esvIntersectionControllerRef.current);
-                esvIntersectionControllerRef.current.addLayer(new GridLayer(gridLayerUuid));
-                esvIntersectionControllerRef.current.setBounds([10, 1000], [0, 3000]);
-                esvIntersectionControllerRef.current.setViewport(1000, 1650, 6000);
-                esvIntersectionControllerRef.current.zoomPanHandler.zFactor = zScale;
-            }
-            return () => {
-                esvIntersectionControllerRef.current?.destroy();
-            };
-        },
-        [gridLayerUuid, zScale]
-    );
+            // Initialize/configure controller
+            addMDOverlay(esvIntersectionControllerRef.current);
+            esvIntersectionControllerRef.current.setBounds([10, 1000], [0, 3000]);
+            esvIntersectionControllerRef.current.setViewport(1000, 1650, 6000);
+        }
+        return () => {
+            esvIntersectionControllerRef.current?.destroy();
+        };
+    }, []);
 
     // Get well trajectories query
     const wellTrajectoriesQuery = useWellTrajectoriesQuery(wellboreAddress ? [wellboreAddress.uuid] : undefined);

--- a/frontend/src/modules/SeismicIntersection/view.tsx
+++ b/frontend/src/modules/SeismicIntersection/view.tsx
@@ -27,7 +27,7 @@ import {
     useGenerateSeismicSliceImageData,
 } from "./utils/esvIntersectionHooks";
 
-export const view = ({ moduleContext, workbenchSettings }: ModuleFCProps<State>) => {
+export const View = ({ moduleContext, workbenchSettings }: ModuleFCProps<State>) => {
     const wrapperDivRef = React.useRef<HTMLDivElement | null>(null);
     const wrapperDivSize = useElementSize(wrapperDivRef);
     const esvIntersectionContainerRef = React.useRef<HTMLDivElement | null>(null);
@@ -66,25 +66,28 @@ export const view = ({ moduleContext, workbenchSettings }: ModuleFCProps<State>)
         React.useState<SeismicSliceImageOptions | null>(null);
     const generatedSeismicSliceImageData = useGenerateSeismicSliceImageData(generateSeismicSliceImageOptions);
 
-    React.useEffect(function initializeEsvIntersectionController() {
-        if (esvIntersectionContainerRef.current) {
-            const axisOptions = { xLabel: "x", yLabel: "y", unitOfMeasure: "m" };
-            esvIntersectionControllerRef.current = new Controller({
-                container: esvIntersectionContainerRef.current,
-                axisOptions,
-            });
+    React.useEffect(
+        function initializeEsvIntersectionController() {
+            if (esvIntersectionContainerRef.current) {
+                const axisOptions = { xLabel: "x", yLabel: "y", unitOfMeasure: "m" };
+                esvIntersectionControllerRef.current = new Controller({
+                    container: esvIntersectionContainerRef.current,
+                    axisOptions,
+                });
 
-            // Initialize/configure controller
-            addMDOverlay(esvIntersectionControllerRef.current);
-            esvIntersectionControllerRef.current.addLayer(new GridLayer(gridLayerUuid));
-            esvIntersectionControllerRef.current.setBounds([10, 1000], [0, 3000]);
-            esvIntersectionControllerRef.current.setViewport(1000, 1650, 6000);
-            esvIntersectionControllerRef.current.zoomPanHandler.zFactor = zScale;
-        }
-        return () => {
-            esvIntersectionControllerRef.current?.destroy();
-        };
-    }, []);
+                // Initialize/configure controller
+                addMDOverlay(esvIntersectionControllerRef.current);
+                esvIntersectionControllerRef.current.addLayer(new GridLayer(gridLayerUuid));
+                esvIntersectionControllerRef.current.setBounds([10, 1000], [0, 3000]);
+                esvIntersectionControllerRef.current.setViewport(1000, 1650, 6000);
+                esvIntersectionControllerRef.current.zoomPanHandler.zFactor = zScale;
+            }
+            return () => {
+                esvIntersectionControllerRef.current?.destroy();
+            };
+        },
+        [gridLayerUuid, zScale]
+    );
 
     // Get well trajectories query
     const wellTrajectoriesQuery = useWellTrajectoriesQuery(wellboreAddress ? [wellboreAddress.uuid] : undefined);

--- a/frontend/src/modules/SimulationTimeSeries/loadModule.tsx
+++ b/frontend/src/modules/SimulationTimeSeries/loadModule.tsx
@@ -1,9 +1,9 @@
 import { Frequency_api } from "@api";
 import { ModuleRegistry } from "@framework/ModuleRegistry";
 
-import { settings } from "./settings";
+import { Settings } from "./settings";
 import { State } from "./state";
-import { view } from "./view";
+import { View } from "./view";
 
 const defaultState: State = {
     vectorSpec: null,
@@ -16,5 +16,5 @@ const defaultState: State = {
 
 const module = ModuleRegistry.initModule<State>("SimulationTimeSeries", defaultState);
 
-module.viewFC = view;
-module.settingsFC = settings;
+module.viewFC = View;
+module.settingsFC = Settings;

--- a/frontend/src/modules/SimulationTimeSeries/settings.tsx
+++ b/frontend/src/modules/SimulationTimeSeries/settings.tsx
@@ -21,7 +21,7 @@ import { useVectorListQuery } from "./queryHooks";
 import { State } from "./state";
 
 //-----------------------------------------------------------------------------------------------------------
-export function settings({ moduleContext, workbenchSession, workbenchServices }: ModuleFCProps<State>) {
+export function Settings({ moduleContext, workbenchSession, workbenchServices }: ModuleFCProps<State>) {
     const myInstanceIdStr = moduleContext.getInstanceIdString();
     console.debug(`${myInstanceIdStr} -- render SimulationTimeSeries settings`);
 
@@ -77,7 +77,7 @@ export function settings({ moduleContext, workbenchSession, workbenchServices }:
                 moduleContext.getStateStore().setValue("vectorSpec", null);
             }
         },
-        [computedEnsembleIdent, computedVectorName, computedVectorNameHasHistoricalData]
+        [computedEnsembleIdent, computedVectorName, computedVectorNameHasHistoricalData, moduleContext]
     );
 
     const computedEnsemble = computedEnsembleIdent ? ensembleSet.findEnsemble(computedEnsembleIdent) : null;

--- a/frontend/src/modules/SimulationTimeSeries/view.tsx
+++ b/frontend/src/modules/SimulationTimeSeries/view.tsx
@@ -20,7 +20,7 @@ interface MyPlotData extends Partial<PlotData> {
     legendrank?: number;
 }
 
-export const view = ({ moduleContext, workbenchSession, workbenchServices }: ModuleFCProps<State>) => {
+export const View = ({ moduleContext, workbenchSession, workbenchServices }: ModuleFCProps<State>) => {
     // Leave this in until we get a feeling for React18/Plotly
     const renderCount = React.useRef(0);
     React.useEffect(function incrementRenderCount() {

--- a/frontend/src/modules/SimulationTimeSeriesMatrix/loadModule.tsx
+++ b/frontend/src/modules/SimulationTimeSeriesMatrix/loadModule.tsx
@@ -1,9 +1,9 @@
 import { Frequency_api, StatisticFunction_api } from "@api";
 import { ModuleRegistry } from "@framework/ModuleRegistry";
 
-import { settings } from "./settings";
+import { Settings } from "./settings";
 import { FanchartStatisticOption, GroupBy, State, VisualizationMode } from "./state";
-import { view } from "./view";
+import { View } from "./view";
 
 const defaultState: State = {
     groupBy: GroupBy.TIME_SERIES,
@@ -23,5 +23,5 @@ const defaultState: State = {
 
 const module = ModuleRegistry.initModule<State>("SimulationTimeSeriesMatrix", defaultState);
 
-module.viewFC = view;
-module.settingsFC = settings;
+module.viewFC = View;
+module.settingsFC = Settings;

--- a/frontend/src/modules/SimulationTimeSeriesMatrix/settings.tsx
+++ b/frontend/src/modules/SimulationTimeSeriesMatrix/settings.tsx
@@ -25,7 +25,7 @@ import { resolveClassNames } from "@lib/utils/resolveClassNames";
 import { FilterAlt } from "@mui/icons-material";
 
 import { isEqual } from "lodash";
-import { VectorDescription } from "src/api/models/VectorDescription";
+import { VectorDescription_api } from "src/api";
 
 import { useVectorListQueries } from "./queryHooks";
 import {
@@ -71,7 +71,10 @@ export function Settings({ moduleContext, workbenchSession }: ModuleFCProps<Stat
     const [vectorSelectorData, setVectorSelectorData] = React.useState<TreeDataNode[]>([]);
     const [statisticsType, setStatisticsType] = React.useState<StatisticsType>(StatisticsType.INDIVIDUAL);
     const [filteredParameterIdentList, setFilteredParameterIdentList] = React.useState<ParameterIdent[]>([]);
-    const [prevVectorQueriesList, setPrevVectorQueriesList] = React.useState<(VectorDescription[] | undefined)[]>([]);
+    const [prevVectorQueriesDataList, setPrevVectorQueriesDataList] = React.useState<
+        (VectorDescription_api[] | undefined)[]
+    >([]);
+    const [prevSelectedEnsembleIdents, setPrevSelectedEnsembleIdents] = React.useState<EnsembleIdent[]>([]);
 
     const ensembleVectorListsHelper = React.useRef<EnsembleVectorListsHelper>(new EnsembleVectorListsHelper([], []));
 
@@ -115,10 +118,12 @@ export function Settings({ moduleContext, workbenchSession }: ModuleFCProps<Stat
     if (
         !isEqual(
             vectorListQueries.map((el) => el.data),
-            prevVectorQueriesList
-        )
+            prevVectorQueriesDataList
+        ) ||
+        !isEqual(selectedEnsembleIdents, prevSelectedEnsembleIdents)
     ) {
-        setPrevVectorQueriesList(vectorListQueries.map((el) => el.data));
+        setPrevVectorQueriesDataList(vectorListQueries.map((el) => el.data));
+        setPrevSelectedEnsembleIdents(selectedEnsembleIdents);
         ensembleVectorListsHelper.current = new EnsembleVectorListsHelper(selectedEnsembleIdents, vectorListQueries);
     }
 

--- a/frontend/src/modules/SimulationTimeSeriesMatrix/settings.tsx
+++ b/frontend/src/modules/SimulationTimeSeriesMatrix/settings.tsx
@@ -47,7 +47,7 @@ enum StatisticsType {
     FANCHART = "Fanchart",
 }
 
-export function settings({ moduleContext, workbenchSession }: ModuleFCProps<State>) {
+export function Settings({ moduleContext, workbenchSession }: ModuleFCProps<State>) {
     const ensembleSet = useEnsembleSet(workbenchSession);
     const statusWriter = useSettingsStatusWriter(moduleContext);
 
@@ -107,7 +107,10 @@ export function settings({ moduleContext, workbenchSession }: ModuleFCProps<Stat
     }
 
     const vectorListQueries = useVectorListQueries(selectedEnsembleIdents);
-    const ensembleVectorListsHelper = new EnsembleVectorListsHelper(selectedEnsembleIdents, vectorListQueries);
+    const ensembleVectorListsHelper = React.useMemo(
+        () => new EnsembleVectorListsHelper(selectedEnsembleIdents, vectorListQueries),
+        [selectedEnsembleIdents, vectorListQueries]
+    );
     const selectedVectorNamesHasHistorical = ensembleVectorListsHelper.hasAnyHistoricalVector(selectedVectorNames);
     const currentVectorSelectorData = createVectorSelectorDataFromVectors(ensembleVectorListsHelper.vectorsUnion());
 
@@ -142,6 +145,8 @@ export function settings({ moduleContext, workbenchSession }: ModuleFCProps<Stat
         statusWriter.addWarning(`Vector ${vectorArrayStr} does not exist in ensemble ${ensembleStr}`);
     }
 
+    const numberOfQueriesWithData = ensembleVectorListsHelper.numberOfQueriesWithData();
+
     React.useEffect(
         function propagateVectorSpecsToView() {
             const newVectorSpecifications: VectorSpec[] = [];
@@ -160,7 +165,13 @@ export function settings({ moduleContext, workbenchSession }: ModuleFCProps<Stat
             }
             setVectorSpecifications(newVectorSpecifications);
         },
-        [selectedEnsembleIdents, selectedVectorNames, ensembleVectorListsHelper.numberOfQueriesWithData()]
+        [
+            selectedEnsembleIdents,
+            selectedVectorNames,
+            numberOfQueriesWithData,
+            setVectorSpecifications,
+            ensembleVectorListsHelper,
+        ]
     );
 
     React.useEffect(
@@ -185,7 +196,7 @@ export function settings({ moduleContext, workbenchSession }: ModuleFCProps<Stat
                 setParameterIdent(null);
             }
         },
-        [selectedParameterIdentStr, filteredParameterIdentList]
+        [selectedParameterIdentStr, filteredParameterIdentList, setParameterIdent]
     );
 
     function handleGroupByChange(event: React.ChangeEvent<HTMLInputElement>) {

--- a/frontend/src/modules/SimulationTimeSeriesMatrix/utils/PlotlyTraceUtils/fanchartPlotting.ts
+++ b/frontend/src/modules/SimulationTimeSeriesMatrix/utils/PlotlyTraceUtils/fanchartPlotting.ts
@@ -183,6 +183,8 @@ export function createFanchartTraces({
 
     validateFanchartData(data);
 
+    // False positive
+    // eslint-disable-next-line react-hooks/rules-of-hooks
     const convertRgb = useMode(modeRgb);
     const rgb = convertRgb(hexColor);
     if (rgb === undefined) {

--- a/frontend/src/modules/SimulationTimeSeriesMatrix/utils/colorUtils.ts
+++ b/frontend/src/modules/SimulationTimeSeriesMatrix/utils/colorUtils.ts
@@ -15,6 +15,8 @@ export function scaleHexColorLightness(
     const min = Math.max(0.0, minScale);
     const max = Math.min(2.0, maxScale);
 
+    // False positive
+    // eslint-disable-next-line react-hooks/rules-of-hooks
     const hslColor = useMode(modeHsl);
     const result = hslColor(hexColor);
     if (result) {

--- a/frontend/src/modules/SimulationTimeSeriesMatrix/view.tsx
+++ b/frontend/src/modules/SimulationTimeSeriesMatrix/view.tsx
@@ -26,7 +26,7 @@ import {
     filterVectorSpecificationAndIndividualStatisticsDataArray,
 } from "./utils/vectorSpecificationsAndQueriesUtils";
 
-export const view = ({ moduleContext, workbenchSession, workbenchSettings }: ModuleFCProps<State>) => {
+export const View = ({ moduleContext, workbenchSession, workbenchSettings }: ModuleFCProps<State>) => {
     const wrapperDivRef = React.useRef<HTMLDivElement>(null);
     const wrapperDivSize = useElementSize(wrapperDivRef);
 

--- a/frontend/src/modules/SimulationTimeSeriesSensitivity/loadModule.tsx
+++ b/frontend/src/modules/SimulationTimeSeriesSensitivity/loadModule.tsx
@@ -1,9 +1,9 @@
 import { Frequency_api } from "@api";
 import { ModuleRegistry } from "@framework/ModuleRegistry";
 
-import { settings } from "./settings";
+import { Settings } from "./settings";
 import { State } from "./state";
-import { view } from "./view";
+import { View } from "./view";
 
 const defaultState: State = {
     vectorSpec: null,
@@ -17,5 +17,5 @@ const defaultState: State = {
 
 const module = ModuleRegistry.initModule<State>("SimulationTimeSeriesSensitivity", defaultState);
 
-module.viewFC = view;
-module.settingsFC = settings;
+module.viewFC = View;
+module.settingsFC = Settings;

--- a/frontend/src/modules/SimulationTimeSeriesSensitivity/settings.tsx
+++ b/frontend/src/modules/SimulationTimeSeriesSensitivity/settings.tsx
@@ -24,7 +24,7 @@ import { State } from "./state";
 
 //-----------------------------------------------------------------------------------------------------------
 
-export function settings({ moduleContext, workbenchSession, workbenchServices }: ModuleFCProps<State>) {
+export function Settings({ moduleContext, workbenchSession, workbenchServices }: ModuleFCProps<State>) {
     const myInstanceIdStr = moduleContext.getInstanceIdString();
     console.debug(`${myInstanceIdStr} -- render SimulationTimeSeries settings`);
 
@@ -89,14 +89,18 @@ export function settings({ moduleContext, workbenchSession, workbenchServices }:
     const computedVectorTag = candidateVectorTag;
 
     const computedEnsemble = computedEnsembleIdent ? ensembleSet.findEnsemble(computedEnsembleIdent) : null;
-    const sensitivityNames = computedEnsemble?.getSensitivities()?.getSensitivityNames() ?? [];
+    const sensitivityNames = React.useMemo(
+        () => computedEnsemble?.getSensitivities()?.getSensitivityNames() ?? [],
+        [computedEnsemble]
+    );
+
     React.useEffect(
         function setSensitivitiesOnEnsembleChange() {
             if (!isEqual(selectedSensitivities, sensitivityNames)) {
                 setSelectedSensitivities(sensitivityNames);
             }
         },
-        [computedEnsemble]
+        [computedEnsemble, sensitivityNames, selectedSensitivities, setSelectedSensitivities]
     );
     const sensitivityOptions: SelectOption[] = sensitivityNames.map((name) => ({
         value: name,
@@ -118,7 +122,7 @@ export function settings({ moduleContext, workbenchSession, workbenchServices }:
                 moduleContext.getStateStore().setValue("vectorSpec", null);
             }
         },
-        [computedEnsembleIdent, computedVectorName, hasComputedVectorName, hasHistoricalVector]
+        [computedEnsembleIdent, computedVectorName, hasComputedVectorName, hasHistoricalVector, moduleContext]
     );
 
     function handleEnsembleSelectionChange(newEnsembleIdent: EnsembleIdent | null) {

--- a/frontend/src/modules/SimulationTimeSeriesSensitivity/view.tsx
+++ b/frontend/src/modules/SimulationTimeSeriesSensitivity/view.tsx
@@ -21,7 +21,7 @@ import { TimeSeriesPlotlyTrace, createStatisticalLineTraces } from "./simulation
 import { createLineTrace, createRealizationLineTraces } from "./simulationTimeSeriesChart/traces";
 import { State } from "./state";
 
-export const view = ({
+export const View = ({
     moduleContext,
     workbenchSession,
     workbenchSettings,

--- a/frontend/src/modules/SubsurfaceMap/loadModule.tsx
+++ b/frontend/src/modules/SubsurfaceMap/loadModule.tsx
@@ -1,8 +1,8 @@
 import { ModuleRegistry } from "@framework/ModuleRegistry";
 
-import { settings } from "./settings";
+import { Settings } from "./settings";
 import { state } from "./state";
-import { view } from "./view";
+import { View } from "./view";
 
 const defaultState: state = {
     meshSurfaceAddress: null,
@@ -20,5 +20,5 @@ const module = ModuleRegistry.initModule<state>("SubsurfaceMap", defaultState, {
     surfaceSettings: { deepCompare: true },
 });
 
-module.viewFC = view;
-module.settingsFC = settings;
+module.viewFC = View;
+module.settingsFC = Settings;

--- a/frontend/src/modules/SubsurfaceMap/queryHooks.tsx
+++ b/frontend/src/modules/SubsurfaceMap/queryHooks.tsx
@@ -12,25 +12,20 @@ export function usePropertySurfaceDataByQueryAddress(
     propertySurfAddr: SurfaceAddress | null,
     enabled: boolean
 ): UseQueryResult<SurfaceData_trans> {
-    function dummyApiCall(): Promise<SurfaceData_trans> {
+    function dummyApiCall(): Promise<SurfaceData_api> {
         return new Promise((_resolve, reject) => {
             reject(null);
-        });
-    }
-
-    if (!propertySurfAddr || !meshSurfAddr) {
-        return useQuery({
-            queryKey: ["getSurfaceData_DUMMY_ALWAYS_DISABLED"],
-            queryFn: () => dummyApiCall,
-            enabled: false,
         });
     }
 
     let queryFn: QueryFunction<SurfaceData_api> | null = null;
     let queryKey: QueryKey | null = null;
 
-    // Static, per realization surface
-    if (meshSurfAddr.addressType === "realization" && propertySurfAddr.addressType === "realization") {
+    if (!propertySurfAddr || !meshSurfAddr) {
+        queryKey = ["getSurfaceData_DUMMY_ALWAYS_DISABLED"];
+        queryFn = dummyApiCall;
+        enabled = false;
+    } else if (meshSurfAddr.addressType === "realization" && propertySurfAddr.addressType === "realization") {
         queryKey = [
             "getPropertySurfaceResampledToStaticSurface",
             meshSurfAddr.caseUuid,

--- a/frontend/src/modules/SubsurfaceMap/settings.tsx
+++ b/frontend/src/modules/SubsurfaceMap/settings.tsx
@@ -53,7 +53,7 @@ const TimeTypeEnumToStringMapping = {
     [TimeType.TimePoint]: "Time point",
     [TimeType.Interval]: "Time interval",
 };
-export function settings({ moduleContext, workbenchSession, workbenchServices }: ModuleFCProps<state>) {
+export function Settings({ moduleContext, workbenchSession, workbenchServices }: ModuleFCProps<state>) {
     const myInstanceIdStr = moduleContext.getInstanceIdString();
     console.debug(`${myInstanceIdStr} -- render TopographicMap settings`);
 
@@ -263,7 +263,17 @@ export function settings({ moduleContext, workbenchSession, workbenchServices }:
             console.debug(`propagateSurfaceSelectionToView() => ${surfAddr ? "valid surfAddr" : "NULL surfAddr"}`);
             moduleContext.getStateStore().setValue("meshSurfaceAddress", surfAddr);
         },
-        [selectedEnsembleIdent, selectedMeshSurfaceName, selectedMeshSurfaceAttribute, aggregation, realizationNum]
+        [
+            selectedEnsembleIdent,
+            selectedMeshSurfaceName,
+            selectedMeshSurfaceAttribute,
+            aggregation,
+            realizationNum,
+            computedEnsembleIdent,
+            computedMeshSurfaceName,
+            computedMeshSurfaceAttribute,
+            moduleContext,
+        ]
     );
     React.useEffect(
         function propagatePropertySurfaceSelectionToView() {
@@ -299,6 +309,11 @@ export function settings({ moduleContext, workbenchSession, workbenchServices }:
             aggregation,
             realizationNum,
             usePropertySurface,
+            computedEnsembleIdent,
+            computedPropertySurfaceName,
+            computedPropertySurfaceAttribute,
+            computedPropertyTimeOrInterval,
+            moduleContext,
         ]
     );
     React.useEffect(
@@ -325,6 +340,11 @@ export function settings({ moduleContext, workbenchSession, workbenchServices }:
             showPolygon,
             aggregation,
             realizationNum,
+            computedEnsembleIdent,
+            computedMeshSurfaceName,
+            computedPolygonsName,
+            computedPolygonsAttribute,
+            moduleContext,
         ]
     );
     React.useEffect(
@@ -336,7 +356,7 @@ export function settings({ moduleContext, workbenchSession, workbenchServices }:
                 material: showMaterial,
             });
         },
-        [showContour, contourStartValue, contourIncValue, showGrid, showSmoothShading, showMaterial]
+        [showContour, contourStartValue, contourIncValue, showGrid, showSmoothShading, showMaterial, moduleContext]
     );
     React.useEffect(
         function propogateSubsurfaceMapViewSettingsToView() {
@@ -344,7 +364,7 @@ export function settings({ moduleContext, workbenchSession, workbenchServices }:
                 show3d: show3D,
             });
         },
-        [show3D]
+        [show3D, moduleContext]
     );
 
     const wellHeadersQuery = useWellHeadersQuery(computedEnsembleIdent?.getCaseUuid());

--- a/frontend/src/modules/SubsurfaceMap/view.tsx
+++ b/frontend/src/modules/SubsurfaceMap/view.tsx
@@ -56,7 +56,7 @@ const updateViewPortBounds = (
     return existingViewPortBounds;
 };
 //-----------------------------------------------------------------------------------------------------------
-export function view({ moduleContext, workbenchSettings, workbenchServices }: ModuleFCProps<state>) {
+export function View({ moduleContext, workbenchSettings, workbenchServices }: ModuleFCProps<state>) {
     const myInstanceIdStr = moduleContext.getInstanceIdString();
     console.debug(`${myInstanceIdStr} -- render TopographicMap view`);
     const viewIds = {

--- a/frontend/src/modules/TimeSeriesParameterDistribution/loadModule.tsx
+++ b/frontend/src/modules/TimeSeriesParameterDistribution/loadModule.tsx
@@ -1,17 +1,16 @@
 import { ModuleRegistry } from "@framework/ModuleRegistry";
 
-import { settings } from "./settings";
+import { Settings } from "./settings";
 import { State } from "./state";
-import { view } from "./view";
+import { View } from "./view";
 
 const defaultState: State = {
     vectorSpec: null,
     timestampUtcMs: null,
-    parameterName: undefined
+    parameterName: undefined,
 };
-
 
 const module = ModuleRegistry.initModule<State>("TimeSeriesParameterDistribution", defaultState);
 
-module.viewFC = view;
-module.settingsFC = settings;
+module.viewFC = View;
+module.settingsFC = Settings;

--- a/frontend/src/modules/TimeSeriesParameterDistribution/settings.tsx
+++ b/frontend/src/modules/TimeSeriesParameterDistribution/settings.tsx
@@ -18,7 +18,7 @@ import { useGetParameterNamesQuery, useTimestampsListQuery, useVectorsQuery } fr
 import { State } from "./state";
 
 //-----------------------------------------------------------------------------------------------------------
-export function settings({ moduleContext, workbenchSession, workbenchServices }: ModuleFCProps<State>) {
+export function Settings({ moduleContext, workbenchSession, workbenchServices }: ModuleFCProps<State>) {
     const ensembleSet = useEnsembleSet(workbenchSession);
     const [selectedEnsemble, setSelectedEnsemble] = React.useState<EnsembleIdent | null>(null);
 
@@ -35,7 +35,10 @@ export function settings({ moduleContext, workbenchSession, workbenchServices }:
     const computedEnsemble = fixupEnsembleIdent(candidateEnsemble, ensembleSet);
 
     const vectorsQuery = useVectorsQuery(computedEnsemble?.getCaseUuid(), computedEnsemble?.getEnsembleName());
-    const timestampsQuery = useTimestampsListQuery(computedEnsemble?.getCaseUuid(), computedEnsemble?.getEnsembleName());
+    const timestampsQuery = useTimestampsListQuery(
+        computedEnsemble?.getCaseUuid(),
+        computedEnsemble?.getEnsembleName()
+    );
     const parameterNamesQuery = useGetParameterNamesQuery(
         computedEnsemble?.getCaseUuid(),
         computedEnsemble?.getEnsembleName()
@@ -66,7 +69,7 @@ export function settings({ moduleContext, workbenchSession, workbenchServices }:
                 moduleContext.getStateStore().setValue("vectorSpec", null);
             }
         },
-        [computedEnsemble, computedVectorName]
+        [computedEnsemble, computedVectorName, moduleContext, ensembleSet]
     );
 
     function handleEnsembleSelectionChange(newEnsembleIdent: EnsembleIdent | null) {

--- a/frontend/src/modules/TimeSeriesParameterDistribution/view.tsx
+++ b/frontend/src/modules/TimeSeriesParameterDistribution/view.tsx
@@ -4,16 +4,14 @@ import { ModuleFCProps } from "@framework/Module";
 import { useElementSize } from "@lib/hooks/useElementSize";
 
 import PlotlyScatter from "./plotlyScatterChart";
-
-import { useVectorAtTimestampQuery, useParameterQuery } from "./queryHooks";
+import { useParameterQuery, useVectorAtTimestampQuery } from "./queryHooks";
 import { State } from "./state";
 
-
-export const view = ({ moduleContext }: ModuleFCProps<State>) => {
+export const View = ({ moduleContext }: ModuleFCProps<State>) => {
     const wrapperDivRef = React.useRef<HTMLDivElement>(null);
     const wrapperDivSize = useElementSize(wrapperDivRef);
     const vectorSpec = moduleContext.useStoreValue("vectorSpec");
-    const [highlightedRealization, setHighlightedRealization] = React.useState(-1)
+    const [highlightedRealization, setHighlightedRealization] = React.useState(-1);
     const parameterName = moduleContext.useStoreValue("parameterName");
     const timestampUtcMs = moduleContext.useStoreValue("timestampUtcMs");
 
@@ -24,20 +22,15 @@ export const view = ({ moduleContext }: ModuleFCProps<State>) => {
         timestampUtcMs
     );
 
-    const parameterQuery = useParameterQuery(
-        vectorSpec?.caseUuid,
-        vectorSpec?.ensembleName,
-        parameterName,
-    )
+    const parameterQuery = useParameterQuery(vectorSpec?.caseUuid, vectorSpec?.ensembleName, parameterName);
 
     const handleHoveredRealization = (real: any) => {
-        setHighlightedRealization(real)
-    }
-
+        setHighlightedRealization(real);
+    };
 
     return (
         <div className="w-full h-full" ref={wrapperDivRef}>
-            {parameterQuery.data && vectorAtTimestampQuery.data &&
+            {parameterQuery.data && vectorAtTimestampQuery.data && (
                 <PlotlyScatter
                     x={parameterQuery.data.values as number[]}
                     y={vectorAtTimestampQuery.data.values as number[]}
@@ -47,7 +40,7 @@ export const view = ({ moduleContext }: ModuleFCProps<State>) => {
                     width={wrapperDivSize.width}
                     height={wrapperDivSize.height}
                 />
-            }
+            )}
         </div>
     );
 };

--- a/frontend/src/modules/TornadoChart/loadModule.tsx
+++ b/frontend/src/modules/TornadoChart/loadModule.tsx
@@ -1,8 +1,8 @@
 import { ModuleRegistry } from "@framework/ModuleRegistry";
 
-import { settings } from "./settings";
+import { Settings } from "./settings";
 import { PlotType, State } from "./state";
-import { view } from "./view";
+import { View } from "./view";
 
 const defaultState: State = {
     plotType: PlotType.TORNADO,
@@ -14,5 +14,5 @@ const defaultState: State = {
 
 const module = ModuleRegistry.initModule<State>("TornadoChart", defaultState);
 
-module.viewFC = view;
-module.settingsFC = settings;
+module.viewFC = View;
+module.settingsFC = Settings;

--- a/frontend/src/modules/TornadoChart/sensitivityChart.tsx
+++ b/frontend/src/modules/TornadoChart/sensitivityChart.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 import Plot from "react-plotly.js";
 
 import { SensitivityColorMap } from "@modules/_shared/sensitivityColors";
@@ -188,13 +188,13 @@ const highTrace = (
     };
 };
 
-const sensitivityChart: React.FC<sensitivityChartProps> = (props) => {
-    const [traceDataArr, setTraceDataArr] = useState<Partial<PlotData>[]>([]);
-    const [xAxisRange, setXAxisRange] = useState<[number, number]>([0, 0]);
-    const [selectedBar, setSelectedBar] = useState<SelectedBar | null>(null);
+export const SensitivityChart: React.FC<sensitivityChartProps> = (props) => {
+    const [traceDataArr, setTraceDataArr] = React.useState<Partial<PlotData>[]>([]);
+    const [xAxisRange, setXAxisRange] = React.useState<[number, number]>([0, 0]);
+    const [selectedBar, setSelectedBar] = React.useState<SelectedBar | null>(null);
     const { showLabels, hideZeroY, sensitivityResponseDataset, height, width } = props;
 
-    useEffect(() => {
+    React.useEffect(() => {
         const traces: Partial<PlotData>[] = [];
         let filteredSensitivityResponses = sensitivityResponseDataset.sensitivityResponses;
         if (hideZeroY) {
@@ -215,7 +215,7 @@ const sensitivityChart: React.FC<sensitivityChartProps> = (props) => {
                 filteredSensitivityResponses.map((s) => s.highCaseReferenceDifference)
             )
         );
-    }, [sensitivityResponseDataset, showLabels, hideZeroY, selectedBar]);
+    }, [sensitivityResponseDataset, showLabels, hideZeroY, selectedBar, props.sensitivityColorMap]);
 
     const handleClick = (event: PlotMouseEvent) => {
         const point = event.points[0];
@@ -310,4 +310,4 @@ const sensitivityChart: React.FC<sensitivityChartProps> = (props) => {
     );
 };
 
-export default sensitivityChart;
+SensitivityChart.displayName = "SensitivityChart";

--- a/frontend/src/modules/TornadoChart/settings.tsx
+++ b/frontend/src/modules/TornadoChart/settings.tsx
@@ -7,7 +7,7 @@ import { Label } from "@lib/components/Label";
 
 import { State } from "./state";
 
-export function settings({ moduleContext, workbenchServices }: ModuleFCProps<State>) {
+export function Settings({ moduleContext, workbenchServices }: ModuleFCProps<State>) {
     const sensitivityNames = moduleContext.useStoreValue("sensitivityNames");
     const [referenceSensitivityName, setReferenceSensitivityName] = React.useState<string | null>(null);
     const setModuleReferenceSensitivityName = moduleContext.useSetStoreValue("referenceSensitivityName");
@@ -15,7 +15,7 @@ export function settings({ moduleContext, workbenchServices }: ModuleFCProps<Sta
         function propogateReferenceSensitivityName() {
             setModuleReferenceSensitivityName(referenceSensitivityName);
         },
-        [referenceSensitivityName]
+        [referenceSensitivityName, setModuleReferenceSensitivityName]
     );
 
     if (!referenceSensitivityName && sensitivityNames.length > 0) {

--- a/frontend/src/modules/TornadoChart/view.tsx
+++ b/frontend/src/modules/TornadoChart/view.tsx
@@ -9,7 +9,7 @@ import { BarChart, TableChart, Tune } from "@mui/icons-material";
 
 import { isEqual } from "lodash";
 
-import SensitivityChart from "./sensitivityChart";
+import { SensitivityChart } from "./sensitivityChart";
 import {
     EnsembleScalarResponse,
     SensitivityResponseCalculator,
@@ -20,13 +20,7 @@ import { PlotType, State } from "./state";
 
 import { createSensitivityColorMap } from "../_shared/sensitivityColors";
 
-export const view = ({ moduleContext, workbenchSession, workbenchSettings, initialSettings }: ModuleFCProps<State>) => {
-    // Leave this in until we get a feeling for React18/Plotly
-    const renderCount = React.useRef(0);
-    React.useEffect(function incrementRenderCount() {
-        renderCount.current = renderCount.current + 1;
-    });
-
+export const View = ({ moduleContext, workbenchSession, workbenchSettings, initialSettings }: ModuleFCProps<State>) => {
     const wrapperDivRef = React.useRef<HTMLDivElement>(null);
     const wrapperDivSize = useElementSize(wrapperDivRef);
     const ensembleSet = useEnsembleSet(workbenchSession);
@@ -101,7 +95,7 @@ export const view = ({ moduleContext, workbenchSession, workbenchSettings, initi
                 setAvailableSensitivityNames(sensitivityNames);
             }
         },
-        [sensitivities]
+        [sensitivities, availableSensitivityNames, setAvailableSensitivityNames]
     );
     const colorSet = workbenchSettings.useColorSet();
     const sensitivitiesColorMap = createSensitivityColorMap(
@@ -228,7 +222,6 @@ export const view = ({ moduleContext, workbenchSession, workbenchSettings, initi
                     </div>
                 )}
             </div>
-            <div className="absolute top-10 left-5 italic text-pink-400">(rc={renderCount.current})</div>
         </div>
     );
 };

--- a/frontend/src/modules/WellCompletions/loadModule.tsx
+++ b/frontend/src/modules/WellCompletions/loadModule.tsx
@@ -1,6 +1,6 @@
 import { ModuleRegistry } from "@framework/ModuleRegistry";
 
-import { settings } from "./settings";
+import { Settings } from "./settings";
 import { DataLoadingStatus, State } from "./state";
 import { view } from "./view";
 
@@ -13,4 +13,4 @@ const initialState: State = {
 const module = ModuleRegistry.initModule<State>("WellCompletions", initialState);
 
 module.viewFC = view;
-module.settingsFC = settings;
+module.settingsFC = Settings;

--- a/frontend/src/modules/WellCompletions/settings.tsx
+++ b/frontend/src/modules/WellCompletions/settings.tsx
@@ -115,9 +115,7 @@ export const Settings = ({ moduleContext, workbenchSession, workbenchServices }:
 
             // Update available time steps
             const allTimeSteps = wellCompletionsDataAccessor.current.getTimeSteps();
-            if (availableTimeSteps !== allTimeSteps) {
-                setAvailableTimeSteps(allTimeSteps);
-            }
+            setAvailableTimeSteps((prev) => (prev !== allTimeSteps ? allTimeSteps : prev));
 
             // Update selected time step indices if not among available time steps
             let timeStepIndex = selectedTimeStepOptions.timeStepIndex;
@@ -147,14 +145,7 @@ export const Settings = ({ moduleContext, workbenchSession, workbenchServices }:
             }
             createAndSetPlotData(allTimeSteps, timeStepIndex, selectedTimeStepOptions.timeAggregationType);
         },
-        [
-            wellCompletionsQuery.data,
-            selectedTimeStepOptions,
-            availableTimeSteps,
-            setPlotData,
-            setAvailableTimeSteps,
-            createAndSetPlotData,
-        ]
+        [wellCompletionsQuery.data, selectedTimeStepOptions, setPlotData, setAvailableTimeSteps, createAndSetPlotData]
     );
 
     React.useEffect(

--- a/frontend/src/modules/_shared/Polygons/queryHooks.ts
+++ b/frontend/src/modules/_shared/Polygons/queryHooks.ts
@@ -29,36 +29,36 @@ export function usePolygonsDataQueryByAddress(
         });
     }
 
-    if (!polygonsAddress) {
-        return useQuery({
-            queryKey: ["getPolygonsData_DUMMY_ALWAYS_DISABLED"],
-            queryFn: () => dummyApiCall,
-            enabled: false,
-        });
-    }
+    let queryKey: QueryKey | null = null;
+    let queryFn: QueryFunction<PolygonData_api[]> | null = null;
 
-    const queryKey: QueryKey | null = [
-        "getPolygonsData",
-        polygonsAddress.caseUuid,
-        polygonsAddress.ensemble,
-        polygonsAddress.realizationNum,
-        polygonsAddress.name,
-        polygonsAddress.attribute,
-    ];
-    const queryFn: QueryFunction<PolygonData_api[]> = () =>
-        apiService.polygons.getPolygonsData(
+    if (!polygonsAddress) {
+        queryKey = ["getPolygonsData_DUMMY_ALWAYS_DISABLED"];
+        queryFn = dummyApiCall;
+    } else {
+        queryKey = [
+            "getPolygonsData",
             polygonsAddress.caseUuid,
             polygonsAddress.ensemble,
             polygonsAddress.realizationNum,
             polygonsAddress.name,
-            polygonsAddress.attribute
-        );
+            polygonsAddress.attribute,
+        ];
+        queryFn = () =>
+            apiService.polygons.getPolygonsData(
+                polygonsAddress.caseUuid,
+                polygonsAddress.ensemble,
+                polygonsAddress.realizationNum,
+                polygonsAddress.name,
+                polygonsAddress.attribute
+            );
+    }
 
     return useQuery({
         queryKey: queryKey,
         queryFn: queryFn,
-
         staleTime: STALE_TIME,
         gcTime: CACHE_TIME,
+        enabled: Boolean(polygonsAddress),
     });
 }

--- a/frontend/src/modules/_shared/Surface/queryHooks.ts
+++ b/frontend/src/modules/_shared/Surface/queryHooks.ts
@@ -22,25 +22,19 @@ export function useSurfaceDirectoryQuery(
 }
 
 export function useSurfaceDataQueryByAddress(surfAddr: SurfaceAddress | null): UseQueryResult<SurfaceData_trans> {
-    function dummyApiCall(): Promise<SurfaceData_trans> {
+    function dummyApiCall(): Promise<SurfaceData_api> {
         return new Promise((_resolve, reject) => {
             reject(null);
-        });
-    }
-
-    if (!surfAddr) {
-        return useQuery({
-            queryKey: ["getSurfaceData_DUMMY_ALWAYS_DISABLED"],
-            queryFn: () => dummyApiCall,
-            enabled: false,
         });
     }
 
     let queryFn: QueryFunction<SurfaceData_api> | null = null;
     let queryKey: QueryKey | null = null;
 
-    // Dynamic, per realization surface
-    if (surfAddr.addressType === "realization") {
+    if (surfAddr === null) {
+        queryKey = ["getSurfaceData_DUMMY_ALWAYS_DISABLED"];
+        queryFn = dummyApiCall;
+    } else if (surfAddr.addressType === "realization") {
         queryKey = [
             "getRealizationSurfaceData",
             surfAddr.caseUuid,
@@ -59,10 +53,7 @@ export function useSurfaceDataQueryByAddress(surfAddr: SurfaceAddress | null): U
                 surfAddr.attribute,
                 surfAddr.isoDateOrInterval ?? undefined
             );
-    }
-
-    // Dynamic, statistical surface
-    else if (surfAddr.addressType === "statistical") {
+    } else if (surfAddr.addressType === "statistical") {
         queryKey = [
             "getStatisticalSurfaceData",
             surfAddr.caseUuid,
@@ -91,5 +82,6 @@ export function useSurfaceDataQueryByAddress(surfAddr: SurfaceAddress | null): U
         select: transformSurfaceData,
         staleTime: STALE_TIME,
         gcTime: CACHE_TIME,
+        enabled: Boolean(surfAddr),
     });
 }


### PR DESCRIPTION
This PR takes in use the recommended rules for `react` and `react-hooks`. It also implements the required changes to the codebase, e.g. missing dependencies in `useEffect`, non-standard-conform hook and component names, non-reference-stable state setters (e.g. in `StateStore`), and possibly changed references in unmount functions. It does also fix a bug in `TableSelect` which led to a jumping behaviour of the scrollbar.

Note: According to the React documentation, reference-stable variables (like state setters) do not need to be passed to dependency arrays. However, the `rules-of-hooks` plugin is not adjusted yet and requires this. In order to benefit from its other bug identification features/advantages, we are now adjusting to its requirements.