### PR TITLE
Adjust warning message for statusWriter in SimulationTimeSeriesMatrix module

### DIFF
--- a/frontend/src/modules/SimulationTimeSeriesMatrix/view.tsx
+++ b/frontend/src/modules/SimulationTimeSeriesMatrix/view.tsx
@@ -133,7 +133,7 @@ export const View = ({ moduleContext, workbenchSession, workbenchSettings }: Mod
         data: SummaryVectorObservations_api;
     }[] = [];
     vectorObservationsQueries.ensembleVectorObservationDataMap.forEach((ensembleObservationData, ensembleIdent) => {
-        if (!ensembleObservationData.hasSummaryObservations) {
+        if (showObservations && !ensembleObservationData.hasSummaryObservations) {
             const ensembleName = ensembleSet.findEnsemble(ensembleIdent)?.getDisplayName() ?? ensembleIdent.toString();
             statusWriter.addWarning(`${ensembleName} has no observations.`);
             return;


### PR DESCRIPTION
Correct/fix warning messages to show correct content

- Ensure warning message with non existing vectors when selecting single ensemble without vectors.
- Only show message for non-existing vector observations when `showObservations` is selected/true