### PR TITLE
Add vds envvar to user session

### DIFF
--- a/radixconfig.yml
+++ b/radixconfig.yml
@@ -130,6 +130,8 @@ spec:
                 envVar: WEBVIZ_SMDA_RESOURCE_SCOPE
               - name: WEBVIZ-SMDA-SUBSCRIPTION-KEY
                 envVar: WEBVIZ_SMDA_SUBSCRIPTION_KEY
+              - name: WEBVIZ-VDS-HOST-ADDRESS
+                envVar: WEBVIZ_VDS_HOST_ADDRESS
       variables:
         UVICORN_PORT: 8000
         UVICORN_ENTRYPOINT: src.backend.user_session.main:app


### PR DESCRIPTION
As primary and session code shares same config and code, this env var is necessary.
