### PR TITLE
Parameter distribution Matrix show underlying data

### DIFF
--- a/frontend/src/modules/ParameterDistributionMatrix/settings/settings.tsx
+++ b/frontend/src/modules/ParameterDistributionMatrix/settings/settings.tsx
@@ -38,6 +38,8 @@ export function Settings({ settingsContext, workbenchSession }: ModuleSettingsPr
 
     const [selectedVisualizationType, setSelectedVisualizationType] =
         settingsContext.useSettingsToViewInterfaceState("selectedVisualizationType");
+    const [showIndividualRealizationValues, setShowIndividualRealizationValues] =
+        settingsContext.useSettingsToViewInterfaceState("showIndividualRealizationValues");
 
     function handleEnsembleSelectionChange(ensembleIdents: EnsembleIdent[]) {
         setSelectedEnsembleIdents(ensembleIdents);
@@ -55,6 +57,9 @@ export function Settings({ settingsContext, workbenchSession }: ModuleSettingsPr
     function handleVisualizationTypeChange(event: React.ChangeEvent<HTMLInputElement>) {
         setSelectedVisualizationType(event.target.value as ParameterDistributionPlotType);
     }
+    function handleShowIndividualRealizationValuesChange(_: React.ChangeEvent<HTMLInputElement>, checked: boolean) {
+        setShowIndividualRealizationValues(checked);
+    }
 
     return (
         <div className="flex flex-col gap-2">
@@ -65,6 +70,13 @@ export function Settings({ settingsContext, workbenchSession }: ModuleSettingsPr
                     })}
                     value={selectedVisualizationType}
                     onChange={handleVisualizationTypeChange}
+                />
+            </CollapsibleGroup>
+            <CollapsibleGroup title="Plot options" expanded>
+                <Checkbox
+                    label="Show individual realization values"
+                    checked={showIndividualRealizationValues}
+                    onChange={handleShowIndividualRealizationValuesChange}
                 />
             </CollapsibleGroup>
             <CollapsibleGroup title="Ensembles" expanded>

--- a/frontend/src/modules/ParameterDistributionMatrix/settings/settings.tsx
+++ b/frontend/src/modules/ParameterDistributionMatrix/settings/settings.tsx
@@ -78,16 +78,19 @@ export function Settings({ settingsContext, workbenchSession }: ModuleSettingsPr
                 />
             </CollapsibleGroup>
             <CollapsibleGroup title="Plot options" expanded>
-                <Checkbox
-                    label="Show individual realization values"
-                    checked={showIndividualRealizationValues}
-                    onChange={handleShowIndividualRealizationValuesChange}
-                />
-                <Checkbox
-                    label="Show P10, Mean, P90 lines"
-                    checked={showPercentilesAndMeanLines}
-                    onChange={handleShowPercentilesAndMeanLinesChange}
-                />
+                <div className="flex flex-col gap-2">
+                    {"Show additional data"}
+                    <Checkbox
+                        label="Individual realization values"
+                        checked={showIndividualRealizationValues}
+                        onChange={handleShowIndividualRealizationValuesChange}
+                    />
+                    <Checkbox
+                        label="Markers P10, Mean, P90"
+                        checked={showPercentilesAndMeanLines}
+                        onChange={handleShowPercentilesAndMeanLinesChange}
+                    />
+                </div>
             </CollapsibleGroup>
             <CollapsibleGroup title="Ensembles" expanded>
                 <EnsembleSelect

--- a/frontend/src/modules/ParameterDistributionMatrix/settings/settings.tsx
+++ b/frontend/src/modules/ParameterDistributionMatrix/settings/settings.tsx
@@ -40,6 +40,8 @@ export function Settings({ settingsContext, workbenchSession }: ModuleSettingsPr
         settingsContext.useSettingsToViewInterfaceState("selectedVisualizationType");
     const [showIndividualRealizationValues, setShowIndividualRealizationValues] =
         settingsContext.useSettingsToViewInterfaceState("showIndividualRealizationValues");
+    const [showPercentilesAndMeanLines, setShowPercentilesAndMeanLines] =
+        settingsContext.useSettingsToViewInterfaceState("showPercentilesAndMeanLines");
 
     function handleEnsembleSelectionChange(ensembleIdents: EnsembleIdent[]) {
         setSelectedEnsembleIdents(ensembleIdents);
@@ -60,6 +62,9 @@ export function Settings({ settingsContext, workbenchSession }: ModuleSettingsPr
     function handleShowIndividualRealizationValuesChange(_: React.ChangeEvent<HTMLInputElement>, checked: boolean) {
         setShowIndividualRealizationValues(checked);
     }
+    function handleShowPercentilesAndMeanLinesChange(_: React.ChangeEvent<HTMLInputElement>, checked: boolean) {
+        setShowPercentilesAndMeanLines(checked);
+    }
 
     return (
         <div className="flex flex-col gap-2">
@@ -77,6 +82,11 @@ export function Settings({ settingsContext, workbenchSession }: ModuleSettingsPr
                     label="Show individual realization values"
                     checked={showIndividualRealizationValues}
                     onChange={handleShowIndividualRealizationValuesChange}
+                />
+                <Checkbox
+                    label="Show P10, Mean, P90 lines"
+                    checked={showPercentilesAndMeanLines}
+                    onChange={handleShowPercentilesAndMeanLinesChange}
                 />
             </CollapsibleGroup>
             <CollapsibleGroup title="Ensembles" expanded>

--- a/frontend/src/modules/ParameterDistributionMatrix/settingsToViewInterface.ts
+++ b/frontend/src/modules/ParameterDistributionMatrix/settingsToViewInterface.ts
@@ -8,6 +8,7 @@ import { ParameterDistributionPlotType } from "./typesAndEnums";
 export type Interface = {
     baseStates: {
         selectedVisualizationType: ParameterDistributionPlotType;
+        showIndividualRealizationValues: boolean;
     };
     derivedStates: {
         selectedEnsembleIdents: EnsembleIdent[];
@@ -18,6 +19,7 @@ export type Interface = {
 export const interfaceInitialization: InterfaceInitialization<Interface> = {
     baseStates: {
         selectedVisualizationType: ParameterDistributionPlotType.DISTRIBUTION_PLOT,
+        showIndividualRealizationValues: false,
     },
     derivedStates: {
         selectedEnsembleIdents: (get) => {

--- a/frontend/src/modules/ParameterDistributionMatrix/settingsToViewInterface.ts
+++ b/frontend/src/modules/ParameterDistributionMatrix/settingsToViewInterface.ts
@@ -9,6 +9,7 @@ export type Interface = {
     baseStates: {
         selectedVisualizationType: ParameterDistributionPlotType;
         showIndividualRealizationValues: boolean;
+        showPercentilesAndMeanLines: boolean;
     };
     derivedStates: {
         selectedEnsembleIdents: EnsembleIdent[];
@@ -20,6 +21,7 @@ export const interfaceInitialization: InterfaceInitialization<Interface> = {
     baseStates: {
         selectedVisualizationType: ParameterDistributionPlotType.DISTRIBUTION_PLOT,
         showIndividualRealizationValues: false,
+        showPercentilesAndMeanLines: false,
     },
     derivedStates: {
         selectedEnsembleIdents: (get) => {

--- a/frontend/src/modules/ParameterDistributionMatrix/typesAndEnums.ts
+++ b/frontend/src/modules/ParameterDistributionMatrix/typesAndEnums.ts
@@ -1,12 +1,13 @@
 import { ParameterIdent } from "@framework/EnsembleParameters";
 
-export type EnsembleParameterValues = {
+export type EnsembleParameterRealizationsAndValues = {
     ensembleDisplayName: string;
+    realizations: number[];
     values: number[];
 };
 export type ParameterDataArr = {
     parameterIdent: ParameterIdent;
-    ensembleParameterValues: EnsembleParameterValues[];
+    ensembleParameterRealizationAndValues: EnsembleParameterRealizationsAndValues[];
 };
 
 export enum ParameterDistributionPlotType {

--- a/frontend/src/modules/ParameterDistributionMatrix/view/components/ParameterDistributionPlot.tsx
+++ b/frontend/src/modules/ParameterDistributionMatrix/view/components/ParameterDistributionPlot.tsx
@@ -20,6 +20,9 @@ export const ParameterDistributionPlot: React.FC<ParameterDistributionPlotProps>
     const numRows = Math.ceil(numSubplots / numColumns);
     const addedLegendNames: Set<string> = new Set();
 
+    const showRugTraces =
+        props.plotType == ParameterDistributionPlotType.DISTRIBUTION_PLOT && props.showIndividualRealizationValues;
+
     function generateDistributionPlotTraces(): any[] {
         const traces: any[] = [];
         let subplotIndex = 1;
@@ -34,6 +37,7 @@ export const ParameterDistributionPlot: React.FC<ParameterDistributionPlotProps>
                 const distributionTrace = {
                     x: ensembleValue.values,
                     type: "violin" as PlotType,
+                    spanmode: "hard",
                     name: ensembleValue.ensembleDisplayName,
                     legendgroup: ensembleValue.ensembleDisplayName,
                     marker: { color: props.ensembleColors.get(ensembleValue.ensembleDisplayName) },
@@ -122,7 +126,7 @@ export const ParameterDistributionPlot: React.FC<ParameterDistributionPlotProps>
                     side: "positive",
                     width: 2,
                     points: false,
-                    boxpoints: props.showIndividualRealizationValues ? "all" : false,
+                    boxpoints: props.showIndividualRealizationValues ? "all" : "outliers",
                 };
                 traces.push(trace);
             });
@@ -152,13 +156,10 @@ export const ParameterDistributionPlot: React.FC<ParameterDistributionPlotProps>
                 linecolor: "black",
             };
 
-            const showYAxisZeroLine =
-                props.showIndividualRealizationValues &&
-                props.plotType == ParameterDistributionPlotType.DISTRIBUTION_PLOT;
             layout[`yaxis${i}`] = {
                 showticklabels: false,
                 showgrid: false,
-                zeroline: showYAxisZeroLine,
+                zeroline: showRugTraces,
                 mirror: true,
                 showline: true,
                 linewidth: 1,

--- a/frontend/src/modules/ParameterDistributionMatrix/view/components/ParameterDistributionPlot.tsx
+++ b/frontend/src/modules/ParameterDistributionMatrix/view/components/ParameterDistributionPlot.tsx
@@ -79,12 +79,12 @@ export const ParameterDistributionPlot: React.FC<ParameterDistributionPlotProps>
                     // Distribution plot shows positive values, thus the rug plot is placed below 0.
                     // Align the realization values horizontally below the distribution plot
                     const yPosition = -0.1 - index * 0.1; // Offset -0.1, and 0.1 between each ensemble
-                    const yValues = ensembleData.values.map(() => yPosition); // Align all values to the same y-position
+                    const yValues = ensembleData.values.map(() => yPosition); // Align horizontally with same y-position
 
                     const rugTrace = {
                         x: ensembleData.values, // Use the same x values as your main trace
                         y: yValues,
-                        type: "rug", // Set type to 'rug' for the rug plot
+                        type: "rug",
                         name: ensembleData.ensembleDisplayName,
                         legendgroup: ensembleData.ensembleDisplayName,
                         xaxis: `x${subplotIndex}`,

--- a/frontend/src/modules/ParameterDistributionMatrix/view/view.tsx
+++ b/frontend/src/modules/ParameterDistributionMatrix/view/view.tsx
@@ -23,6 +23,9 @@ export function View(props: ModuleViewProps<State, Interface>) {
     const showIndividualRealizationValues = props.viewContext.useSettingsToViewInterfaceValue(
         "showIndividualRealizationValues"
     );
+    const showPercentilesAndMeanLines =
+        props.viewContext.useSettingsToViewInterfaceValue("showPercentilesAndMeanLines");
+
     const ensembleSet = props.workbenchSession.getEnsembleSet();
     const filterEnsembleRealizationsFunc = useEnsembleRealizationFilterFunc(props.workbenchSession);
 
@@ -47,6 +50,7 @@ export function View(props: ModuleViewProps<State, Interface>) {
                 ensembleColors={ensembleColors}
                 plotType={selectedVisualizationType}
                 showIndividualRealizationValues={showIndividualRealizationValues}
+                showPercentilesAndMeanLines={showPercentilesAndMeanLines}
                 width={wrapperDivSize.width}
                 height={wrapperDivSize.height}
             ></ParameterDistributionPlot>

--- a/frontend/src/modules/ParameterDistributionMatrix/view/view.tsx
+++ b/frontend/src/modules/ParameterDistributionMatrix/view/view.tsx
@@ -20,6 +20,9 @@ export function View(props: ModuleViewProps<State, Interface>) {
     const selectedEnsembleIdents = props.viewContext.useSettingsToViewInterfaceValue("selectedEnsembleIdents");
     const selectedParameterIdents = props.viewContext.useSettingsToViewInterfaceValue("selectedParameterIdents");
     const selectedVisualizationType = props.viewContext.useSettingsToViewInterfaceValue("selectedVisualizationType");
+    const showIndividualRealizationValues = props.viewContext.useSettingsToViewInterfaceValue(
+        "showIndividualRealizationValues"
+    );
     const ensembleSet = props.workbenchSession.getEnsembleSet();
     const filterEnsembleRealizationsFunc = useEnsembleRealizationFilterFunc(props.workbenchSession);
 
@@ -43,6 +46,7 @@ export function View(props: ModuleViewProps<State, Interface>) {
                 dataArr={parameterDataArr}
                 ensembleColors={ensembleColors}
                 plotType={selectedVisualizationType}
+                showIndividualRealizationValues={showIndividualRealizationValues}
                 width={wrapperDivSize.width}
                 height={wrapperDivSize.height}
             ></ParameterDistributionPlot>
@@ -61,7 +65,7 @@ function makeParameterDataArr(
     for (const parameterIdent of parameterIdents) {
         const parameterDataArrEntry: ParameterDataArr = {
             parameterIdent: parameterIdent,
-            ensembleParameterValues: [],
+            ensembleParameterRealizationAndValues: [],
         };
 
         for (const ensembleIdent of ensembleIdents) {
@@ -71,28 +75,28 @@ function makeParameterDataArr(
             const ensembleParameters = ensemble.getParameters();
             if (!ensembleParameters.hasParameter(parameterIdent)) continue;
 
+            const filteredRealizations = new Set(filterEnsembleRealizations(ensembleIdent));
             const parameter = ensembleParameters.getParameter(parameterIdent);
 
-            const filteredRealizations = new Set(filterEnsembleRealizations(ensembleIdent));
-
-            const parameterValues = parameter.realizations
-                .map((realization, index) => {
-                    if (filteredRealizations.has(realization)) {
-                        return parameter.values[index] as number;
-                    }
-                    return null;
-                })
-                .filter((value) => value !== null);
+            const parameterValues: number[] = [];
+            const realizationNumbers: number[] = [];
+            parameter.realizations.forEach((realization, index) => {
+                if (filteredRealizations.has(realization)) {
+                    parameterValues.push(parameter.values[index] as number);
+                    realizationNumbers.push(realization);
+                }
+            });
 
             const ensembleParameterValues = {
                 ensembleDisplayName: ensemble.getDisplayName(),
-                values: parameterValues as number[],
+                values: parameterValues,
+                realizations: realizationNumbers,
             };
 
-            parameterDataArrEntry.ensembleParameterValues.push(ensembleParameterValues);
+            parameterDataArrEntry.ensembleParameterRealizationAndValues.push(ensembleParameterValues);
         }
 
-        if (parameterDataArrEntry.ensembleParameterValues.length > 0) {
+        if (parameterDataArrEntry.ensembleParameterRealizationAndValues.length > 0) {
             parameterDataArr.push(parameterDataArrEntry);
         }
     }

--- a/frontend/src/modules/_shared/statistics.ts
+++ b/frontend/src/modules/_shared/statistics.ts
@@ -7,7 +7,7 @@ export const computeQuantile = (data: number[], quantile: number): number => {
     if (data.length === 0) {
         return 0;
     }
-    if (data.length === 0) {
+    if (data.length === 1) {
         return data[0];
     }
     const sortedValues = data.sort((a, b) => a - b);
@@ -24,4 +24,4 @@ export const computeQuantile = (data: number[], quantile: number): number => {
         const fraction = rank - lowerRank;
         return sortedValues[lowerRank] * (1 - fraction) + sortedValues[lowerRank + 1] * fraction;
     }
-}
+};


### PR DESCRIPTION
- Show individual realization values (check box enabling), with hover info
- Show P10, mean and P90 as markers, i.e. x-symbols along the 0-axis for the ensemble (check box enabling).
- Bug fixes