### PR TITLE
Fixed bug where scrolling is not detected

### DIFF
--- a/frontend/src/lib/hooks/useElementBoundingRect.ts
+++ b/frontend/src/lib/hooks/useElementBoundingRect.ts
@@ -44,8 +44,8 @@ export function useElementBoundingRect(ref: React.RefObject<HTMLElement | SVGSVG
 
         const resizeObserver = new ResizeObserver(handleResizeAndScroll);
         const mutationObserver = new MutationObserver(handleMutations);
-        window.addEventListener("resize", handleResizeAndScroll);
-        window.addEventListener("scroll", handleResizeAndScroll);
+        window.addEventListener("resize", handleResizeAndScroll, true);
+        window.addEventListener("scroll", handleResizeAndScroll, true);
 
         if (ref.current) {
             handleResizeAndScroll();
@@ -61,8 +61,8 @@ export function useElementBoundingRect(ref: React.RefObject<HTMLElement | SVGSVG
         return () => {
             resizeObserver.disconnect();
             mutationObserver.disconnect();
-            window.removeEventListener("resize", handleResizeAndScroll);
-            window.removeEventListener("scroll", handleResizeAndScroll);
+            window.removeEventListener("resize", handleResizeAndScroll, true);
+            window.removeEventListener("scroll", handleResizeAndScroll, true);
         };
     }, [ref]);
 


### PR DESCRIPTION
Set `useCapture` to true in order to capture all scroll events for any child of `window`.