### PR TITLE
Simulation Time Series: Prevent unnecessary fetch of individual realization data

### DIFF
--- a/frontend/src/modules/SimulationTimeSeries/view/atoms/atomDefinitions.ts
+++ b/frontend/src/modules/SimulationTimeSeries/view/atoms/atomDefinitions.ts
@@ -62,6 +62,11 @@ export function viewAtomsInitialization(
     const vectorDataQueriesAtom = atomWithQueries((get) => {
         const vectorSpecifications = get(settingsToViewInterface.getAtom("vectorSpecifications"));
         const resampleFrequency = get(settingsToViewInterface.getAtom("resampleFrequency"));
+        const visualizationMode = get(settingsToViewInterface.getAtom("visualizationMode"));
+
+        const enabled =
+            visualizationMode === VisualizationMode.INDIVIDUAL_REALIZATIONS ||
+            visualizationMode === VisualizationMode.STATISTICS_AND_REALIZATIONS;
 
         const queries = vectorSpecifications.map((item) => {
             return () => ({
@@ -82,6 +87,7 @@ export function viewAtomsInitialization(
                 staleTime: STALE_TIME,
                 gcTime: CACHE_TIME,
                 enabled: !!(
+                    enabled &&
                     item.vectorName &&
                     item.ensembleIdent.getCaseUuid() &&
                     item.ensembleIdent.getEnsembleName()

--- a/frontend/src/modules/SimulationTimeSeriesMatrix/view.tsx
+++ b/frontend/src/modules/SimulationTimeSeriesMatrix/view.tsx
@@ -91,13 +91,22 @@ export const View = ({ viewContext, workbenchSession, workbenchSettings }: Modul
     });
 
     // Queries
-    const vectorDataQueries = useVectorDataQueries(vectorSpecifications, resampleFrequency, true);
+    const doFetchIndividualRealizationsData =
+        visualizationMode === VisualizationMode.INDIVIDUAL_REALIZATIONS ||
+        visualizationMode === VisualizationMode.STATISTICS_AND_REALIZATIONS;
+    const doFetchStatisticsData =
+        visualizationMode === VisualizationMode.STATISTICAL_FANCHART ||
+        visualizationMode === VisualizationMode.STATISTICAL_LINES ||
+        visualizationMode === VisualizationMode.STATISTICS_AND_REALIZATIONS;
+    const vectorDataQueries = useVectorDataQueries(
+        vectorSpecifications,
+        resampleFrequency,
+        doFetchIndividualRealizationsData
+    );
     const vectorStatisticsQueries = useStatisticalVectorDataQueries(
         vectorSpecifications,
         resampleFrequency,
-        visualizationMode === VisualizationMode.STATISTICAL_FANCHART ||
-            visualizationMode === VisualizationMode.STATISTICAL_LINES ||
-            visualizationMode === VisualizationMode.STATISTICS_AND_REALIZATIONS
+        doFetchStatisticsData
     );
 
     const vectorSpecificationsWithHistoricalData = vectorSpecifications?.filter((vec) => vec.hasHistoricalVector);


### PR DESCRIPTION
Add enable flag for fetching individual realization data for `SimulationTimeSeries`- and `SimulationTimeSeriesMatrix`-module

Closes: #632