### PR TITLE
Work around bug in Sumo Explorer that reports too few iterations/ensembles

### DIFF
--- a/backend_py/primary/primary/services/sumo_access/case_inspector.py
+++ b/backend_py/primary/primary/services/sumo_access/case_inspector.py
@@ -30,7 +30,9 @@ class CaseInspector:
         return self._case.name
 
     async def get_iterations_async(self) -> list[IterationInfo]:
-        iterations = await self._case.iterations_async
+        # Stick with the sync version for now, since there is a bug in the async version of SumoExplorer
+        # See: https://github.com/equinor/fmu-sumo/issues/326
+        iterations = self._case.iterations
 
         iter_info_arr: list[IterationInfo] = []
         for iteration in iterations:


### PR DESCRIPTION
There is a bug in Sumo Explorer's `Case.iterations_async`
Revert back to using the sync version of `Case.iterations` instead of `Case.iterations_async` until this has been remedied.

See also: https://github.com/equinor/fmu-sumo/issues/326

