### PR TITLE
Lazy initialization of Sumo `Case` object in `CaseInspector`

### DIFF
--- a/backend_py/primary/primary/routers/explore.py
+++ b/backend_py/primary/primary/routers/explore.py
@@ -71,7 +71,7 @@ async def get_ensembles(
     case_uuid: str = Path(description="Sumo case uuid"),
 ) -> List[EnsembleInfo]:
     """Get list of ensembles for a case"""
-    case_inspector = await CaseInspector.from_case_uuid_async(authenticated_user.get_sumo_access_token(), case_uuid)
+    case_inspector = CaseInspector.from_case_uuid(authenticated_user.get_sumo_access_token(), case_uuid)
     iteration_info_arr = await case_inspector.get_iterations_async()
 
     print(iteration_info_arr)
@@ -87,8 +87,8 @@ async def get_ensemble_details(
 ) -> EnsembleDetails:
     """Get more detailed information for an ensemble"""
 
-    case_inspector = await CaseInspector.from_case_uuid_async(authenticated_user.get_sumo_access_token(), case_uuid)
-    case_name = case_inspector.get_case_name()
+    case_inspector = CaseInspector.from_case_uuid(authenticated_user.get_sumo_access_token(), case_uuid)
+    case_name = await case_inspector.get_case_name_async()
     realizations = await case_inspector.get_realizations_in_iteration_async(ensemble_name)
     field_identifiers = await case_inspector.get_field_identifiers_async()
 

--- a/backend_py/primary/primary/routers/polygons/router.py
+++ b/backend_py/primary/primary/routers/polygons/router.py
@@ -33,7 +33,7 @@ async def get_polygons_directory(
     )
     polygons_dir = await access.get_polygons_directory_async()
 
-    case_inspector = await CaseInspector.from_case_uuid_async(authenticated_user.get_sumo_access_token(), case_uuid)
+    case_inspector = CaseInspector.from_case_uuid(authenticated_user.get_sumo_access_token(), case_uuid)
     strat_column_identifier = await case_inspector.get_stratigraphic_column_identifier_async()
     strat_access: Union[StratigraphyAccess, _mocked_stratigraphy_access.StratigraphyAccess]
 

--- a/backend_py/primary/primary/routers/surface/router.py
+++ b/backend_py/primary/primary/routers/surface/router.py
@@ -40,7 +40,7 @@ async def get_surface_directory(
     )
     sumo_surf_dir = await surface_access.get_surface_directory_async()
 
-    case_inspector = await CaseInspector.from_case_uuid_async(authenticated_user.get_sumo_access_token(), case_uuid)
+    case_inspector = CaseInspector.from_case_uuid(authenticated_user.get_sumo_access_token(), case_uuid)
     strat_column_identifier = await case_inspector.get_stratigraphic_column_identifier_async()
     strat_access: Union[StratigraphyAccess, _mocked_stratigraphy_access.StratigraphyAccess]
 

--- a/backend_py/primary/primary/routers/well/router.py
+++ b/backend_py/primary/primary/routers/well/router.py
@@ -29,7 +29,7 @@ async def get_well_headers(
 ) -> List[WellBoreHeader]:
     """Get well headers for all wells in the field"""
 
-    case_inspector = await CaseInspector.from_case_uuid_async(authenticated_user.get_sumo_access_token(), case_uuid)
+    case_inspector = CaseInspector.from_case_uuid(authenticated_user.get_sumo_access_token(), case_uuid)
     field_identifier = (await case_inspector.get_field_identifiers_async())[0]
     well_access: Union[WellAccess, mocked_drogon_smda_access.WellAccess]
     if field_identifier == "DROGON":
@@ -50,7 +50,7 @@ async def get_field_well_trajectories(
     # fmt:on
 ) -> List[WellBoreTrajectory]:
     """Get well trajectories for field"""
-    case_inspector = await CaseInspector.from_case_uuid_async(authenticated_user.get_sumo_access_token(), case_uuid)
+    case_inspector = CaseInspector.from_case_uuid(authenticated_user.get_sumo_access_token(), case_uuid)
     field_identifier = (await case_inspector.get_field_identifiers_async())[0]
     well_access: Union[WellAccess, mocked_drogon_smda_access.WellAccess]
     if field_identifier == "DROGON":
@@ -95,7 +95,7 @@ async def get_wellbore_picks_and_stratigraphic_units(
     well_access: Union[WellAccess, mocked_drogon_smda_access.WellAccess]
     stratigraphy_access: Union[StratigraphyAccess, mocked_drogon_smda_access.StratigraphyAccess]
 
-    case_inspector = await CaseInspector.from_case_uuid_async(authenticated_user.get_sumo_access_token(), case_uuid)
+    case_inspector = CaseInspector.from_case_uuid(authenticated_user.get_sumo_access_token(), case_uuid)
     stratigraphic_column_identifier = await case_inspector.get_stratigraphic_column_identifier_async()
 
     # Handle DROGON

--- a/backend_py/primary/primary/services/sumo_access/case_inspector.py
+++ b/backend_py/primary/primary/services/sumo_access/case_inspector.py
@@ -14,25 +14,35 @@ class IterationInfo(BaseModel):
 
 
 class CaseInspector:
-    def __init__(self, sumo_client: SumoClient, case: Case, case_uuid: str):
+    def __init__(self, sumo_client: SumoClient, case_uuid: str):
         self._sumo_client = sumo_client
-        self._case = case
         self._case_uuid = case_uuid
+        self._cached_case_obj: Case | None = None
 
     @classmethod
-    async def from_case_uuid_async(cls, access_token: str, case_uuid: str) -> "CaseInspector":
+    def from_case_uuid(cls, access_token: str, case_uuid: str) -> "CaseInspector":
         sumo_client: SumoClient = create_sumo_client(access_token)
-        case: Case = await create_sumo_case_async(client=sumo_client, case_uuid=case_uuid, want_keepalive_pit=False)
-        return CaseInspector(sumo_client=sumo_client, case=case, case_uuid=case_uuid)
+        return CaseInspector(sumo_client=sumo_client, case_uuid=case_uuid)
 
-    def get_case_name(self) -> str:
+    async def _get_or_create_case_obj(self) -> Case:
+        if not self._cached_case_obj:
+            self._cached_case_obj = await create_sumo_case_async(
+                client=self._sumo_client, case_uuid=self._case_uuid, want_keepalive_pit=False
+            )
+
+        return self._cached_case_obj
+
+    async def get_case_name_async(self) -> str:
         """Get name of the case"""
-        return self._case.name
+        case: Case = await self._get_or_create_case_obj()
+        return case.name
 
     async def get_iterations_async(self) -> list[IterationInfo]:
+        case: Case = await self._get_or_create_case_obj()
+
         # Stick with the sync version for now, since there is a bug in the async version of SumoExplorer
         # See: https://github.com/equinor/fmu-sumo/issues/326
-        iterations = self._case.iterations
+        iterations = case.iterations
 
         iter_info_arr: list[IterationInfo] = []
         for iteration in iterations:
@@ -47,7 +57,8 @@ class CaseInspector:
 
     async def get_realizations_in_iteration_async(self, iteration_name: str) -> list[int]:
         """Get list of realizations for the specified iteration"""
-        realization_list = await self._case.get_realizations_async(iteration_name)
+        case: Case = await self._get_or_create_case_obj()
+        realization_list = await case.get_realizations_async(iteration_name)
         return sorted([int(real) for real in realization_list])
 
     async def get_stratigraphic_column_identifier_async(self) -> str:

--- a/backend_py/primary/primary/services/sumo_access/dev/dev_summary_access_test_driver.py
+++ b/backend_py/primary/primary/services/sumo_access/dev/dev_summary_access_test_driver.py
@@ -125,7 +125,7 @@ async def main() -> None:
         print("The sumo case id was not found")
         sys.exit(1)
 
-    case_inspector = await CaseInspector.from_case_uuid_async(access_token, sumo_case_id)
+    case_inspector = CaseInspector.from_case_uuid(access_token, sumo_case_id)
     iteration_list = await case_inspector.get_iterations_async()
     print("\n\n")
     for iteration_info in iteration_list:


### PR DESCRIPTION
Do lazy initialization of the Sumo `Case` object in `CaseInspector` to avoid the server roundtrip unless it is actually being used