### PR TITLE
Adjust gap for RadioGroup component

### DIFF
--- a/frontend/src/lib/components/RadioGroup/radioGroup.tsx
+++ b/frontend/src/lib/components/RadioGroup/radioGroup.tsx
@@ -83,7 +83,7 @@ export function RadioGroup<T extends string | number>(props: RadioGroupProps<T>)
             >
                 <span>{props.name}</span>
                 <div
-                    className={resolveClassNames("flex", "radio-group", "gap-3", {
+                    className={resolveClassNames("flex", "radio-group", "gap-y-1", "gap-x-3", {
                         "flex-col": props.direction !== "horizontal",
                     })}
                 >


### PR DESCRIPTION
Decrease the gap, as items takes up too much space.

Vertically: gap-1 seems to be a reasonable gap
Horizontally: gap-3 seems suitable to separate text of a radio group element to the radio button of next radio group element.


Closes: #743