### PR TITLE
Refactor: Make smda access use field ident only when neccessary

### DIFF
--- a/backend_py/primary/primary/routers/polygons/router.py
+++ b/backend_py/primary/primary/routers/polygons/router.py
@@ -34,14 +34,13 @@ async def get_polygons_directory(
     polygons_dir = await access.get_polygons_directory_async()
 
     case_inspector = CaseInspector.from_case_uuid(authenticated_user.get_sumo_access_token(), case_uuid)
-    field_identifiers = await case_inspector.get_field_identifiers_async()
     strat_column_identifier = await case_inspector.get_stratigraphic_column_identifier_async()
     smda_access: Union[SmdaAccess, DrogonSmdaAccess]
 
     if strat_column_identifier == "DROGON_HAS_NO_STRATCOLUMN":
         smda_access = DrogonSmdaAccess()
     else:
-        smda_access = SmdaAccess(authenticated_user.get_smda_access_token(), field_identifier=field_identifiers[0])
+        smda_access = SmdaAccess(authenticated_user.get_smda_access_token())
     strat_units = await smda_access.get_stratigraphic_units(strat_column_identifier)
     sorted_stratigraphic_surfaces = sort_stratigraphic_names_by_hierarchy(strat_units)
 

--- a/backend_py/primary/primary/routers/surface/router.py
+++ b/backend_py/primary/primary/routers/surface/router.py
@@ -319,7 +319,6 @@ async def _get_stratigraphic_units_for_case_async(
     perf_metrics = PerfMetrics()
 
     case_inspector = CaseInspector.from_case_uuid(authenticated_user.get_sumo_access_token(), case_uuid)
-    field_identifiers = await case_inspector.get_field_identifiers_async()
     strat_column_identifier = await case_inspector.get_stratigraphic_column_identifier_async()
     perf_metrics.record_lap("get-strat-ident")
 
@@ -327,7 +326,7 @@ async def _get_stratigraphic_units_for_case_async(
     if strat_column_identifier == "DROGON_HAS_NO_STRATCOLUMN":
         smda_access = DrogonSmdaAccess()
     else:
-        smda_access = SmdaAccess(authenticated_user.get_smda_access_token(), field_identifier=field_identifiers[0])
+        smda_access = SmdaAccess(authenticated_user.get_smda_access_token())
 
     strat_units = await smda_access.get_stratigraphic_units(strat_column_identifier)
     perf_metrics.record_lap("get-strat-units")

--- a/backend_py/primary/primary/routers/well/router.py
+++ b/backend_py/primary/primary/routers/well/router.py
@@ -31,9 +31,9 @@ async def get_drilled_wellbore_headers(
         # Handle DROGON
         well_access = DrogonSmdaAccess()
     else:
-        well_access = SmdaAccess(authenticated_user.get_smda_access_token(), field_identifier=field_identifier)
+        well_access = SmdaAccess(authenticated_user.get_smda_access_token())
 
-    wellbore_headers = await well_access.get_wellbore_headers()
+    wellbore_headers = await well_access.get_wellbore_headers(field_identifier)
 
     return [converters.convert_wellbore_header_to_schema(wellbore_header) for wellbore_header in wellbore_headers]
 
@@ -52,9 +52,12 @@ async def get_well_trajectories(
         # Handle DROGON
         well_access = DrogonSmdaAccess()
     else:
-        well_access = SmdaAccess(authenticated_user.get_smda_access_token(), field_identifier=field_identifier)
+        well_access = SmdaAccess(authenticated_user.get_smda_access_token())
 
-    wellbore_trajectories = await well_access.get_wellbore_trajectories(wellbore_uuids=wellbore_uuids)
+    wellbore_trajectories = await well_access.get_wellbore_trajectories(
+        field_identifier=field_identifier,
+        wellbore_uuids=wellbore_uuids,
+    )
 
     return [
         converters.convert_well_trajectory_to_schema(wellbore_trajectory)
@@ -66,18 +69,17 @@ async def get_well_trajectories(
 async def get_wellbore_pick_identifiers(
     # fmt:off
     authenticated_user: AuthenticatedUser = Depends(AuthHelper.get_authenticated_user),
-    field_identifier: str = Query(description="Official field identifier"),
     strat_column_identifier: str = Query(description="Stratigraphic column identifier")
     # fmt:on
 ) -> List[str]:
     """Get wellbore pick identifiers for field and stratigraphic column"""
     well_access: Union[SmdaAccess, DrogonSmdaAccess]
-    if field_identifier == "DROGON":
+    if strat_column_identifier == "DROGON_HAS_NO_STRATCOLUMN":
         # Handle DROGON
         well_access = DrogonSmdaAccess()
 
     else:
-        well_access = SmdaAccess(authenticated_user.get_smda_access_token(), field_identifier=field_identifier)
+        well_access = SmdaAccess(authenticated_user.get_smda_access_token())
 
     wellbore_picks = await well_access.get_wellbore_pick_identifiers_in_stratigraphic_column(
         strat_column_identifier=strat_column_identifier
@@ -100,9 +102,12 @@ async def get_wellbore_picks_for_pick_identifier(
         well_access = DrogonSmdaAccess()
 
     else:
-        well_access = SmdaAccess(authenticated_user.get_smda_access_token(), field_identifier=field_identifier)
+        well_access = SmdaAccess(authenticated_user.get_smda_access_token())
 
-    wellbore_picks = await well_access.get_wellbore_picks_for_pick_identifier(pick_identifier=pick_identifier)
+    wellbore_picks = await well_access.get_wellbore_picks_for_pick_identifier(
+        field_identifier=field_identifier,
+        pick_identifier=pick_identifier,
+    )
     return [converters.convert_wellbore_pick_to_schema(wellbore_pick) for wellbore_pick in wellbore_picks]
 
 
@@ -110,18 +115,17 @@ async def get_wellbore_picks_for_pick_identifier(
 async def get_wellbore_picks_for_wellbore(
     # fmt:off
     authenticated_user: AuthenticatedUser = Depends(AuthHelper.get_authenticated_user),
-    field_identifier: str = Query(description="Official field identifier"),
     wellbore_uuid: str = Query(description="Wellbore uuid")
     # fmt:on
 ) -> List[schemas.WellborePick]:
     """Get wellbore picks for field and pick identifier"""
     well_access: Union[SmdaAccess, DrogonSmdaAccess]
-    if field_identifier == "DROGON":
+    if wellbore_uuid in ["drogon_horizontal", "drogon_vertical"]:
         # Handle DROGON
         well_access = DrogonSmdaAccess()
 
     else:
-        well_access = SmdaAccess(authenticated_user.get_smda_access_token(), field_identifier=field_identifier)
+        well_access = SmdaAccess(authenticated_user.get_smda_access_token())
 
     wellbore_picks = await well_access.get_wellbore_picks_for_wellbore(wellbore_uuid=wellbore_uuid)
     return [converters.convert_wellbore_pick_to_schema(wellbore_pick) for wellbore_pick in wellbore_picks]

--- a/backend_py/primary/primary/services/smda_access/drogon/drogon_smda_access.py
+++ b/backend_py/primary/primary/services/smda_access/drogon/drogon_smda_access.py
@@ -18,11 +18,14 @@ class SmdaAccess:
     async def get_stratigraphic_units(self, stratigraphic_column_identifier: str) -> List[StratigraphicUnit]:
         return get_drogon_strat_units()
 
-    async def get_wellbore_headers(self) -> List[WellboreHeader]:
+    # pylint: disable=unused-argument
+    async def get_wellbore_headers(self, field_identififer: str) -> List[WellboreHeader]:
         """Get Drogon wellbore headers"""
         return get_drogon_well_headers()
 
-    async def get_wellbore_trajectories(self, wellbore_uuids: Optional[List[str]] = None) -> List[WellboreTrajectory]:
+    async def get_wellbore_trajectories(
+        self, field_identifier: str, wellbore_uuids: Optional[List[str]] = None
+    ) -> List[WellboreTrajectory]:
         """Get all Drogon trajectories"""
         all_well_trajs = get_drogon_well_trajectories()
         if wellbore_uuids:
@@ -40,6 +43,7 @@ class SmdaAccess:
     # pylint: disable=unused-argument
     async def get_wellbore_picks_for_pick_identifier(
         self,
+        field_identifier: str,
         pick_identifier: str,
         interpreter: str = "STAT",
         obs_no: Optional[int] = None,

--- a/frontend/src/api/services/WellService.ts
+++ b/frontend/src/api/services/WellService.ts
@@ -62,20 +62,17 @@ export class WellService {
     /**
      * Get Wellbore Pick Identifiers
      * Get wellbore pick identifiers for field and stratigraphic column
-     * @param fieldIdentifier Official field identifier
      * @param stratColumnIdentifier Stratigraphic column identifier
      * @returns string Successful Response
      * @throws ApiError
      */
     public getWellborePickIdentifiers(
-        fieldIdentifier: string,
         stratColumnIdentifier: string,
     ): CancelablePromise<Array<string>> {
         return this.httpRequest.request({
             method: 'GET',
             url: '/well/wellbore_pick_identifiers/',
             query: {
-                'field_identifier': fieldIdentifier,
                 'strat_column_identifier': stratColumnIdentifier,
             },
             errors: {
@@ -110,20 +107,17 @@ export class WellService {
     /**
      * Get Wellbore Picks For Wellbore
      * Get wellbore picks for field and pick identifier
-     * @param fieldIdentifier Official field identifier
      * @param wellboreUuid Wellbore uuid
      * @returns WellborePick Successful Response
      * @throws ApiError
      */
     public getWellborePicksForWellbore(
-        fieldIdentifier: string,
         wellboreUuid: string,
     ): CancelablePromise<Array<WellborePick>> {
         return this.httpRequest.request({
             method: 'GET',
             url: '/well/wellbore_picks_for_wellbore/',
             query: {
-                'field_identifier': fieldIdentifier,
                 'wellbore_uuid': wellboreUuid,
             },
             errors: {

--- a/frontend/src/modules/Intersection/utils/layers/WellpicksLayer.ts
+++ b/frontend/src/modules/Intersection/utils/layers/WellpicksLayer.ts
@@ -72,20 +72,12 @@ export class WellpicksLayer extends BaseLayer<WellpicksLayerSettings, WellPicksL
     }
 
     protected async fetchData(queryClient: QueryClient): Promise<WellPicksLayerData> {
-        const queryKey = [
-            "getWellborePicksAndStratigraphicUnits",
-            this._settings.fieldIdentifier,
-            this._settings.wellboreUuid,
-        ];
+        const queryKey = ["getWellborePicksAndStratigraphicUnits", this._settings.wellboreUuid];
         this.registerQueryKey(queryKey);
 
         const wellborePicksPromise = queryClient.fetchQuery({
             queryKey,
-            queryFn: () =>
-                apiService.well.getWellborePicksForWellbore(
-                    this._settings.fieldIdentifier ?? "",
-                    this._settings.wellboreUuid ?? ""
-                ),
+            queryFn: () => apiService.well.getWellborePicksForWellbore(this._settings.wellboreUuid ?? ""),
             staleTime: STALE_TIME,
             gcTime: CACHE_TIME,
         });

--- a/frontend/src/modules/WellLogViewer/settings/atoms/queryAtoms.ts
+++ b/frontend/src/modules/WellLogViewer/settings/atoms/queryAtoms.ts
@@ -43,13 +43,12 @@ export const wellLogCurveHeadersQueryAtom = atomWithQuery((get) => {
 });
 
 export const wellborePicksQueryAtom = atomWithQuery((get) => {
-    const selectedFieldIdent = get(selectedFieldIdentifierAtom) ?? "";
     const selectedWellboreUuid = get(selectedWellboreHeaderAtom)?.wellboreUuid ?? "";
 
     return {
-        queryKey: ["getWellborePicksForWellbore", selectedFieldIdent, selectedWellboreUuid],
-        enabled: Boolean(selectedFieldIdent && selectedWellboreUuid),
-        queryFn: () => apiService.well.getWellborePicksForWellbore(selectedFieldIdent, selectedWellboreUuid),
+        queryKey: ["getWellborePicksForWellbore", selectedWellboreUuid],
+        enabled: Boolean(selectedWellboreUuid),
+        queryFn: () => apiService.well.getWellborePicksForWellbore(selectedWellboreUuid),
         ...SHARED_QUERY_OPTS,
     };
 });
@@ -61,7 +60,7 @@ export const wellboreStratigraphicUnitsQueryAtom = atomWithQuery((get) => {
     const caseUuid = selectedEnsemble?.getCaseUuid() ?? "";
 
     return {
-        queryKey: ["getWellborePicksForWellbore", caseUuid],
+        queryKey: ["getStratigraphicUnits", caseUuid],
         enabled: Boolean(caseUuid),
         queryFn: () => apiService.surface.getStratigraphicUnits(caseUuid),
         ...SHARED_QUERY_OPTS,


### PR DESCRIPTION
Not all calls to SMDA actually requires the field identifier parameter, making it's use more cumbersome than it needs to be.
This PR updates the service (and relevant endpoints) to take field ident as a normal param when necessary instead.