### PR TITLE
Refactor - Removed unused duplicated strat unit schema

### DIFF
--- a/backend_py/primary/primary/routers/surface/schemas.py
+++ b/backend_py/primary/primary/routers/surface/schemas.py
@@ -167,6 +167,12 @@ class PointSetXY(BaseModel):
 
 
 class StratigraphicUnit(BaseModel):
+    """
+    Stratigraphic unit from SMDA
+
+    Camel case attributes needed for esvIntersection component in front-end
+    """
+
     identifier: str
     top: str
     base: str

--- a/backend_py/primary/primary/routers/well/converters.py
+++ b/backend_py/primary/primary/routers/well/converters.py
@@ -1,4 +1,4 @@
-from primary.services.smda_access.types import WellboreHeader, WellboreTrajectory, WellborePick, StratigraphicUnit
+from primary.services.smda_access.types import WellboreHeader, WellboreTrajectory, WellborePick
 from primary.services.ssdl_access.types import (
     WellboreCasing,
     WellboreCompletion,
@@ -24,25 +24,6 @@ def convert_wellbore_pick_to_schema(wellbore_pick: WellborePick) -> schemas.Well
         confidence=wellbore_pick.confidence,
         depthReferencePoint=wellbore_pick.depth_reference_point,
         mdUnit=wellbore_pick.md_unit,
-    )
-
-
-def convert_stratigraphic_unit_to_schema(
-    stratigraphic_unit: StratigraphicUnit,
-) -> schemas.StratigraphicUnit:
-    return schemas.StratigraphicUnit(
-        identifier=stratigraphic_unit.identifier,
-        top=stratigraphic_unit.top,
-        base=stratigraphic_unit.base,
-        stratUnitLevel=stratigraphic_unit.strat_unit_level,
-        stratUnitType=stratigraphic_unit.strat_unit_type,
-        topAge=stratigraphic_unit.top_age,
-        baseAge=stratigraphic_unit.base_age,
-        stratUnitParent=stratigraphic_unit.strat_unit_parent,
-        colorR=stratigraphic_unit.color_r,
-        colorG=stratigraphic_unit.color_g,
-        colorB=stratigraphic_unit.color_b,
-        lithologyType=stratigraphic_unit.lithology_type,
     )
 
 

--- a/backend_py/primary/primary/routers/well/schemas.py
+++ b/backend_py/primary/primary/routers/well/schemas.py
@@ -2,27 +2,6 @@ from typing import List, Optional
 from pydantic import BaseModel
 
 
-class StratigraphicUnit(BaseModel):
-    """
-    Stratigraphic unit from SMDA
-
-    Camel case attributes needed for esvIntersection component in front-end
-    """
-
-    identifier: str
-    top: str
-    base: str
-    stratUnitLevel: int
-    stratUnitType: str
-    topAge: int | float
-    baseAge: int | float
-    stratUnitParent: Optional[str] = None
-    colorR: int
-    colorG: int
-    colorB: int
-    lithologyType: int | float | str = "unknown"
-
-
 class WellboreHeader(BaseModel):
     wellboreUuid: str
     uniqueWellboreIdentifier: str
@@ -64,11 +43,6 @@ class WellborePick(BaseModel):
     confidence: Optional[str] = None
     depthReferencePoint: str
     mdUnit: str
-
-
-class WellborePicksAndStratigraphicUnits(BaseModel):
-    wellbore_picks: List[WellborePick] = []
-    stratigraphic_units: List[StratigraphicUnit] = []
 
 
 class WellboreCompletion(BaseModel):

--- a/frontend/src/api/models/StratigraphicUnit.ts
+++ b/frontend/src/api/models/StratigraphicUnit.ts
@@ -2,6 +2,11 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+/**
+ * Stratigraphic unit from SMDA
+ *
+ * Camel case attributes needed for esvIntersection component in front-end
+ */
 export type StratigraphicUnit = {
     identifier: string;
     top: string;


### PR DESCRIPTION
There was two `StratigraphicUnit` schemas. The one in the well-router was not used, so I removed it