### PR TITLE
Pin poetry to v `1.8.5` and fix deprecated poetry workflow command

### DIFF
--- a/.github/workflows/webviz.yml
+++ b/.github/workflows/webviz.yml
@@ -94,7 +94,7 @@ jobs:
         working-directory: ./backend_py/primary
         run: |
           pip install --upgrade pip
-          pip install poetry
+          pip install poetry==1.8.0  # Pin Poetry to version 1.8.0
           poetry config virtualenvs.create false
           poetry check --lock  # Check lock file is consistent with pyproject.toml
           poetry install --with dev

--- a/.github/workflows/webviz.yml
+++ b/.github/workflows/webviz.yml
@@ -94,7 +94,7 @@ jobs:
         working-directory: ./backend_py/primary
         run: |
           pip install --upgrade pip
-          pip install poetry==1.8.0  # Pin Poetry to version 1.8.0
+          pip install poetry==1.8.5  # Pin Poetry to version 1.8.5
           poetry config virtualenvs.create false
           poetry check --lock  # Check lock file is consistent with pyproject.toml
           poetry install --with dev

--- a/.github/workflows/webviz.yml
+++ b/.github/workflows/webviz.yml
@@ -96,7 +96,7 @@ jobs:
           pip install --upgrade pip
           pip install poetry
           poetry config virtualenvs.create false
-          poetry lock --check --no-update  # Check lock file is consistent with pyproject.toml
+          poetry check --lock  # Check lock file is consistent with pyproject.toml
           poetry install --with dev
 
       - name: 🕵️ Check code style & linting


### PR DESCRIPTION
- Pin version to `1.8.5`
- Adjust deprecated command

---
1) Workflow failed after poetry update `2.0.0`. Pin version to `1.8.5` for now, and crated a separate issue to update to `2.0.0`: https://github.com/equinor/webviz/issues/839
2) Deprecated command `poetry lock --check --no-update` replaced with `poetry check --lock`

---

Closes: #837
