### PR TITLE
Use synchronous client temporarily until we update fmu-sumo >= 2.0

### DIFF
--- a/backend_py/primary/primary/services/sumo_access/_helpers.py
+++ b/backend_py/primary/primary/services/sumo_access/_helpers.py
@@ -41,7 +41,7 @@ def create_sumo_client(access_token: str) -> SumoClient:
         sumo_client = SumoClient(
             env=config.SUMO_ENV,
             token=access_token,
-            http_client=FakeHTTPXClient(),
+            http_client=None,  # Until we update fmu-sumo > 2.0 we need to initialize a sync client.
             async_http_client=httpx_async_client.client,
         )
     timer.record_lap("create_sumo_client()")

--- a/backend_py/primary/primary/services/sumo_access/case_inspector.py
+++ b/backend_py/primary/primary/services/sumo_access/case_inspector.py
@@ -40,7 +40,8 @@ class CaseInspector:
     async def get_iterations_async(self) -> list[IterationInfo]:
         case: Case = await self._get_or_create_case_obj()
 
-        iterations = await case.iterations_async
+        # Until we update fmu-sumo > 2.0 we need to fetch iterations synchronously.
+        iterations = case.iterations
 
         iter_info_arr: list[IterationInfo] = []
         for iteration in iterations:


### PR DESCRIPTION
There is a bug when fetching iterations async. Only the first iteration is returned.
