### PR TITLE
Adjust slider component

### DIFF
--- a/frontend/src/lib/components/Slider/slider.tsx
+++ b/frontend/src/lib/components/Slider/slider.tsx
@@ -7,13 +7,13 @@ import { Popper as PopperUnstyled, Slider as SliderUnstyled, SliderProps as Slid
 
 import { BaseComponent } from "../BaseComponent";
 
-interface SliderValueLabelProps {
+type SliderValueLabelProps = {
     currentlyActiveThumb: number;
     sliderValue: number | number[];
     scale?: (value: number) => number;
     valueLabelFormat?: string | ((value: number) => React.ReactNode);
     visible: boolean;
-}
+};
 
 function SliderValueLabel(props: SliderValueLabelProps) {
     const anchorRef = React.useRef<HTMLDivElement | null>(null);

--- a/frontend/src/lib/components/Slider/slider.tsx
+++ b/frontend/src/lib/components/Slider/slider.tsx
@@ -12,11 +12,7 @@ import {
 
 import { BaseComponent } from "../BaseComponent";
 
-type SliderValueLabelProps = {
-    visible: boolean;
-} & SliderValueLabelSlotProps;
-
-function SliderValueLabel(props: SliderValueLabelProps) {
+function SliderValueLabel(props: SliderValueLabelSlotProps) {
     const anchorRef = React.useRef<HTMLDivElement | null>(null);
 
     return (
@@ -24,7 +20,7 @@ function SliderValueLabel(props: SliderValueLabelProps) {
             <PopperUnstyled
                 id="slider-popper"
                 className="z-50"
-                open={props.visible}
+                open={props.disabled ? false : true}
                 anchorEl={() => anchorRef.current!}
                 placement="top"
                 popperOptions={{ modifiers: [{ name: "offset", options: { offset: [0, 8] } }] }}
@@ -210,7 +206,7 @@ function SliderComponent(props: SliderProps, ref: React.ForwardedRef<HTMLDivElem
                 }}
                 slotProps={{
                     valueLabel: {
-                        visible: valueLabelDisplay === "auto" && valueLabelVisible,
+                        disabled: !(valueLabelDisplay === "auto" && valueLabelVisible),
                     },
                     root: {
                         className: resolveClassNames(

--- a/frontend/src/lib/components/Slider/slider.tsx
+++ b/frontend/src/lib/components/Slider/slider.tsx
@@ -171,7 +171,7 @@ function SliderComponent(props: SliderProps, ref: React.ForwardedRef<HTMLDivElem
         };
     }, []);
 
-    // This function converts the slider value to a content for label
+    // This function converts the slider value to a content string for the label
     const formatLabelValue = React.useCallback(
         function formatLabelValue(labelValue: number): React.ReactNode {
             const adjustedValue = scale ? scale(labelValue) : labelValue;

--- a/frontend/src/lib/components/Slider/slider.tsx
+++ b/frontend/src/lib/components/Slider/slider.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { useElementBoundingRect } from "@lib/hooks/useElementBoundingRect";
 import { resolveClassNames } from "@lib/utils/resolveClassNames";
 import { convertRemToPixels } from "@lib/utils/screenUnitConversions";
-import { Slider as SliderUnstyled, SliderProps as SliderUnstyledProps } from "@mui/base";
+import { Popper as PopperUnstyled, Slider as SliderUnstyled, SliderProps as SliderUnstyledProps } from "@mui/base";
 
 import { BaseComponent } from "../BaseComponent";
 
@@ -18,45 +18,51 @@ interface SliderValueLabelProps {
     visible: boolean;
 }
 
-function SliderValueLabel({ labelContent, visible }: SliderValueLabelProps) {
+function SliderValueLabel(props: SliderValueLabelProps) {
+    const anchorRef = React.useRef<HTMLDivElement | null>(null);
     return (
-        <span
-            className={resolveClassNames(
-                "rounded",
-                "bg-blue-600",
-                "text-white",
-                "p-2",
-                "text-xs",
-                "font-bold",
-                "leading-none",
-                "transform",
-                "-translate-x-1/2",
-                "-translate-y-full",
-                "transition-opacity",
-                "pointer-events-none",
-                "h-6",
-                "inline-block",
-                "absolute",
-                "whitespace-nowrap",
-                "before:absolute",
-                "before:-bottom-2",
-                "before:left-1/2",
-                "before:transform",
-                "before:-translate-x-1/2",
-                "before:-translate-y-1/2",
-                "before:w-2",
-                "before:h-2",
-                "before:bg-blue-600",
-                "before:rotate-45",
-                "before:-z-10",
+        <>
+            <PopperUnstyled
+                id="slider-popper"
+                className="z-50"
+                open={props.visible}
+                anchorEl={() => anchorRef.current!}
+                placement="top"
+                // Push the popper a little bit upwards to make room for the arrow
+                popperOptions={{ modifiers: [{ name: "offset", options: { offset: [0, 8] } }] }}
+            >
+                <span
+                    className={resolveClassNames(
+                        "pointer-events-none",
+                        "inline-block",
+                        "rounded",
+                        "bg-blue-600",
+                        "text-white",
+                        "p-2",
+                        "h-6",
+                        "text-xs",
+                        "font-bold",
+                        "leading-none",
+                        "whitespace-nowrap",
 
-                {
-                    hidden: !visible,
-                }
-            )}
-        >
-            <div>{labelContent}</div>
-        </span>
+                        // Arrow
+                        "before:absolute",
+                        "before:-bottom-2",
+                        "before:left-1/2",
+                        "before:transform",
+                        "before:-translate-x-1/2",
+                        "before:-translate-y-1/2",
+                        "before:w-2",
+                        "before:h-2",
+                        "before:bg-blue-600",
+                        "before:rotate-45"
+                    )}
+                >
+                    {props.labelContent}
+                </span>
+            </PopperUnstyled>
+            <div ref={anchorRef} />
+        </>
     );
 }
 


### PR DESCRIPTION
Fixed slider bugs.

Replaced label code, with slot named `valueLabel` for mui-base `Slider`-component. Render a `Popper`-component for the label.

Thereby there is no need to calculate positioning of label component anymore.

---

Closes: #777
Closes: #645
