### PR TITLE
Fix: Issues with element position tracking

### DIFF
--- a/frontend/src/framework/internal/components/SelectEnsemblesDialog/selectEnsemblesDialog.tsx
+++ b/frontend/src/framework/internal/components/SelectEnsemblesDialog/selectEnsemblesDialog.tsx
@@ -539,7 +539,6 @@ export const SelectEnsemblesDialog: React.FC<SelectEnsemblesDialogProps> = (prop
                 modal
                 width={"75%"}
                 minWidth={800}
-                // minHeight={600}
                 height={"75"}
                 actions={
                     <div className="flex gap-4">

--- a/frontend/src/lib/components/CircularProgress/circularProgress.tsx
+++ b/frontend/src/lib/components/CircularProgress/circularProgress.tsx
@@ -21,15 +21,11 @@ export const CircularProgress = withDefaults<CircularProgressProps>()(defaultPro
         <div
             className={resolveClassNames(
                 {
-                    "w-3": props.size === "extra-small",
-                    "w-4": props.size === "small",
-                    "w-5": props.size === "medium-small",
-                    "w-8": props.size === "medium",
-                    "w-12": props.size === "large",
-                    "h-3": props.size === "extra-small",
-                    "h-4": props.size === "small",
-                    "h-8": props.size === "medium",
-                    "h-12": props.size === "large",
+                    "w-3 h-3": props.size === "extra-small",
+                    "w-4 h-4": props.size === "small",
+                    "w-5 h-5": props.size === "medium-small",
+                    "w-8 h-8": props.size === "medium",
+                    "w-12 h-12": props.size === "large",
                 },
                 "relative",
                 props.className ?? "",
@@ -37,7 +33,7 @@ export const CircularProgress = withDefaults<CircularProgressProps>()(defaultPro
         >
             <svg
                 aria-hidden="true"
-                className="w-full h-full text-gray-200 animate-spin dark:text-gray-600 fill-blue-600"
+                className="w-full h-full text-gray-200 animate-spin fill-blue-600"
                 viewBox="0 0 100 101"
                 fill="none"
                 xmlns="http://www.w3.org/2000/svg"

--- a/frontend/src/lib/components/Dialog/dialog.tsx
+++ b/frontend/src/lib/components/Dialog/dialog.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 
-import { useElementSize } from "@lib/hooks/useElementSize";
 import { createPortal } from "@lib/utils/createPortal";
 import { resolveClassNames } from "@lib/utils/resolveClassNames";
 import { Close } from "@mui/icons-material";
@@ -22,8 +21,6 @@ export type DialogProps = {
 export const Dialog: React.FC<DialogProps> = (props) => {
     const wrapperRef = React.useRef<HTMLDivElement>(null);
     const dialogRef = React.useRef<HTMLDivElement>(null);
-
-    const dialogSize = useElementSize(dialogRef);
 
     const handleClose = (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
         props.onClose?.(e);

--- a/frontend/src/lib/components/Dialog/dialog.tsx
+++ b/frontend/src/lib/components/Dialog/dialog.tsx
@@ -61,8 +61,7 @@ export const Dialog: React.FC<DialogProps> = (props) => {
                     "pointer-events-auto",
                 )}
                 style={{
-                    marginLeft: -dialogSize.width / 2,
-                    marginTop: -dialogSize.height / 2,
+                    transform: `translate(-50%, -50%)`,
                     height: props.height,
                     width: props.width,
                     minWidth: props.minWidth,

--- a/frontend/src/lib/components/Dropdown/dropdown.tsx
+++ b/frontend/src/lib/components/Dropdown/dropdown.tsx
@@ -282,50 +282,43 @@ function DropdownComponent<TValue = string>(props: DropdownProps<TValue>, ref: R
 
     React.useEffect(
         function computeDropdownRectEffect() {
-            if (dropdownVisible) {
-                const bodyClientBoundingRect = document.body.getBoundingClientRect();
+            const bodyClientBoundingRect = document.body.getBoundingClientRect();
 
-                const preferredHeight =
-                    Math.min(
-                        MIN_HEIGHT,
-                        Math.max(filteredOptionsWithSeparators.length * OPTION_HEIGHT, OPTION_HEIGHT),
-                    ) + 2;
+            const preferredHeight =
+                Math.min(MIN_HEIGHT, Math.max(filteredOptionsWithSeparators.length * OPTION_HEIGHT, OPTION_HEIGHT)) + 2;
 
-                if (inputBoundingRect && bodyClientBoundingRect) {
-                    const newDropdownRect: DropdownRect = {
-                        minWidth: inputBoundingRect.width,
-                        width: dropdownRect.width,
-                        height: preferredHeight,
-                    };
+            if (inputBoundingRect && bodyClientBoundingRect) {
+                const newDropdownRect: DropdownRect = {
+                    minWidth: inputBoundingRect.width,
+                    width: dropdownRect.width,
+                    height: preferredHeight,
+                };
 
-                    if (inputBoundingRect.y + inputBoundingRect.height + preferredHeight > window.innerHeight) {
-                        const height = Math.min(inputBoundingRect.y, preferredHeight);
-                        newDropdownRect.top = inputBoundingRect.y - height;
-                        newDropdownRect.height = height;
-                    } else {
-                        newDropdownRect.top = inputBoundingRect.y + inputBoundingRect.height;
-                        newDropdownRect.height = Math.min(
-                            preferredHeight,
-                            window.innerHeight - inputBoundingRect.y - inputBoundingRect.height,
-                        );
-                    }
-                    if (inputBoundingRect.x + inputBoundingRect.width > window.innerWidth / 2) {
-                        newDropdownRect.right = window.innerWidth - (inputBoundingRect.x + inputBoundingRect.width);
-                    } else {
-                        newDropdownRect.left = inputBoundingRect.x;
-                    }
-
-                    setDropdownRect((prev) => ({ ...newDropdownRect, width: prev.width }));
-
-                    const selectedIndex = filteredOptionsWithSeparators.findIndex((opt) =>
-                        isOptionOfValue(opt, selection),
+                if (inputBoundingRect.y + inputBoundingRect.height + preferredHeight > window.innerHeight) {
+                    const height = Math.min(inputBoundingRect.y, preferredHeight);
+                    newDropdownRect.top = inputBoundingRect.y - height;
+                    newDropdownRect.height = height;
+                } else {
+                    newDropdownRect.top = inputBoundingRect.y + inputBoundingRect.height;
+                    newDropdownRect.height = Math.min(
+                        preferredHeight,
+                        window.innerHeight - inputBoundingRect.y - inputBoundingRect.height,
                     );
-                    const selectedIndexOrDefault = selectedIndex !== -1 ? selectedIndex : 0;
-                    const visibleOptions = Math.round(preferredHeight / OPTION_HEIGHT / 2);
-
-                    setStartIndex(Math.max(0, selectedIndexOrDefault - visibleOptions));
-                    setOptionIndexWithFocusToCurrentSelection();
                 }
+                if (inputBoundingRect.x + inputBoundingRect.width > window.innerWidth / 2) {
+                    newDropdownRect.right = window.innerWidth - (inputBoundingRect.x + inputBoundingRect.width);
+                } else {
+                    newDropdownRect.left = inputBoundingRect.x;
+                }
+
+                setDropdownRect((prev) => ({ ...newDropdownRect, width: prev.width }));
+
+                const selectedIndex = filteredOptionsWithSeparators.findIndex((opt) => isOptionOfValue(opt, selection));
+                const selectedIndexOrDefault = selectedIndex !== -1 ? selectedIndex : 0;
+                const visibleOptions = Math.round(preferredHeight / OPTION_HEIGHT / 2);
+
+                setStartIndex(Math.max(0, selectedIndexOrDefault - visibleOptions));
+                setOptionIndexWithFocusToCurrentSelection();
             }
         },
         [

--- a/frontend/src/lib/components/Dropdown/dropdown.tsx
+++ b/frontend/src/lib/components/Dropdown/dropdown.tsx
@@ -323,7 +323,6 @@ function DropdownComponent<TValue = string>(props: DropdownProps<TValue>, ref: R
         },
         [
             inputBoundingRect,
-            dropdownVisible,
             filteredOptionsWithSeparators,
             selection,
             dropdownRect.width,

--- a/frontend/src/lib/hooks/useElementBoundingRect.ts
+++ b/frontend/src/lib/hooks/useElementBoundingRect.ts
@@ -5,104 +5,68 @@ import { elementIsVisible } from "@lib/utils/htmlElementUtils";
 
 export function useElementBoundingRect(ref: React.RefObject<HTMLElement | SVGSVGElement>): DOMRect {
     const [rect, setRect] = React.useState<DOMRect>(new DOMRect(0, 0, 0, 0));
-    const id = React.useId();
 
     React.useEffect(
         function onMountEffect() {
             let isHidden = false;
             let currentRect = new DOMRect(0, 0, 0, 0);
+            let intersectionObserver: IntersectionObserver | null = null;
 
-            let container = document.getElementById("intersection-observables-root");
-            if (!container) {
-                container = document.createElement("div");
-                container.id = "intersection-observables-root";
-                document.body.appendChild(container);
-            }
-
-            // Create an invisible div that will be used to observe the intersection between the old position (the invisible div)
-            // and the new position (the element that we want to observe)
-            let element = document.getElementById(id);
-            if (!element) {
-                element = document.createElement("div");
-                element.id = id;
-                element.style.visibility = "hidden";
-                element.style.position = "absolute";
-                element.style.pointerEvents = "none";
-                container.appendChild(element);
-            }
-
-            function handleResizeAndScroll() {
+            function handleRectChange() {
+                intersectionObserver?.disconnect();
                 if (ref.current) {
+                    const rect = ref.current.getBoundingClientRect();
+                    const margins = `${-Math.round(rect.top)}px ${-Math.round(rect.right)}px ${-Math.round(rect.bottom)}px ${-Math.round(rect.left)}px`;
+
+                    intersectionObserver = new IntersectionObserver(handleRectChange, {
+                        root: document.body,
+                        rootMargin: margins,
+                    });
+
+                    intersectionObserver.observe(ref.current);
+
                     // If element is not visible do not change size as it might be expensive to render
                     if (!isHidden && !elementIsVisible(ref.current)) {
                         isHidden = true;
                         return;
                     }
 
-                    const newRect = ref.current.getBoundingClientRect();
+                    isHidden = false;
 
-                    if (domRectsAreEqual(currentRect, newRect)) {
-                        isHidden = false;
+                    if (domRectsAreEqual(currentRect, rect)) {
                         return;
                     }
 
-                    maybeUpdateRect(newRect);
-                }
-            }
-
-            function handleMutations() {
-                if (ref.current) {
-                    const newRect = ref.current.getBoundingClientRect();
-                    maybeUpdateRect(newRect);
-                }
-            }
-
-            function handleIntersectionChange() {
-                if (ref.current) {
-                    const newRect = ref.current.getBoundingClientRect();
-                    maybeUpdateRect(newRect);
-                }
-            }
-
-            function maybeUpdateRect(rect: DOMRect) {
-                if (!domRectsAreEqual(rect, currentRect)) {
                     currentRect = rect;
                     setRect(rect);
-                    element!.style.width = `${rect.width}px`;
-                    element!.style.height = `${rect.height}px`;
-                    element!.style.top = `${rect.top}px`;
-                    element!.style.left = `${rect.left}px`;
                 }
             }
 
-            const resizeObserver = new ResizeObserver(handleResizeAndScroll);
-            const mutationObserver = new MutationObserver(handleMutations);
-            const intersectionObserver = new IntersectionObserver(handleIntersectionChange, { root: element });
-            window.addEventListener("resize", handleResizeAndScroll, true);
-            window.addEventListener("scroll", handleResizeAndScroll, true);
+            const resizeObserver = new ResizeObserver(handleRectChange);
+            const mutationObserver = new MutationObserver(handleRectChange);
+            window.addEventListener("resize", handleRectChange, true);
+            window.addEventListener("scroll", handleRectChange, true);
 
             if (ref.current) {
-                handleResizeAndScroll();
-                resizeObserver.observe(ref.current);
+                resizeObserver.observe(document.body);
                 mutationObserver.observe(ref.current, {
                     attributes: true,
                     subtree: false,
                     childList: false,
                     attributeFilter: ["style", "class"],
                 });
-                intersectionObserver.observe(ref.current);
+                handleRectChange();
             }
 
             return function onUnmount() {
                 resizeObserver.disconnect();
+                intersectionObserver?.disconnect();
                 mutationObserver.disconnect();
-                intersectionObserver.disconnect();
-                window.removeEventListener("resize", handleResizeAndScroll, true);
-                window.removeEventListener("scroll", handleResizeAndScroll, true);
-                container.removeChild(element);
+                window.removeEventListener("resize", handleRectChange, true);
+                window.removeEventListener("scroll", handleRectChange, true);
             };
         },
-        [ref, id],
+        [ref],
     );
 
     return rect;

--- a/frontend/src/lib/hooks/useElementBoundingRect.ts
+++ b/frontend/src/lib/hooks/useElementBoundingRect.ts
@@ -12,13 +12,18 @@ export function useElementBoundingRect(ref: React.RefObject<HTMLElement | SVGSVG
             let currentRect = new DOMRect(0, 0, 0, 0);
             let intersectionObserver: IntersectionObserver | null = null;
 
-            function handleRectChange() {
+            function handlePotentialRectChange() {
+                // Anytime the element's position is changing, the intersection observer must be reinitialized
+                // in order to get the new correct root margin
+                // https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API#rootmargin
                 intersectionObserver?.disconnect();
+
                 if (ref.current) {
+                    // Using the browser's viewport as the root for the intersection observer and calculating the root margin based on the element's position
                     const rect = ref.current.getBoundingClientRect();
                     const margins = `${-Math.round(rect.top)}px ${-Math.round(rect.right)}px ${-Math.round(rect.bottom)}px ${-Math.round(rect.left)}px`;
 
-                    intersectionObserver = new IntersectionObserver(handleRectChange, {
+                    intersectionObserver = new IntersectionObserver(handlePotentialRectChange, {
                         root: document.body,
                         rootMargin: margins,
                     });
@@ -42,10 +47,12 @@ export function useElementBoundingRect(ref: React.RefObject<HTMLElement | SVGSVG
                 }
             }
 
-            const resizeObserver = new ResizeObserver(handleRectChange);
-            const mutationObserver = new MutationObserver(handleRectChange);
-            window.addEventListener("resize", handleRectChange, true);
-            window.addEventListener("scroll", handleRectChange, true);
+            // Anytime the element's position might change, the intersection observer must be reinitialized with the correct root margin.
+            // Hence, we listen to resize, scroll, and mutation events.
+            const resizeObserver = new ResizeObserver(handlePotentialRectChange);
+            const mutationObserver = new MutationObserver(handlePotentialRectChange);
+            window.addEventListener("resize", handlePotentialRectChange, true);
+            window.addEventListener("scroll", handlePotentialRectChange, true);
 
             if (ref.current) {
                 resizeObserver.observe(document.body);
@@ -55,15 +62,15 @@ export function useElementBoundingRect(ref: React.RefObject<HTMLElement | SVGSVG
                     childList: false,
                     attributeFilter: ["style", "class"],
                 });
-                handleRectChange();
+                handlePotentialRectChange();
             }
 
             return function onUnmount() {
                 resizeObserver.disconnect();
                 intersectionObserver?.disconnect();
                 mutationObserver.disconnect();
-                window.removeEventListener("resize", handleRectChange, true);
-                window.removeEventListener("scroll", handleRectChange, true);
+                window.removeEventListener("resize", handlePotentialRectChange, true);
+                window.removeEventListener("scroll", handlePotentialRectChange, true);
             };
         },
         [ref],

--- a/frontend/src/lib/hooks/useElementBoundingRect.ts
+++ b/frontend/src/lib/hooks/useElementBoundingRect.ts
@@ -5,66 +5,105 @@ import { elementIsVisible } from "@lib/utils/htmlElementUtils";
 
 export function useElementBoundingRect(ref: React.RefObject<HTMLElement | SVGSVGElement>): DOMRect {
     const [rect, setRect] = React.useState<DOMRect>(new DOMRect(0, 0, 0, 0));
+    const id = React.useId();
 
-    React.useEffect(() => {
-        let isHidden = false;
-        let currentRect = new DOMRect(0, 0, 0, 0);
+    React.useEffect(
+        function onMountEffect() {
+            let isHidden = false;
+            let currentRect = new DOMRect(0, 0, 0, 0);
 
-        const handleResizeAndScroll = (): void => {
-            if (ref.current) {
-                // If element is not visible do not change size as it might be expensive to render
-                if (!isHidden && !elementIsVisible(ref.current)) {
-                    isHidden = true;
-                    return;
-                }
-
-                const newRect = ref.current.getBoundingClientRect();
-
-                if (domRectsAreEqual(currentRect, newRect)) {
-                    isHidden = false;
-                    return;
-                }
-
-                currentRect = newRect;
-
-                setRect(newRect);
+            let container = document.getElementById("intersection-observables-root");
+            if (!container) {
+                container = document.createElement("div");
+                container.id = "intersection-observables-root";
+                document.body.appendChild(container);
             }
-        };
 
-        function handleMutations(): void {
-            if (ref.current) {
-                const newRect = ref.current.getBoundingClientRect();
+            // Create an invisible div that will be used to observe the intersection between the old position (the invisible div)
+            // and the new position (the element that we want to observe)
+            let element = document.getElementById(id);
+            if (!element) {
+                element = document.createElement("div");
+                element.id = id;
+                element.style.visibility = "hidden";
+                element.style.position = "absolute";
+                element.style.pointerEvents = "none";
+                container.appendChild(element);
+            }
 
-                if (!domRectsAreEqual(currentRect, newRect)) {
-                    currentRect = newRect;
-                    setRect(newRect);
+            function handleResizeAndScroll() {
+                if (ref.current) {
+                    // If element is not visible do not change size as it might be expensive to render
+                    if (!isHidden && !elementIsVisible(ref.current)) {
+                        isHidden = true;
+                        return;
+                    }
+
+                    const newRect = ref.current.getBoundingClientRect();
+
+                    if (domRectsAreEqual(currentRect, newRect)) {
+                        isHidden = false;
+                        return;
+                    }
+
+                    maybeUpdateRect(newRect);
                 }
             }
-        }
 
-        const resizeObserver = new ResizeObserver(handleResizeAndScroll);
-        const mutationObserver = new MutationObserver(handleMutations);
-        window.addEventListener("resize", handleResizeAndScroll, true);
-        window.addEventListener("scroll", handleResizeAndScroll, true);
+            function handleMutations() {
+                if (ref.current) {
+                    const newRect = ref.current.getBoundingClientRect();
+                    maybeUpdateRect(newRect);
+                }
+            }
 
-        if (ref.current) {
-            handleResizeAndScroll();
-            resizeObserver.observe(ref.current);
-            mutationObserver.observe(ref.current, {
-                attributes: true,
-                subtree: false,
-                childList: false,
-                attributeFilter: ["style", "class"],
-            });
-        }
+            function handleIntersectionChange() {
+                if (ref.current) {
+                    const newRect = ref.current.getBoundingClientRect();
+                    maybeUpdateRect(newRect);
+                }
+            }
 
-        return () => {
-            resizeObserver.disconnect();
-            mutationObserver.disconnect();
-            window.removeEventListener("resize", handleResizeAndScroll, true);
-            window.removeEventListener("scroll", handleResizeAndScroll, true);
-        };
-    }, [ref]);
+            function maybeUpdateRect(rect: DOMRect) {
+                if (!domRectsAreEqual(rect, currentRect)) {
+                    currentRect = rect;
+                    setRect(rect);
+                    element!.style.width = `${rect.width}px`;
+                    element!.style.height = `${rect.height}px`;
+                    element!.style.top = `${rect.top}px`;
+                    element!.style.left = `${rect.left}px`;
+                }
+            }
+
+            const resizeObserver = new ResizeObserver(handleResizeAndScroll);
+            const mutationObserver = new MutationObserver(handleMutations);
+            const intersectionObserver = new IntersectionObserver(handleIntersectionChange, { root: element });
+            window.addEventListener("resize", handleResizeAndScroll, true);
+            window.addEventListener("scroll", handleResizeAndScroll, true);
+
+            if (ref.current) {
+                handleResizeAndScroll();
+                resizeObserver.observe(ref.current);
+                mutationObserver.observe(ref.current, {
+                    attributes: true,
+                    subtree: false,
+                    childList: false,
+                    attributeFilter: ["style", "class"],
+                });
+                intersectionObserver.observe(ref.current);
+            }
+
+            return function onUnmount() {
+                resizeObserver.disconnect();
+                mutationObserver.disconnect();
+                intersectionObserver.disconnect();
+                window.removeEventListener("resize", handleResizeAndScroll, true);
+                window.removeEventListener("scroll", handleResizeAndScroll, true);
+                container.removeChild(element);
+            };
+        },
+        [ref, id],
+    );
 
     return rect;
 }


### PR DESCRIPTION
Elements were not properly tracked anymore after recent changes. Introduced a new observation pattern utilizing the `IntersectionObserver`. We might want to look at the `Popover API` at some later point of time in order to remove custom code and to stick to the new standard: https://developer.mozilla.org/en-US/docs/Web/API/Popover_API

Also removed unused/unnecessary CSS classes.