### PR TITLE
Some minor improvements regarding stored data and avoid updates in deps

### DIFF
--- a/frontend/src/modules/_shared/LayerFramework/delegates/_utils/Dependency.ts
+++ b/frontend/src/modules/_shared/LayerFramework/delegates/_utils/Dependency.ts
@@ -4,6 +4,7 @@ import { isEqual } from "lodash";
 
 import type { GlobalSettings } from "../../framework/DataLayerManager/DataLayerManager";
 import { SettingTopic } from "../../framework/SettingManager/SettingManager";
+import { CancelUpdate } from "../../interfacesAndTypes/customSettingsHandler";
 import type { UpdateFunc } from "../../interfacesAndTypes/customSettingsHandler";
 import type { SettingsKeysFromTuple } from "../../interfacesAndTypes/utils";
 import type { MakeSettingTypesMap, Settings } from "../../settings/settingsDefinitions";
@@ -24,7 +25,7 @@ export class Dependency<
     TReturnValue,
     TSettings extends Settings,
     TSettingTypes extends MakeSettingTypesMap<TSettings>,
-    TKey extends SettingsKeysFromTuple<TSettings>
+    TKey extends SettingsKeysFromTuple<TSettings>,
 > {
     private _updateFunc: UpdateFunc<TReturnValue, TSettings, TSettingTypes, TKey>;
     private _dependencies: Set<(value: Awaited<TReturnValue> | null) => void> = new Set();
@@ -36,7 +37,7 @@ export class Dependency<
     private _makeLocalSettingGetter: <K extends TKey>(key: K, handler: (value: TSettingTypes[K]) => void) => void;
     private _makeGlobalSettingGetter: <K extends keyof GlobalSettings>(
         key: K,
-        handler: (value: GlobalSettings[K]) => void
+        handler: (value: GlobalSettings[K]) => void,
     ) => void;
     private _cachedSettingsMap: Map<string, any> = new Map();
     private _cachedGlobalSettingsMap: Map<string, any> = new Map();
@@ -53,8 +54,8 @@ export class Dependency<
         makeLocalSettingGetter: <K extends TKey>(key: K, handler: (value: TSettingTypes[K]) => void) => void,
         makeGlobalSettingGetter: <K extends keyof GlobalSettings>(
             key: K,
-            handler: (value: GlobalSettings[K]) => void
-        ) => void
+            handler: (value: GlobalSettings[K]) => void,
+        ) => void,
     ) {
         this._contextDelegate = contextDelegate;
         this._updateFunc = updateFunc;
@@ -157,7 +158,7 @@ export class Dependency<
 
         this._cachedGlobalSettingsMap.set(
             settingName as string,
-            this._contextDelegate.getLayerManager().getGlobalSetting(settingName)
+            this._contextDelegate.getLayerManager().getGlobalSetting(settingName),
         );
         return this._cachedGlobalSettingsMap.get(settingName as string);
     }
@@ -220,7 +221,7 @@ export class Dependency<
 
         this.setLoadingState(true);
 
-        let newValue: Awaited<TReturnValue> | null = null;
+        let newValue: Awaited<TReturnValue> | null | typeof CancelUpdate = null;
         try {
             newValue = await this._updateFunc({
                 getLocalSetting: this.getLocalSetting,
@@ -233,6 +234,10 @@ export class Dependency<
                 this.applyNewValue(null);
                 return;
             }
+            return;
+        }
+
+        if (newValue === CancelUpdate) {
             return;
         }
 

--- a/frontend/src/modules/_shared/LayerFramework/framework/DataLayer/DataLayer.ts
+++ b/frontend/src/modules/_shared/LayerFramework/framework/DataLayer/DataLayer.ts
@@ -137,6 +137,15 @@ export class DataLayer<
             "settings-context",
             this._settingsContextDelegate
                 .getPublishSubscribeDelegate()
+                .makeSubscriberFunction(SettingsContextDelegateTopic.STORED_DATA_CHANGED)(() => {
+                this.handleSettingsChange();
+            }),
+        );
+
+        this._unsubscribeHandler.registerUnsubscribeFunction(
+            "settings-context",
+            this._settingsContextDelegate
+                .getPublishSubscribeDelegate()
                 .makeSubscriberFunction(SettingsContextDelegateTopic.STATUS)(() => {
                 this.handleSettingsStatusChange();
             }),

--- a/frontend/src/modules/_shared/LayerFramework/framework/utils/DeserializationFactory.ts
+++ b/frontend/src/modules/_shared/LayerFramework/framework/utils/DeserializationFactory.ts
@@ -5,10 +5,9 @@ import type {
     SerializedItem,
     SerializedLayer,
     SerializedSettingsGroup,
-    SerializedSharedSetting} from "../../interfacesAndTypes/serialization";
-import {
-    SerializedType,
+    SerializedSharedSetting,
 } from "../../interfacesAndTypes/serialization";
+import { SerializedType } from "../../interfacesAndTypes/serialization";
 import { LayerRegistry } from "../../layers/LayerRegistry";
 import type { DataLayerManager } from "../DataLayerManager/DataLayerManager";
 import { SettingsGroup } from "../SettingsGroup/SettingsGroup";
@@ -38,10 +37,10 @@ export class DeserializationFactory {
         }
 
         if (serialized.type === SerializedType.GROUP) {
-            const serializedView = serialized as SerializedGroup;
-            const view = GroupRegistry.makeGroup(serializedView.groupType, this._layerManager);
-            view.deserializeState(serializedView);
-            return view;
+            const serializedGroup = serialized as SerializedGroup;
+            const group = GroupRegistry.makeGroup(serializedGroup.groupType, this._layerManager);
+            group.deserializeState(serializedGroup);
+            return group;
         }
 
         if (serialized.type === SerializedType.SETTINGS_GROUP) {
@@ -56,7 +55,7 @@ export class DeserializationFactory {
             const setting = new SharedSetting(
                 serializedSharedSetting.wrappedSettingType,
                 serializedSharedSetting.value,
-                this._layerManager
+                this._layerManager,
             );
             setting.deserializeState(serializedSharedSetting);
             return setting;

--- a/frontend/src/modules/_shared/LayerFramework/interfacesAndTypes/customDataLayerImplementation.ts
+++ b/frontend/src/modules/_shared/LayerFramework/interfacesAndTypes/customDataLayerImplementation.ts
@@ -16,9 +16,9 @@ import type { MakeSettingTypesMap, Settings } from "../settings/settingsDefiniti
 export type DataLayerInformationAccessors<
     TSettings extends Settings,
     TData,
-    TStoredData extends StoredData = Record<string, unknown>,
+    TStoredData extends StoredData = Record<string, never>,
     TSettingKey extends SettingsKeysFromTuple<TSettings> = SettingsKeysFromTuple<TSettings>,
-    TSettingTypes extends MakeSettingTypesMap<TSettings> = MakeSettingTypesMap<TSettings>
+    TSettingTypes extends MakeSettingTypesMap<TSettings> = MakeSettingTypesMap<TSettings>,
 > = {
     /**
      * Access the data that the layer is currently storing.
@@ -96,7 +96,7 @@ export type DataLayerInformationAccessors<
 export type FetchDataParams<
     TSettings extends Settings,
     TData,
-    TStoredData extends StoredData = Record<string, unknown>
+    TStoredData extends StoredData = Record<string, never>,
 > = {
     queryClient: QueryClient;
     registerQueryKey: (key: unknown[]) => void;
@@ -108,7 +108,7 @@ export interface CustomDataLayerImplementation<
     TStoredData extends StoredData = Record<string, never>,
     TSettingTypes extends MakeSettingTypesMap<TSettings> = MakeSettingTypesMap<TSettings>,
     TSettingKey extends SettingsKeysFromTuple<TSettings> = SettingsKeysFromTuple<TSettings>,
-    TStoredDataKey extends keyof TStoredData = keyof TStoredData
+    TStoredDataKey extends keyof TStoredData = keyof TStoredData,
 > extends CustomSettingsHandler<TSettings, TStoredData, TSettingTypes, TSettingKey, TStoredDataKey> {
     /**
      * The default name of a layer of this type.
@@ -126,7 +126,7 @@ export interface CustomDataLayerImplementation<
     doSettingsChangesRequireDataRefetch(
         prevSettings: TSettingTypes | null,
         newSettings: TSettingTypes,
-        accessors: DataLayerInformationAccessors<TSettings, TData, TStoredData>
+        accessors: DataLayerInformationAccessors<TSettings, TData, TStoredData>,
     ): boolean;
 
     /**

--- a/frontend/src/modules/_shared/LayerFramework/interfacesAndTypes/customSettingsHandler.ts
+++ b/frontend/src/modules/_shared/LayerFramework/interfacesAndTypes/customSettingsHandler.ts
@@ -12,23 +12,25 @@ import type { MakeSettingTypesMap, Settings } from "../settings/settingsDefiniti
 export interface GetHelperDependency<
     TSettings extends Settings,
     TSettingTypes extends MakeSettingTypesMap<TSettings>,
-    TKey extends SettingsKeysFromTuple<TSettings>
+    TKey extends SettingsKeysFromTuple<TSettings>,
 > {
     <TDep>(dep: Dependency<TDep, TSettings, TSettingTypes, TKey>): Awaited<TDep> | null;
 }
+
+export const CancelUpdate = Symbol("CancelUpdate");
 
 export interface UpdateFunc<
     TReturnValue,
     TSettings extends Settings,
     TSettingTypes extends MakeSettingTypesMap<TSettings>,
-    TKey extends SettingsKeysFromTuple<TSettings>
+    TKey extends SettingsKeysFromTuple<TSettings>,
 > {
     (args: {
         getLocalSetting: <K extends TKey>(settingName: K) => TSettingTypes[K];
         getGlobalSetting: <T extends keyof GlobalSettings>(settingName: T) => GlobalSettings[T];
         getHelperDependency: GetHelperDependency<TSettings, TSettingTypes, TKey>;
         abortSignal: AbortSignal;
-    }): TReturnValue;
+    }): TReturnValue | typeof CancelUpdate;
 }
 
 export interface DefineDependenciesArgs<
@@ -36,25 +38,25 @@ export interface DefineDependenciesArgs<
     TStoredData extends StoredData = Record<string, never>,
     TSettingTypes extends MakeSettingTypesMap<TSettings> = MakeSettingTypesMap<TSettings>,
     TKey extends SettingsKeysFromTuple<TSettings> = SettingsKeysFromTuple<TSettings>,
-    TStoredDataKey extends keyof TStoredData = keyof TStoredData
+    TStoredDataKey extends keyof TStoredData = keyof TStoredData,
 > {
     availableSettingsUpdater: <TSettingKey extends TKey>(
         settingKey: TSettingKey,
-        update: UpdateFunc<AvailableValuesType<TSettingKey>, TSettings, TSettingTypes, TKey>
+        update: UpdateFunc<AvailableValuesType<TSettingKey>, TSettings, TSettingTypes, TKey>,
     ) => Dependency<AvailableValuesType<TSettingKey>, TSettings, TSettingTypes, TKey>;
     storedDataUpdater: <K extends TStoredDataKey>(
         key: K,
-        update: UpdateFunc<NullableStoredData<TStoredData>[TStoredDataKey], TSettings, TSettingTypes, TKey>
+        update: UpdateFunc<NullableStoredData<TStoredData>[TStoredDataKey], TSettings, TSettingTypes, TKey>,
     ) => Dependency<NullableStoredData<TStoredData>[TStoredDataKey], TSettings, TSettingTypes, TKey>;
     helperDependency: <T>(
         update: (args: {
             getLocalSetting: <T extends TKey>(settingName: T) => TSettingTypes[T];
             getGlobalSetting: <T extends keyof GlobalSettings>(settingName: T) => GlobalSettings[T];
             getHelperDependency: <TDep>(
-                helperDependency: Dependency<TDep, TSettings, TSettingTypes, TKey>
+                helperDependency: Dependency<TDep, TSettings, TSettingTypes, TKey>,
             ) => TDep | null;
             abortSignal: AbortSignal;
-        }) => T
+        }) => T,
     ) => Dependency<T, TSettings, TSettingTypes, TKey>;
     workbenchSession: WorkbenchSession;
     workbenchSettings: WorkbenchSettings;
@@ -70,7 +72,7 @@ export interface CustomSettingsHandler<
     TStoredData extends StoredData = Record<string, never>,
     TSettingTypes extends MakeSettingTypesMap<TSettings> = MakeSettingTypesMap<TSettings>,
     TSettingKey extends SettingsKeysFromTuple<TSettings> = SettingsKeysFromTuple<TSettings>,
-    TStoredDataKey extends keyof TStoredData = keyof TStoredData
+    TStoredDataKey extends keyof TStoredData = keyof TStoredData,
 > {
     /**
      * The settings that this handler is using/providing.
@@ -135,6 +137,6 @@ export interface CustomSettingsHandler<
      *
      */
     defineDependencies(
-        args: DefineDependenciesArgs<TSettings, TStoredData, TSettingTypes, TSettingKey, TStoredDataKey>
+        args: DefineDependenciesArgs<TSettings, TStoredData, TSettingTypes, TSettingKey, TStoredDataKey>,
     ): void;
 }

--- a/frontend/src/modules/_shared/LayerFramework/settings/implementations/GridLayerRangeSetting.tsx
+++ b/frontend/src/modules/_shared/LayerFramework/settings/implementations/GridLayerRangeSetting.tsx
@@ -6,7 +6,6 @@ import type {
     CustomSettingImplementation,
     SettingComponentProps,
 } from "../../interfacesAndTypes/customSettingImplementation";
-import type { MakeAvailableValuesTypeBasedOnCategory } from "../../interfacesAndTypes/utils";
 import type { SettingCategory } from "../settingsDefinitions";
 
 type ValueType = [number, number] | null;
@@ -35,50 +34,6 @@ export class GridLayerRangeSetting implements CustomSettingImplementation<ValueT
             case Direction.K:
                 return "Grid layer K";
         }
-    }
-
-    isValueValid(
-        value: ValueType,
-        availableValues: MakeAvailableValuesTypeBasedOnCategory<ValueType, SettingCategory.RANGE>
-    ): boolean {
-        if (value === null) {
-            return false;
-        }
-
-        if (!availableValues) {
-            return false;
-        }
-
-        const min = availableValues[0];
-        const max = availableValues[1];
-
-        if (max === null || min === null) {
-            return false;
-        }
-
-        return value[0] >= min && value[0] <= max;
-    }
-
-    fixupValue(
-        currentValue: ValueType,
-        availableValues: MakeAvailableValuesTypeBasedOnCategory<ValueType, SettingCategory.RANGE>
-    ): ValueType {
-        if (!availableValues) {
-            return null;
-        }
-
-        const min = availableValues[0];
-        const max = availableValues[1];
-
-        if (max === null) {
-            return null;
-        }
-
-        if (currentValue === null) {
-            return [min, max];
-        }
-
-        return [Math.max(currentValue[0], min), Math.min(currentValue[1], max)];
     }
 
     makeComponent(): (props: SettingComponentProps<ValueType, SettingCategory.RANGE>) => React.ReactNode {

--- a/frontend/src/modules/_shared/LayerFramework/settings/implementations/SeismicSliceSetting.tsx
+++ b/frontend/src/modules/_shared/LayerFramework/settings/implementations/SeismicSliceSetting.tsx
@@ -24,31 +24,9 @@ export class SeismicSliceSetting implements CustomSettingImplementation<ValueTyp
         this._direction = direction;
     }
 
-    isValueValid(
-        value: ValueType,
-        availableValues: MakeAvailableValuesTypeBasedOnCategory<ValueType, SettingCategory.NUMBER_WITH_STEP>
-    ): boolean {
-        if (value === null) {
-            return false;
-        }
-
-        if (availableValues.length < 2) {
-            return false;
-        }
-
-        const min = 0;
-        const max = availableValues[1];
-
-        if (max === null) {
-            return false;
-        }
-
-        return value >= min && value <= max;
-    }
-
     fixupValue(
         currentValue: ValueType,
-        availableValues: MakeAvailableValuesTypeBasedOnCategory<ValueType, SettingCategory.NUMBER_WITH_STEP>
+        availableValues: MakeAvailableValuesTypeBasedOnCategory<ValueType, SettingCategory.NUMBER_WITH_STEP>,
     ): ValueType {
         if (availableValues.length < 2) {
             return null;
@@ -91,10 +69,10 @@ export class SeismicSliceSetting implements CustomSettingImplementation<ValueTyp
                     const step = availableValues[2];
                     const allowedValues = Array.from(
                         { length: Math.floor((max - min) / step) + 1 },
-                        (_, i) => min + i * step
+                        (_, i) => min + i * step,
                     );
                     value = allowedValues.reduce((prev, curr) =>
-                        Math.abs(curr - value) < Math.abs(prev - value) ? curr : prev
+                        Math.abs(curr - value) < Math.abs(prev - value) ? curr : prev,
                     );
                 }
 

--- a/frontend/src/modules/_shared/LayerFramework/visualization/utils/colors.ts
+++ b/frontend/src/modules/_shared/LayerFramework/visualization/utils/colors.ts
@@ -13,9 +13,12 @@ export function makeColorMapFunctionFromColorScale(
         return undefined;
     }
 
+    const localColorScale = colorScale.clone();
+    localColorScale.setRange(valueMin, valueMax);
+
     return (value: number) => {
         const nonNormalizedValue = unnormalize ? value * (valueMax - valueMin) + valueMin : value;
-        const interpolatedColor = colorScale.getColorForValue(nonNormalizedValue);
+        const interpolatedColor = localColorScale.getColorForValue(nonNormalizedValue);
         const color = parse(interpolatedColor) as Rgb;
         if (color === undefined) {
             return [0, 0, 0];
@@ -23,3 +26,4 @@ export function makeColorMapFunctionFromColorScale(
         return [color.r * 255, color.g * 255, color.b * 255];
     };
 }
+0;


### PR DESCRIPTION
- Fixed some issues regarding type-safety of `StoredData` (especially in `VisualizationFactory`)
- `StoredData` changes are now triggering `maybeRefetchData` method in `DataLayer` class
- Added a symbol `CancelUpdate` that can be returned in dependencies in order to avoid any updates and instead of returning an arbitrary empty type - e.g. when data is not available yet