### PR TITLE
Fix: `SettingManager` not calling custom `isValueValid` implementation when value is null

### DIFF
--- a/frontend/src/modules/_shared/LayerFramework/framework/SettingManager/SettingManager.ts
+++ b/frontend/src/modules/_shared/LayerFramework/framework/SettingManager/SettingManager.ts
@@ -417,9 +417,6 @@ export class SettingManager<
     }
 
     private checkIfValueIsValid(value: TValue): boolean {
-        if (value === null) {
-            return false;
-        }
         if (this._isStatic) {
             return true;
         }


### PR DESCRIPTION
Fixes #408.