### PR TITLE
[DPF]: Fix for stored data comparison and dependency waterfall order

### DIFF
--- a/frontend/src/modules/_shared/DataProviderFramework/delegates/_utils/Dependency.ts
+++ b/frontend/src/modules/_shared/DataProviderFramework/delegates/_utils/Dependency.ts
@@ -132,6 +132,16 @@ export class Dependency<
             // #Waterfall
         });
 
+        setting.getPublishSubscribeDelegate().makeSubscriberFunction(SettingTopic.VALUE_ABOUT_TO_BE_CHANGED)(() => {
+            const loading = true;
+            if (loading) {
+                this.setLoadingState(true);
+            }
+            // Not subscribing to loading state false as it will
+            // be set when this dependency is updated
+            // #Waterfall
+        });
+
         return this._cachedSettingsMap.get(settingName as string);
     }
 
@@ -245,12 +255,12 @@ export class Dependency<
     }
 
     private applyNewValue(newValue: Awaited<TReturnValue> | null) {
+        this.setLoadingState(false);
         if (!isEqual(newValue, this._cachedValue) || newValue === null) {
             this._cachedValue = newValue;
             for (const callback of this._dependencies) {
                 callback(newValue);
             }
         }
-        this.setLoadingState(false);
     }
 }

--- a/frontend/src/modules/_shared/DataProviderFramework/framework/DataProvider/DataProvider.ts
+++ b/frontend/src/modules/_shared/DataProviderFramework/framework/DataProvider/DataProvider.ts
@@ -6,7 +6,7 @@ import { PublishSubscribeDelegate } from "@modules/_shared/utils/PublishSubscrib
 import type { QueryClient } from "@tanstack/react-query";
 import { isCancelledError } from "@tanstack/react-query";
 
-import { isEqual } from "lodash";
+import { clone, isEqual } from "lodash";
 
 import { ItemDelegate } from "../../delegates/ItemDelegate";
 import {
@@ -231,7 +231,7 @@ export class DataProvider<
 
         this._cancellationPending = true;
         this._prevSettings = this._settingsContextDelegate.getValues() as TSettingTypes;
-        this._prevStoredData = this._settingsContextDelegate.getStoredDataRecord() as TStoredData;
+        this._prevStoredData = clone(this._settingsContextDelegate.getStoredDataRecord()) as TStoredData;
         this.maybeCancelQuery().then(() => {
             this.maybeRefetchData();
         });

--- a/frontend/src/modules/_shared/DataProviderFramework/framework/SettingManager/SettingManager.ts
+++ b/frontend/src/modules/_shared/DataProviderFramework/framework/SettingManager/SettingManager.ts
@@ -16,6 +16,7 @@ import { Group } from "../Group/Group";
 
 export enum SettingTopic {
     VALUE = "VALUE",
+    VALUE_ABOUT_TO_BE_CHANGED = "VALUE_ABOUT_TO_BE_CHANGED",
     IS_VALID = "IS_VALID",
     AVAILABLE_VALUES = "AVAILABLE_VALUES",
     OVERRIDDEN_VALUE = "OVERRIDDEN_VALUE",
@@ -28,6 +29,7 @@ export enum SettingTopic {
 
 export type SettingTopicPayloads<TValue, TCategory extends SettingCategory> = {
     [SettingTopic.VALUE]: TValue;
+    [SettingTopic.VALUE_ABOUT_TO_BE_CHANGED]: void;
     [SettingTopic.IS_VALID]: boolean;
     [SettingTopic.AVAILABLE_VALUES]: MakeAvailableValuesTypeBasedOnCategory<TValue, TCategory> | null;
     [SettingTopic.OVERRIDDEN_VALUE]: TValue | undefined;
@@ -186,10 +188,12 @@ export class SettingManager<
             return;
         }
         this._currentValueFromPersistence = null;
+
+        this._publishSubscribeDelegate.notifySubscribers(SettingTopic.VALUE_ABOUT_TO_BE_CHANGED);
+
         this._value = value;
 
         this.setValueValid(this.checkIfValueIsValid(this._value));
-
         this._publishSubscribeDelegate.notifySubscribers(SettingTopic.VALUE);
     }
 
@@ -314,6 +318,8 @@ export class SettingManager<
             switch (topic) {
                 case SettingTopic.VALUE:
                     return this.getValue();
+                case SettingTopic.VALUE_ABOUT_TO_BE_CHANGED:
+                    return;
                 case SettingTopic.IS_VALID:
                     return this._isValueValid;
                 case SettingTopic.AVAILABLE_VALUES:


### PR DESCRIPTION
- Previous stored data was not stored as a clone but as a reference - this would cause `isEqual` to always return true in `DataProvider`.
- Dependencies using local settings did only subscribe to the setting's loading state change but not all settings would actually load - this could cause sequence issues when checking if all dependencies were loaded as some dependency update had not been triggered yet but all had their loading state set to true. Now, all dependencies using local settings do also subscribe to when values are about to be changed and immediately set their loading state to true. It is important to subscribe to this earlier event as we cannot guarantee correct order when just subscribing to value changes.