### PR TITLE
Added data sharing disclaimer on login screen

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,11 +18,27 @@ import { resolveClassNames } from "@lib/utils/resolveClassNames";
 import "./modules/registerAllModules";
 import "./templates/registerAllTemplates";
 
+function DataSharingLabel() {
+    return (
+        <div className="border-2 border-orange-600  px-3 py-2 rounded-sm max-w-[600px] text-justify mt-4 z-50 shadow-sm">
+            <p>
+                <strong>Disclaimer:</strong> Webviz is a service provided by Equinor and is not a way of sharing
+                official data. Data should continue to be shared through L2S, FTP and/or Dasha.
+            </p>
+            <p className="mt-3">
+                References to e.g. earlier models, model results and data should still be done through the mentioned
+                tools, and not Webviz. Since Webviz is currently under heavy development and not production ready, there
+                is no guarantee given as of now that calculations are error-free.
+            </p>
+        </div>
+    );
+}
+
 function DevLabel() {
     return (
-        <div className="bg-orange-600 text-white p-2 rounded-sm max-w-[400px] text-sm text-center mt-4 z-50 shadow-sm">
-            <strong>NOTE:</strong> This application is still under heavy development and bugs are to be expected. Please
-            help us improve Webviz by reporting any undesired behaviour either on{" "}
+        <div className="bg-orange-600 text-white px-3 py-2 rounded-sm max-w-[400px] text-sm text-justify mt-4 z-50 shadow-sm">
+            <strong>NOTE:</strong> This application is still under heavy development; bugs and occasional downtime
+            should be expected. Please help us improve Webviz by reporting any undesired behaviour either on{" "}
             <a href="https://equinor.slack.com/messages/webviz/" target="blank" className="underline cursor-pointer">
                 Slack
             </a>{" "}
@@ -133,9 +149,12 @@ function App() {
 
     return (
         <>
+            {/* <UsageNoticeDialog /> */}
+
             {authState === AuthState.NotLoggedIn ? (
                 <div className="w-screen h-screen flex flex-col items-center justify-center gap-8">
                     <img src={WebvizLogo} alt="Webviz logo" className="w-32 h-32" />
+                    <DataSharingLabel />
                     <p className="text-lg">Please sign in to continue.</p>
                     <Button onClick={signIn}>Sign in</Button>
                     <DevLabel />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -20,7 +20,7 @@ import "./templates/registerAllTemplates";
 
 function DataSharingLabel() {
     return (
-        <div className="border-2 border-orange-600  px-3 py-2 rounded-sm max-w-[600px] text-justify mt-4 z-50 shadow-sm">
+        <div className="border-2 border-orange-600 px-3 py-2 rounded-sm max-w-[600px] text-justify mt-4 z-50 shadow-sm">
             <p>
                 <strong>Disclaimer:</strong> Webviz is a service provided by Equinor and is not a way of sharing
                 official data. Data should continue to be shared through L2S, FTP and/or Dasha.
@@ -149,8 +149,6 @@ function App() {
 
     return (
         <>
-            {/* <UsageNoticeDialog /> */}
-
             {authState === AuthState.NotLoggedIn ? (
                 <div className="w-screen h-screen flex flex-col items-center justify-center gap-8">
                     <img src={WebvizLogo} alt="Webviz logo" className="w-32 h-32" />


### PR DESCRIPTION
Resolves #942. Adds a disclaimer regarding data sharing and quality to the login page. Also tweaks the existing orange dev notice to mention down-time.

![image](https://github.com/user-attachments/assets/8df69c27-f7e6-447d-9c47-4c3f7336a13f)
