### PR TITLE
Increase max number of HTTPX connections + disable Sumo Explorer retries

### DIFF
--- a/backend_py/primary/primary/services/sumo_access/sumo_client_factory.py
+++ b/backend_py/primary/primary/services/sumo_access/sumo_client_factory.py
@@ -1,6 +1,6 @@
 import logging
 
-from fmu.sumo.explorer.explorer import SumoClient
+from sumo.wrapper import SumoClient, RetryStrategy
 from webviz_pkg.core_utils.perf_timer import PerfTimer
 
 from primary import config
@@ -29,6 +29,7 @@ def create_sumo_client(access_token: str) -> SumoClient:
         sumo_client = SumoClient(
             env=config.SUMO_ENV,
             token=access_token,
+            retry_strategy=RetryStrategy(stop_after=1),
             http_client=_FakeSyncHttpClient(),
             async_http_client=HTTPX_ASYNC_CLIENT_WRAPPER.client,
         )

--- a/backend_py/primary/primary/services/utils/httpx_async_client_wrapper.py
+++ b/backend_py/primary/primary/services/utils/httpx_async_client_wrapper.py
@@ -28,8 +28,11 @@ class HTTPXAsyncClientWrapper:
     def start(self) -> None:
         """Instantiate the client. Call from the FastAPI startup hook."""
         if self._async_client is None:
-            self._async_client = httpx.AsyncClient()
-            LOGGER.info(f"httpx AsyncClient instantiated. Id {id(self._async_client)}")
+            # Try and increase the maximum number of concurrent connections and the max number of
+            # keep-alive connections from their defualts of 100 and 20 respectively.
+            limits=httpx.Limits(max_connections=300, max_keepalive_connections=100)
+            self._async_client = httpx.AsyncClient(limits=limits)
+            LOGGER.info(f"httpx AsyncClient instantiated: id={id(self._async_client)}, {limits=}")
 
     async def stop_async(self) -> None:
         """Gracefully shutdown. Call from FastAPI shutdown hook."""


### PR DESCRIPTION
Increase httpx limits:
* `max_connections=300`
* `max_keepalive_connections=100`

Disable Sumo Explorer retries by using a retry strategy: `RetryStrategy(stop_after=1)`