### PR TITLE
[DPF] Visualization assembler product hook

### DIFF
--- a/frontend/src/modules/2DViewer/view/components/LayersWrapper.tsx
+++ b/frontend/src/modules/2DViewer/view/components/LayersWrapper.tsx
@@ -30,6 +30,7 @@ import { DrilledWellTrajectoriesProvider } from "@modules/_shared/DataProviderFr
 import type { DataProviderManager } from "@modules/_shared/DataProviderFramework/framework/DataProviderManager/DataProviderManager";
 import { DataProviderManagerTopic } from "@modules/_shared/DataProviderFramework/framework/DataProviderManager/DataProviderManager";
 import { GroupType } from "@modules/_shared/DataProviderFramework/groups/groupTypes";
+import { useVisualizationAssemblerProduct } from "@modules/_shared/DataProviderFramework/hooks/useVisualizationProduct";
 import { makeDrilledWellborePicksBoundingBox } from "@modules/_shared/DataProviderFramework/visualization/deckgl/boundingBoxes/makeDrilledWellborePicksBoundingBox";
 import { makeDrilledWellTrajectoriesBoundingBox } from "@modules/_shared/DataProviderFramework/visualization/deckgl/boundingBoxes/makeDrilledWellTrajectoriesBoundingBox";
 import { makeDrilledWellborePicksLayer } from "@modules/_shared/DataProviderFramework/visualization/deckgl/makeDrilledWellborePicksLayer";
@@ -124,7 +125,10 @@ export function LayersWrapper(props: LayersWrapperProps): React.ReactNode {
 
     usePublishSubscribeTopicValue(props.layerManager, DataProviderManagerTopic.DATA_REVISION);
 
-    const assemblerProduct = VISUALIZATION_ASSEMBLER.make(props.layerManager);
+    // const assemblerProduct = VISUALIZATION_ASSEMBLER.make(props.layerManager);
+
+    const assemblerProduct = useVisualizationAssemblerProduct(props.layerManager, VISUALIZATION_ASSEMBLER);
+
     const globalAnnotations = assemblerProduct.annotations.filter((el) => "colorScale" in el);
 
     const viewports: ViewportTypeExtended[] = [];

--- a/frontend/src/modules/2DViewer/view/components/LayersWrapper.tsx
+++ b/frontend/src/modules/2DViewer/view/components/LayersWrapper.tsx
@@ -28,7 +28,6 @@ import { DataProviderType } from "@modules/_shared/DataProviderFramework/dataPro
 import { DrilledWellborePicksProvider } from "@modules/_shared/DataProviderFramework/dataProviders/implementations/DrilledWellborePicksProvider";
 import { DrilledWellTrajectoriesProvider } from "@modules/_shared/DataProviderFramework/dataProviders/implementations/DrilledWellTrajectoriesProvider";
 import type { DataProviderManager } from "@modules/_shared/DataProviderFramework/framework/DataProviderManager/DataProviderManager";
-import { DataProviderManagerTopic } from "@modules/_shared/DataProviderFramework/framework/DataProviderManager/DataProviderManager";
 import { GroupType } from "@modules/_shared/DataProviderFramework/groups/groupTypes";
 import { useVisualizationAssemblerProduct } from "@modules/_shared/DataProviderFramework/hooks/useVisualizationProduct";
 import { makeDrilledWellborePicksBoundingBox } from "@modules/_shared/DataProviderFramework/visualization/deckgl/boundingBoxes/makeDrilledWellborePicksBoundingBox";
@@ -40,7 +39,6 @@ import {
     VisualizationAssembler,
     VisualizationItemType,
 } from "@modules/_shared/DataProviderFramework/visualization/VisualizationAssembler";
-import { usePublishSubscribeTopicValue } from "@modules/_shared/utils/PublishSubscribeDelegate";
 
 import { PlaceholderLayer } from "../../../_shared/customDeckGlLayers/PlaceholderLayer";
 
@@ -122,10 +120,6 @@ export function LayersWrapper(props: LayersWrapperProps): React.ReactNode {
     const [prevBoundingBox, setPrevBoundingBox] = React.useState<bbox.BBox | null>(null);
 
     const statusWriter = useViewStatusWriter(props.viewContext);
-
-    usePublishSubscribeTopicValue(props.layerManager, DataProviderManagerTopic.DATA_REVISION);
-
-    // const assemblerProduct = VISUALIZATION_ASSEMBLER.make(props.layerManager);
 
     const assemblerProduct = useVisualizationAssemblerProduct(props.layerManager, VISUALIZATION_ASSEMBLER);
 

--- a/frontend/src/modules/_shared/DataProviderFramework/hooks/useVisualizationProduct.ts
+++ b/frontend/src/modules/_shared/DataProviderFramework/hooks/useVisualizationProduct.ts
@@ -1,0 +1,37 @@
+import React from "react";
+
+import {
+    DataProviderManagerTopic,
+    type DataProviderManager,
+} from "../framework/DataProviderManager/DataProviderManager";
+import type {
+    AssemblerProduct,
+    CustomGroupPropsMap,
+    VisualizationAssembler,
+    VisualizationTarget,
+} from "../visualization/VisualizationAssembler";
+
+export function useVisualizationAssemblerProduct<
+    TTarget extends VisualizationTarget,
+    TCustomGroupProps extends CustomGroupPropsMap,
+    TAccumulatedData extends Record<string, any>,
+>(
+    dataProviderManager: DataProviderManager,
+    visualizationAssembler: VisualizationAssembler<TTarget, TCustomGroupProps, TAccumulatedData>,
+): AssemblerProduct<TTarget, TCustomGroupProps, TAccumulatedData> {
+    const latestRevision = React.useSyncExternalStore(
+        dataProviderManager
+            .getPublishSubscribeDelegate()
+            .makeSubscriberFunction(DataProviderManagerTopic.DATA_REVISION),
+        dataProviderManager.makeSnapshotGetter(DataProviderManagerTopic.DATA_REVISION),
+    );
+
+    const productMemoized = React.useMemo(() => {
+        return visualizationAssembler.make(dataProviderManager);
+
+        // ! "latestRevision" is included in the array to trigger recomputes
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [latestRevision, dataProviderManager, visualizationAssembler]);
+
+    return productMemoized;
+}


### PR DESCRIPTION
Adds a small hook to make the `VisualizationAssembler.make(...)` function only run when actual data revisions have happened