### PR TITLE
Framework - preserve plot state

### DIFF
--- a/frontend/src/modules/DistributionPlot/view.tsx
+++ b/frontend/src/modules/DistributionPlot/view.tsx
@@ -13,9 +13,9 @@ import { ColorScaleGradientType } from "@lib/utils/ColorScale";
 import type { Size2D } from "@lib/utils/geometry";
 import { ContentInfo } from "@modules/_shared/components/ContentMessage";
 import { ContentWarning } from "@modules/_shared/components/ContentMessage/contentMessage";
+import { Plot } from "@modules/_shared/components/Plot";
 import { makeSubplots } from "@modules/_shared/Figure";
 import { makeHistogramTrace } from "@modules/_shared/histogram";
-
 
 import type { Interfaces } from "./interfaces";
 import { PlotType } from "./typesAndEnums";
@@ -207,7 +207,7 @@ export const View = ({ viewContext, workbenchSettings }: ModuleViewProps<Interfa
                         cellIndex++;
                     }
                 }
-                setContent(figure.makePlot());
+                setContent(<Plot data={figure.makeData()} layout={figure.makeLayout()} />);
                 return;
             }
 
@@ -279,7 +279,7 @@ export const View = ({ viewContext, workbenchSettings }: ModuleViewProps<Interfa
                     }
                 }
 
-                setContent(figure.makePlot());
+                setContent(<Plot data={figure.makeData()} layout={figure.makeLayout()} />);
                 return;
             }
 
@@ -435,7 +435,7 @@ export const View = ({ viewContext, workbenchSettings }: ModuleViewProps<Interfa
                     autosize: true,
                 };
                 figure.updateLayout(patch);
-                setContent(figure.makePlot());
+                setContent(<Plot data={figure.makeData()} layout={figure.makeLayout()} />);
                 return;
             }
         });

--- a/frontend/src/modules/MyModule/view.tsx
+++ b/frontend/src/modules/MyModule/view.tsx
@@ -1,12 +1,11 @@
 import React from "react";
 
 import type { PlotData } from "plotly.js";
-import Plot from "react-plotly.js";
 
 import type { ModuleViewProps } from "@framework/Module";
 import { useElementSize } from "@lib/hooks/useElementSize";
 import { ColorScaleType } from "@lib/utils/ColorScale";
-
+import { Plot } from "@modules/_shared/components/Plot";
 
 import type { Interfaces } from "./interfaces";
 

--- a/frontend/src/modules/ParameterCorrelationPlot/view/parameterCorrelationFigure.ts
+++ b/frontend/src/modules/ParameterCorrelationPlot/view/parameterCorrelationFigure.ts
@@ -64,8 +64,12 @@ export class ParameterCorrelationFigure {
         });
     }
 
-    build(handleOnClick?: ((event: Readonly<Plotly.PlotMouseEvent>) => void) | undefined): React.ReactNode {
-        return this._figure.makePlot({ onClick: handleOnClick });
+    buildData() {
+        return this._figure.makeData();
+    }
+
+    buildLayout() {
+        return this._figure.makeLayout();
     }
 }
 

--- a/frontend/src/modules/ParameterDistributionMatrix/view/components/ParameterDistributionPlot.tsx
+++ b/frontend/src/modules/ParameterDistributionMatrix/view/components/ParameterDistributionPlot.tsx
@@ -1,10 +1,9 @@
 import type React from "react";
 
 import type { PlotType } from "plotly.js";
-import Plot from "react-plotly.js";
 
+import { Plot } from "@modules/_shared/components/Plot";
 import { computeQuantile } from "@modules/_shared/utils/math/statistics";
-
 
 import type { ParameterDataArr } from "../../typesAndEnums";
 import { ParameterDistributionPlotType } from "../../typesAndEnums";

--- a/frontend/src/modules/ParameterResponseCrossPlot/view/scatterPlotParameterResponseFigure.ts
+++ b/frontend/src/modules/ParameterResponseCrossPlot/view/scatterPlotParameterResponseFigure.ts
@@ -66,8 +66,12 @@ export class ScatterPlotParameterResponseFigure {
         };
         this._figure.updateLayout(layoutPatch);
     }
-    build() {
-        return this._figure.makePlot();
+
+    buildData() {
+        return this._figure.makeData();
+    }
+    buildLayout() {
+        return this._figure.makeLayout();
     }
 }
 export type scatterPlotParameterResponseData = {

--- a/frontend/src/modules/ParameterResponseCrossPlot/view/view.tsx
+++ b/frontend/src/modules/ParameterResponseCrossPlot/view/view.tsx
@@ -13,6 +13,7 @@ import { useElementSize } from "@lib/hooks/useElementSize";
 import type { Size2D } from "@lib/utils/geometry";
 import { ContentInfo } from "@modules/_shared/components/ContentMessage";
 import { ContentWarning } from "@modules/_shared/components/ContentMessage/contentMessage";
+import { Plot } from "@modules/_shared/components/Plot";
 
 import type { Interfaces } from "../interfaces";
 import { PlotType } from "../typesAndEnums";
@@ -184,7 +185,7 @@ export function View({ viewContext, workbenchSession }: ModuleViewProps<Interfac
                 }
             }
 
-            setContent(figure.build());
+            setContent(<Plot data={figure.buildData()} layout={figure.buildLayout()} />);
             return;
         }
     }

--- a/frontend/src/modules/ParameterResponseParallelCoordsPlot/view/parallelCoordinatesFigure.ts
+++ b/frontend/src/modules/ParameterResponseParallelCoordsPlot/view/parallelCoordinatesFigure.ts
@@ -54,8 +54,11 @@ export class ParallelCoordinatesFigure {
         this._figure.updateLayout({ width: width });
     }
 
-    build() {
-        return this._figure.makePlot();
+    buildLayout() {
+        return this._figure.makeLayout();
+    }
+    buildData() {
+        return this._figure.makeData();
     }
 }
 

--- a/frontend/src/modules/ParameterResponseParallelCoordsPlot/view/view.tsx
+++ b/frontend/src/modules/ParameterResponseParallelCoordsPlot/view/view.tsx
@@ -13,6 +13,7 @@ import { useElementSize } from "@lib/hooks/useElementSize";
 import type { Size2D } from "@lib/utils/geometry";
 import { ContentInfo } from "@modules/_shared/components/ContentMessage";
 import { ContentWarning } from "@modules/_shared/components/ContentMessage/contentMessage";
+import { Plot } from "@modules/_shared/components/Plot";
 import type { ResponseData } from "@modules/_shared/rankParameter";
 import { createRankedParameterCorrelations, getRankedParameterData } from "@modules/_shared/rankParameter";
 
@@ -140,7 +141,7 @@ export function View({ viewContext, workbenchSession }: ModuleViewProps<Interfac
             const figure = new ParallelCoordinatesFigure(wrapperDivSize);
             figure.addPlot(responseData, rankedParametersData, {});
 
-            setContent(figure.build());
+            setContent(<Plot data={figure.buildData()} layout={figure.buildLayout()} />);
             return;
         });
     }

--- a/frontend/src/modules/Pvt/utils/PvtPlotBuilder.ts
+++ b/frontend/src/modules/Pvt/utils/PvtPlotBuilder.ts
@@ -7,7 +7,6 @@ import type { Size2D } from "@lib/utils/geometry";
 import type { Figure } from "@modules/_shared/Figure";
 import { makeSubplots } from "@modules/_shared/Figure";
 
-
 import {
     ColorBy,
     PRESSURE_DEPENDENT_VARIABLE_TO_DISPLAY_NAME,
@@ -16,7 +15,6 @@ import {
 } from "../typesAndEnums";
 
 import type { PvtDataAccessor } from "./PvtDataAccessor";
-
 
 type TracePointData = {
     ratio: number;
@@ -287,9 +285,12 @@ export class PvtPlotBuilder {
         }
     }
 
-    makePlot(): React.ReactNode {
-        const figure = this.getFigureAndAssertValidity();
-        return figure.makePlot();
+    buildData() {
+        return this.getFigureAndAssertValidity().makeData();
+    }
+
+    buildLayout() {
+        return this.getFigureAndAssertValidity().makeLayout();
     }
 
     private makeHoverTemplate(

--- a/frontend/src/modules/Pvt/view.tsx
+++ b/frontend/src/modules/Pvt/view.tsx
@@ -9,6 +9,7 @@ import { useEnsembleSet } from "@framework/WorkbenchSession";
 import { CircularProgress } from "@lib/components/CircularProgress";
 import { useElementSize } from "@lib/hooks/useElementSize";
 import { ContentMessage, ContentMessageType } from "@modules/_shared/components/ContentMessage/contentMessage";
+import { Plot } from "@modules/_shared/components/Plot";
 import { makeDistinguishableEnsembleDisplayName } from "@modules/_shared/ensembleNameUtils";
 
 import type { Interfaces } from "./interfaces";
@@ -88,7 +89,7 @@ export function View({ viewContext, workbenchSettings, workbenchSession }: Modul
         pvtPlotBuilder.makeLayout(selectedPhase, selectedPlots, wrapperDivSize);
         pvtPlotBuilder.makeTraces(selectedPlots, selectedPvtNums, selectedPhase, selectedColorBy, colorSet);
 
-        return pvtPlotBuilder.makePlot();
+        return <Plot layout={pvtPlotBuilder.buildLayout()} data={pvtPlotBuilder.buildData()} />;
     }
 
     return (

--- a/frontend/src/modules/Rft/view.tsx
+++ b/frontend/src/modules/Rft/view.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 
 import type { PlotData } from "plotly.js";
-import Plot from "react-plotly.js";
 
 import type { RftRealizationData_api } from "@api";
 import type { ModuleViewProps } from "@framework/Module";
@@ -10,8 +9,8 @@ import { timestampUtcMsToCompactIsoString } from "@framework/utils/timestampUtil
 import { CircularProgress } from "@lib/components/CircularProgress";
 import { useElementSize } from "@lib/hooks/useElementSize";
 import { ContentMessage, ContentMessageType } from "@modules/_shared/components/ContentMessage/contentMessage";
+import { Plot } from "@modules/_shared/components/Plot";
 import { usePropagateApiErrorToStatusWriter } from "@modules/_shared/hooks/usePropagateApiErrorToStatusWriter";
-
 
 import type { Interfaces } from "./interfaces";
 

--- a/frontend/src/modules/SimulationTimeSeries/view/hooks/useMakeViewStatusWriterMessages.ts
+++ b/frontend/src/modules/SimulationTimeSeries/view/hooks/useMakeViewStatusWriterMessages.ts
@@ -7,7 +7,7 @@ import type { RegularEnsemble } from "@framework/RegularEnsemble";
 import type { ViewStatusWriter } from "@framework/StatusWriter";
 import type { Interfaces } from "@modules/SimulationTimeSeries/interfaces";
 
-
+import { showObservationsAtom } from "../atoms/baseAtoms";
 import {
     historicalDataQueryHasErrorAtom,
     queryIsFetchingAtom,
@@ -23,7 +23,8 @@ export function useMakeViewStatusWriterMessages(
     ensemblesWithoutParameter: (RegularEnsemble | DeltaEnsemble)[],
 ) {
     const ensembleSet = useAtomValue(EnsembleSetAtom);
-    const showObservations = viewContext.useSettingsToViewInterfaceValue("showObservations");
+    const showObservations = useAtomValue(showObservationsAtom);
+
     const vectorObservationsQueries = useAtomValue(vectorObservationsQueriesAtom);
     const isQueryFetching = useAtomValue(queryIsFetchingAtom);
     const hasHistoricalVectorQueryError = useAtomValue(historicalDataQueryHasErrorAtom);

--- a/frontend/src/modules/SimulationTimeSeries/view/hooks/usePlotBuilder.ts
+++ b/frontend/src/modules/SimulationTimeSeries/view/hooks/usePlotBuilder.ts
@@ -1,5 +1,3 @@
-import type React from "react";
-
 import { useAtomValue } from "jotai";
 
 import type { SummaryVectorObservations_api } from "@api";
@@ -8,11 +6,9 @@ import type { ColorSet } from "@lib/utils/ColorSet";
 import type { Size2D } from "@lib/utils/geometry";
 import type { Interfaces } from "@modules/SimulationTimeSeries/interfaces";
 
-
-
 import type { VectorSpec } from "../../typesAndEnums";
 import { GroupBy, VisualizationMode } from "../../typesAndEnums";
-import { resampleFrequencyAtom } from "../atoms/baseAtoms";
+import { resampleFrequencyAtom, showObservationsAtom, visualizationModeAtom } from "../atoms/baseAtoms";
 import {
     activeTimestampUtcMsAtom,
     loadedRegularEnsembleVectorSpecificationsAndHistoricalDataAtom,
@@ -34,11 +30,11 @@ export function usePlotBuilder(
     wrapperDivSize: Size2D,
     colorSet: ColorSet,
     ensemblesParameterColoring: EnsemblesContinuousParameterColoring | null,
-    handlePlotOnClick?: ((event: Readonly<Plotly.PlotMouseEvent>) => void) | undefined,
-): React.ReactNode {
+): PlotBuilder {
     const groupBy = viewContext.useSettingsToViewInterfaceValue("groupBy");
-    const visualizationMode = viewContext.useSettingsToViewInterfaceValue("visualizationMode");
-    const showObservations = viewContext.useSettingsToViewInterfaceValue("showObservations");
+    const showObservations = useAtomValue(showObservationsAtom);
+    const visualizationMode = useAtomValue(visualizationModeAtom);
+
     const vectorSpecifications = viewContext.useSettingsToViewInterfaceValue("vectorSpecifications");
     const showHistorical = viewContext.useSettingsToViewInterfaceValue("showHistorical");
     const statisticsSelection = viewContext.useSettingsToViewInterfaceValue("statisticsSelection");
@@ -46,6 +42,7 @@ export function usePlotBuilder(
 
     const resampleFrequency = useAtomValue(resampleFrequencyAtom);
     const vectorObservationsQueries = useAtomValue(vectorObservationsQueriesAtom);
+
     const loadedVectorSpecificationsAndRealizationData = useAtomValue(loadedVectorSpecificationsAndRealizationDataAtom);
     const loadedVectorSpecificationsAndStatisticsData = useAtomValue(loadedVectorSpecificationsAndStatisticsDataAtom);
     const loadedRegularEnsembleVectorSpecificationsAndHistoricalData = useAtomValue(
@@ -138,7 +135,5 @@ export function usePlotBuilder(
         plotBuilder.addTimeAnnotation(activeTimestampUtcMs);
     }
 
-    const plot = plotBuilder.build(handlePlotOnClick);
-
-    return plot;
+    return plotBuilder;
 }

--- a/frontend/src/modules/SimulationTimeSeries/view/utils/PlotBuilder.ts
+++ b/frontend/src/modules/SimulationTimeSeries/view/utils/PlotBuilder.ts
@@ -1,6 +1,7 @@
 import type React from "react";
 
 import type { Annotations, PlotMarker, Shape } from "plotly.js";
+import type { PlotParams } from "react-plotly.js";
 
 import type {
     DerivedVectorInfo_api,
@@ -21,7 +22,6 @@ import { simulationUnitReformat, simulationVectorDescription } from "@modules/_s
 import type { VectorSpec } from "@modules/SimulationTimeSeries/typesAndEnums";
 import { FrequencyEnumToStringMapping, SubplotLimitDirection } from "@modules/SimulationTimeSeries/typesAndEnums";
 import { createDerivedVectorDescription } from "@modules/SimulationTimeSeries/utils/vectorDescriptionUtils";
-
 
 import { scaleHexColorLightness } from "./colorUtils";
 import type { EnsemblesContinuousParameterColoring } from "./ensemblesContinuousParameterColoring";
@@ -259,6 +259,33 @@ export class PlotBuilder {
         }
     }
 
+    buildProps(customProps?: Omit<Partial<PlotParams>, "data" | "layout">): PlotParams {
+        this.createGraphLegends();
+        this.updateSubplotTitles();
+
+        // Add time annotations and shapes
+        for (let index = 0; index < this._numberOfSubplots; index++) {
+            const { row, col } = this.getSubplotRowAndColFromIndex(index);
+            for (const timeAnnotation of this.createTimeAnnotations()) {
+                this._figure.addAnnotation(timeAnnotation, row, col, CoordinateDomain.DATA, CoordinateDomain.SCENE);
+            }
+            for (const timeShape of this.createTimeShapes()) {
+                this._figure.addShape(timeShape, row, col, CoordinateDomain.DATA, CoordinateDomain.SCENE);
+            }
+        }
+
+        return {
+            data: this._figure.makeData(),
+            layout: this._figure.makeLayout(),
+            ...customProps,
+        };
+    }
+
+    /**
+     * @deprecated
+     * @param handleOnClick
+     * @returns
+     */
     build(handleOnClick?: ((event: Readonly<Plotly.PlotMouseEvent>) => void) | undefined): React.ReactNode {
         this.createGraphLegends();
         this.updateSubplotTitles();

--- a/frontend/src/modules/SimulationTimeSeries/view/utils/PlotBuilder.ts
+++ b/frontend/src/modules/SimulationTimeSeries/view/utils/PlotBuilder.ts
@@ -1,5 +1,3 @@
-import type React from "react";
-
 import type { Annotations, PlotMarker, Shape } from "plotly.js";
 import type { PlotParams } from "react-plotly.js";
 
@@ -279,29 +277,6 @@ export class PlotBuilder {
             layout: this._figure.makeLayout(),
             ...customProps,
         };
-    }
-
-    /**
-     * @deprecated
-     * @param handleOnClick
-     * @returns
-     */
-    build(handleOnClick?: ((event: Readonly<Plotly.PlotMouseEvent>) => void) | undefined): React.ReactNode {
-        this.createGraphLegends();
-        this.updateSubplotTitles();
-
-        // Add time annotations and shapes
-        for (let index = 0; index < this._numberOfSubplots; index++) {
-            const { row, col } = this.getSubplotRowAndColFromIndex(index);
-            for (const timeAnnotation of this.createTimeAnnotations()) {
-                this._figure.addAnnotation(timeAnnotation, row, col, CoordinateDomain.DATA, CoordinateDomain.SCENE);
-            }
-            for (const timeShape of this.createTimeShapes()) {
-                this._figure.addShape(timeShape, row, col, CoordinateDomain.DATA, CoordinateDomain.SCENE);
-            }
-        }
-
-        return this._figure.makePlot({ onClick: handleOnClick });
     }
 
     addRealizationTracesColoredByParameter(

--- a/frontend/src/modules/SimulationTimeSeriesSensitivity/view/components/timeSeriesChart.tsx
+++ b/frontend/src/modules/SimulationTimeSeriesSensitivity/view/components/timeSeriesChart.tsx
@@ -1,10 +1,9 @@
 import type React from "react";
 
 import type { Layout, PlotDatum, PlotHoverEvent, PlotMouseEvent } from "plotly.js";
-import Plot from "react-plotly.js";
 
 import { timestampUtcMsToCompactIsoString } from "@framework/utils/timestampUtils";
-
+import { Plot } from "@modules/_shared/components/Plot";
 
 import type { TimeSeriesPlotlyTrace } from "../utils/createTracesUtils";
 

--- a/frontend/src/modules/TornadoChart/view/components/sensitivityChart.tsx
+++ b/frontend/src/modules/TornadoChart/view/components/sensitivityChart.tsx
@@ -1,11 +1,10 @@
 import React from "react";
 
 import type { Layout, PlotData, PlotMouseEvent } from "plotly.js";
-import Plot from "react-plotly.js";
 
+import { Plot } from "@modules/_shared/components/Plot";
 import type { SensitivityColorMap } from "@modules/_shared/sensitivityColors";
 import type { SelectedSensitivity } from "@modules/TornadoChart/typesAndEnums";
-
 
 import type { SensitivityResponse, SensitivityResponseDataset } from "../utils/sensitivityResponseCalculator";
 

--- a/frontend/src/modules/Vfp/view.tsx
+++ b/frontend/src/modules/Vfp/view.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 
 import type { PlotData } from "plotly.js";
-import Plot from "react-plotly.js";
 
 import type { ModuleViewProps } from "@framework/Module";
 import { useViewStatusWriter } from "@framework/StatusWriter";
@@ -9,8 +8,8 @@ import { CircularProgress } from "@lib/components/CircularProgress";
 import { useElementSize } from "@lib/hooks/useElementSize";
 import { ColorScaleGradientType } from "@lib/utils/ColorScale";
 import { ContentMessage, ContentMessageType } from "@modules/_shared/components/ContentMessage/contentMessage";
+import { Plot } from "@modules/_shared/components/Plot";
 import { usePropagateApiErrorToStatusWriter } from "@modules/_shared/hooks/usePropagateApiErrorToStatusWriter";
-
 
 import type { Interfaces } from "./interfaces";
 import { VfpDataAccessor } from "./utils/vfpDataAccessor";

--- a/frontend/src/modules/_shared/Figure.tsx
+++ b/frontend/src/modules/_shared/Figure.tsx
@@ -1,5 +1,5 @@
 import { merge } from "lodash";
-import type { Annotations, AxisType, Layout, PlotData, Shape, XAxisName, YAxisName } from "plotly.js";
+import type { Annotations, AxisType, Data, Layout, PlotData, Shape, XAxisName, YAxisName } from "plotly.js";
 import type { PlotParams } from "react-plotly.js";
 import Plot from "react-plotly.js";
 
@@ -168,8 +168,12 @@ export class Figure {
         subplotTitleAnnotation.text = title;
     }
 
+    makeData(): Partial<Data>[] {
+        return [...this._plotData];
+    }
+
     makeLayout(): Partial<Layout> {
-        const layout = { ...this._plotLayout };
+        const layout: Partial<Layout> = { ...this._plotLayout };
         layout.annotations = [
             ...(layout.annotations ?? []),
             ...Array.from(this._axesIndexToSubplotTitleAnnotationMap.values()),
@@ -190,6 +194,9 @@ export class Figure {
         merge(this._plotLayout, patch);
     }
 
+    /**
+     * @deprecated Use the Plot component, combined with makeData() and makeLayout() instead
+     */
     makePlot(plotArgs?: Omit<PlotParams, "data" | "layout">): React.ReactNode {
         const config = plotArgs?.config ?? {
             displaylogo: false,
@@ -318,7 +325,7 @@ export function makeSubplots(options: MakeSubplotOptions): Figure {
             t: titleMargin,
             b: 0,
         },
-        title: options.title,
+        title: { text: options.title },
     };
 
     const axesIndexToSubplotTitleAnnotationMap: Map<number, Partial<Annotations>> = new Map();

--- a/frontend/src/modules/_shared/Figure.tsx
+++ b/frontend/src/modules/_shared/Figure.tsx
@@ -1,7 +1,5 @@
 import { merge } from "lodash";
 import type { Annotations, AxisType, Data, Layout, PlotData, Shape, XAxisName, YAxisName } from "plotly.js";
-import type { PlotParams } from "react-plotly.js";
-import Plot from "react-plotly.js";
 
 /**
  * Enum for axis coordinate domain.
@@ -192,27 +190,6 @@ export class Figure {
 
     updateLayout(patch: Partial<Layout>): void {
         merge(this._plotLayout, patch);
-    }
-
-    /**
-     * @deprecated Use the Plot component, combined with makeData() and makeLayout() instead
-     */
-    makePlot(plotArgs?: Omit<PlotParams, "data" | "layout">): React.ReactNode {
-        const config = plotArgs?.config ?? {
-            displaylogo: false,
-            responsive: true,
-            modeBarButtonsToRemove: ["toImage", "sendDataToCloud", "resetScale2d"],
-        };
-
-        return (
-            <Plot
-                key={this._plotData.length} // Note: Temporary to trigger re-render and remove legends when plotData is empty
-                data={this._plotData}
-                layout={this.makeLayout()}
-                config={config}
-                {...plotArgs}
-            />
-        );
     }
 
     private makeYAxisRef(axisIndex: number, coordinateDomain: CoordinateDomain): YAxisName {

--- a/frontend/src/modules/_shared/InplaceVolumetrics/PlotBuilder.tsx
+++ b/frontend/src/modules/_shared/InplaceVolumetrics/PlotBuilder.tsx
@@ -2,7 +2,7 @@ import type React from "react";
 
 import type { Axis, PlotData } from "plotly.js";
 
-
+import { Plot } from "../components/Plot";
 import type { Figure, MakeSubplotOptions } from "../Figure";
 import { CoordinateDomain, makeSubplots } from "../Figure";
 
@@ -96,7 +96,7 @@ export class PlotBuilder {
         if (!this._groupByColumn) {
             const figure = this.buildSubplots(this._table, height, width, options ?? {});
             this.updateLayout(figure);
-            return figure.makePlot();
+            return <Plot layout={figure.makeLayout()} data={figure.makeData()} />;
         }
 
         const components: React.ReactNode[] = [];
@@ -109,7 +109,7 @@ export class PlotBuilder {
             this.updateLayout(figure);
             const label = this._formatLabelFunction(tableCollection.getCollectedBy(), key);
             components.push(<h3 key={key}>{label}</h3>);
-            components.push(figure.makePlot());
+            components.push(<Plot layout={figure.makeLayout()} data={figure.makeData()} />);
         }
 
         return <>{components}</>;

--- a/frontend/src/modules/_shared/components/Plot/index.ts
+++ b/frontend/src/modules/_shared/components/Plot/index.ts
@@ -1,0 +1,1 @@
+export { Plot } from "./plot";

--- a/frontend/src/modules/_shared/components/Plot/plot.tsx
+++ b/frontend/src/modules/_shared/components/Plot/plot.tsx
@@ -8,7 +8,7 @@ export type PlotProps = {
     /**
      * Informs if data/layout changes are ready to be applied
      */
-    plotUpdateReady: boolean;
+    plotUpdateReady?: boolean;
 } & PlotParams;
 
 const DEFAULT_CONFIG: Partial<Plotly.Config> = {
@@ -33,6 +33,9 @@ const DEFAULT_LAYOUT: Partial<Plotly.Layout> = {
 export function Plot(props: PlotProps): React.ReactNode {
     const { plotUpdateReady, layout, data, config, ...otherProps } = props;
 
+    // Default to true if not defined
+    const shouldApplyPlotUpdate = plotUpdateReady ?? true;
+
     // Store previous prop to avoid unnecessary rerenders
     const [prevLayout, setPrevLayout] = React.useState<PlotParams["layout"]>(layout);
     const [prevData, setPrevData] = React.useState<PlotParams["data"]>(data);
@@ -46,22 +49,22 @@ export function Plot(props: PlotProps): React.ReactNode {
 
     const [otherPropsStable, setOtherPropsStable] = React.useState<typeof otherProps>(otherProps);
 
-    if (plotUpdateReady && !_.isEqual(prevLayout, layout)) {
+    if (shouldApplyPlotUpdate && !_.isEqual(prevLayout, layout)) {
         setPrevLayout(layout);
         setLayoutStable(_.cloneDeep(layout));
     }
 
-    if (plotUpdateReady && !_.isEqual(prevData, data)) {
+    if (shouldApplyPlotUpdate && !_.isEqual(prevData, data)) {
         setPrevData(data);
         setDataStable(_.cloneDeep(data));
     }
 
-    if (plotUpdateReady && !_.isEqual(prevConfig, config)) {
+    if (shouldApplyPlotUpdate && !_.isEqual(prevConfig, config)) {
         setPrevConfig(config);
         setConfigStable(_.cloneDeep(config));
     }
 
-    if (plotUpdateReady && !_.isEqual(otherPropsStable, otherProps)) {
+    if (shouldApplyPlotUpdate && !_.isEqual(otherPropsStable, otherProps)) {
         setOtherPropsStable(otherProps);
     }
 

--- a/frontend/src/modules/_shared/components/Plot/plot.tsx
+++ b/frontend/src/modules/_shared/components/Plot/plot.tsx
@@ -1,0 +1,76 @@
+import React from "react";
+
+import _ from "lodash";
+import type { PlotParams } from "react-plotly.js";
+import BasePlot from "react-plotly.js";
+
+export type PlotProps = {
+    /**
+     * Informs if data/layout changes are ready to be applied
+     */
+    plotUpdateReady: boolean;
+} & PlotParams;
+
+const DEFAULT_CONFIG: Partial<Plotly.Config> = {
+    modeBarButtonsToRemove: ["toImage", "sendDataToCloud", "resetScale2d"],
+    displaylogo: false,
+    responsive: true,
+    displayModeBar: true,
+};
+
+const DEFAULT_LAYOUT: Partial<Plotly.Layout> = {
+    // By default, we try to keep the ui changes stable
+    uirevision: "revision_stable",
+};
+
+/**
+ * A wrapper utility of react-plotly that avoids the loss of UI state (zoom/pan/select)
+ * ! This component is still a bit unstable, and might reset if re-rendered multiple
+ * ! times in succession. Try to keep property references as stable as possible
+ * @param props
+ * @returns
+ */
+export function Plot(props: PlotProps): React.ReactNode {
+    const { plotUpdateReady, layout, data, config, ...otherProps } = props;
+
+    // Store previous prop to avoid unnecessary rerenders
+    const [prevLayout, setPrevLayout] = React.useState<PlotParams["layout"]>(layout);
+    const [prevData, setPrevData] = React.useState<PlotParams["data"]>(data);
+    const [prevConfig, setPrevConfig] = React.useState<PlotParams["config"]>(config);
+
+    // ! Plotly seems to mutate objects given to it as props, so we need to clone them when
+    // ! For example, it changed the data's xAxis from "x1" to "x"
+    const [layoutStable, setLayoutStable] = React.useState<PlotParams["layout"]>(layout);
+    const [dataStable, setDataStable] = React.useState<PlotParams["data"]>(data);
+    const [configStable, setConfigStable] = React.useState<PlotParams["config"]>(config);
+
+    const [otherPropsStable, setOtherPropsStable] = React.useState<typeof otherProps>(otherProps);
+
+    if (plotUpdateReady && !_.isEqual(prevLayout, layout)) {
+        setPrevLayout(layout);
+        setLayoutStable(_.cloneDeep(layout));
+    }
+
+    if (plotUpdateReady && !_.isEqual(prevData, data)) {
+        setPrevData(data);
+        setDataStable(_.cloneDeep(data));
+    }
+
+    if (plotUpdateReady && !_.isEqual(prevConfig, config)) {
+        setPrevConfig(config);
+        setConfigStable(_.cloneDeep(config));
+    }
+
+    if (plotUpdateReady && !_.isEqual(otherPropsStable, otherProps)) {
+        setOtherPropsStable(otherProps);
+    }
+
+    return React.useMemo(() => {
+        const layoutWithRevision = _.defaults({}, layoutStable, DEFAULT_LAYOUT);
+        const configWithDefaults = _.defaults({}, configStable, DEFAULT_CONFIG);
+
+        return (
+            <BasePlot data={dataStable} layout={layoutWithRevision} config={configWithDefaults} {...otherPropsStable} />
+        );
+    }, [configStable, dataStable, layoutStable, otherPropsStable]);
+}


### PR DESCRIPTION
Creates a wrapper around `plotly-react` that should make ui state more stable. All this is doing is creating stable copies of provided data and layout objects, and injecting the `uirevision` prop to a fixed string if none is given (implementers can still trigger ui-resets by setting the prop manually, if needed).

Generally, this makes plots more stable, and partially solves #223, but there are still cases where where the ui ends up resetting, and it's hard to pinpoint exactly what causes it. Some causes seem to be:
* Many re-renders
* Data and layout changing during fetching, (`populated -> empty -> populated`)
  * I added a `plotUpdateReady` prop to stop the component from updating internally while fetching
* Some components are unmounting the component to show a loading icon, which (naturally) resets the state.
* Sometimes, it seemingly resets for no reason...

Generally, all plot components should be refactored to: keep the plotly comp mounted, memoize data/layout, use the new prop to avoid uneccessary internal state updates

### Future work
As mentioned, the uirevision approach is still very unstable. I think this band-aid solution is better than nothing, but we should probably consider a proper react-like ui state wrapper in the future, where we manually track ui changes and store them in the state, reapplying them each render (PR #231 presents a spike for this)
