### PR TITLE
Depdency updates - Playwright, webviz/equinor components, and jotai

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2700,144 +2700,26 @@
             }
         },
         "node_modules/@playwright/experimental-ct-core": {
-            "version": "1.50.1",
-            "resolved": "https://registry.npmjs.org/@playwright/experimental-ct-core/-/experimental-ct-core-1.50.1.tgz",
-            "integrity": "sha512-t3gGk337prIGGkAQm7aoWuEQKtNB9Mh6F9GpptEntioSx3Fn2V4UOqi9gO4FwyhOmW3yp1JcxbnZcivOcfxhBg==",
+            "version": "1.52.0",
+            "resolved": "https://registry.npmjs.org/@playwright/experimental-ct-core/-/experimental-ct-core-1.52.0.tgz",
+            "integrity": "sha512-DiDEammXxt8OIFDfoNitoOZyHFJAu6aYi0abmHl0IZgOQHxccP6UX50aTEnSTTUWCfwUWB0Vd8TKJ6w122WJEw==",
             "dev": true,
-            "license": "Apache-2.0",
             "dependencies": {
-                "playwright": "1.50.1",
-                "playwright-core": "1.50.1",
-                "vite": "^5.4.14"
+                "playwright": "1.52.0",
+                "playwright-core": "1.52.0",
+                "vite": "^6.2.6"
             },
             "engines": {
                 "node": ">=18"
             }
         },
-        "node_modules/@playwright/experimental-ct-core/node_modules/@esbuild/linux-x64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
-            "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@playwright/experimental-ct-core/node_modules/esbuild": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
-            "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
-            "dev": true,
-            "hasInstallScript": true,
-            "license": "MIT",
-            "bin": {
-                "esbuild": "bin/esbuild"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "optionalDependencies": {
-                "@esbuild/aix-ppc64": "0.21.5",
-                "@esbuild/android-arm": "0.21.5",
-                "@esbuild/android-arm64": "0.21.5",
-                "@esbuild/android-x64": "0.21.5",
-                "@esbuild/darwin-arm64": "0.21.5",
-                "@esbuild/darwin-x64": "0.21.5",
-                "@esbuild/freebsd-arm64": "0.21.5",
-                "@esbuild/freebsd-x64": "0.21.5",
-                "@esbuild/linux-arm": "0.21.5",
-                "@esbuild/linux-arm64": "0.21.5",
-                "@esbuild/linux-ia32": "0.21.5",
-                "@esbuild/linux-loong64": "0.21.5",
-                "@esbuild/linux-mips64el": "0.21.5",
-                "@esbuild/linux-ppc64": "0.21.5",
-                "@esbuild/linux-riscv64": "0.21.5",
-                "@esbuild/linux-s390x": "0.21.5",
-                "@esbuild/linux-x64": "0.21.5",
-                "@esbuild/netbsd-x64": "0.21.5",
-                "@esbuild/openbsd-x64": "0.21.5",
-                "@esbuild/sunos-x64": "0.21.5",
-                "@esbuild/win32-arm64": "0.21.5",
-                "@esbuild/win32-ia32": "0.21.5",
-                "@esbuild/win32-x64": "0.21.5"
-            }
-        },
-        "node_modules/@playwright/experimental-ct-core/node_modules/vite": {
-            "version": "5.4.14",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.14.tgz",
-            "integrity": "sha512-EK5cY7Q1D8JNhSaPKVK4pwBFvaTmZxEnoKXLG/U9gmdDcihQGNzFlgIvaxezFR4glP1LsuiedwMBqCXH3wZccA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "esbuild": "^0.21.3",
-                "postcss": "^8.4.43",
-                "rollup": "^4.20.0"
-            },
-            "bin": {
-                "vite": "bin/vite.js"
-            },
-            "engines": {
-                "node": "^18.0.0 || >=20.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/vitejs/vite?sponsor=1"
-            },
-            "optionalDependencies": {
-                "fsevents": "~2.3.3"
-            },
-            "peerDependencies": {
-                "@types/node": "^18.0.0 || >=20.0.0",
-                "less": "*",
-                "lightningcss": "^1.21.0",
-                "sass": "*",
-                "sass-embedded": "*",
-                "stylus": "*",
-                "sugarss": "*",
-                "terser": "^5.4.0"
-            },
-            "peerDependenciesMeta": {
-                "@types/node": {
-                    "optional": true
-                },
-                "less": {
-                    "optional": true
-                },
-                "lightningcss": {
-                    "optional": true
-                },
-                "sass": {
-                    "optional": true
-                },
-                "sass-embedded": {
-                    "optional": true
-                },
-                "stylus": {
-                    "optional": true
-                },
-                "sugarss": {
-                    "optional": true
-                },
-                "terser": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/@playwright/experimental-ct-react": {
-            "version": "1.50.1",
-            "resolved": "https://registry.npmjs.org/@playwright/experimental-ct-react/-/experimental-ct-react-1.50.1.tgz",
-            "integrity": "sha512-M/erj/ItC7MflGD2pgMs1KHpdLX32X58Im7HenWxX8Q3ZXVNhs55X0H4EUAhI0B0GWkhWTiaVGvKySWKAs93bw==",
+            "version": "1.52.0",
+            "resolved": "https://registry.npmjs.org/@playwright/experimental-ct-react/-/experimental-ct-react-1.52.0.tgz",
+            "integrity": "sha512-r9gREinfeCAgnMp2Kpr6MnXSnKE06HlM0qWkortrtOHhD1xdGAT+mBBBP0YvPN2f169wGNIRuSOxp05MFZ+XaQ==",
             "dev": true,
-            "license": "Apache-2.0",
             "dependencies": {
-                "@playwright/experimental-ct-core": "1.50.1",
+                "@playwright/experimental-ct-core": "1.52.0",
                 "@vitejs/plugin-react": "^4.2.1"
             },
             "bin": {
@@ -2848,12 +2730,12 @@
             }
         },
         "node_modules/@playwright/test": {
-            "version": "1.50.1",
-            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.50.1.tgz",
-            "integrity": "sha512-Jii3aBg+CEDpgnuDxEp/h7BimHcUTDlpEtce89xEumlJ5ef2hqepZ+PWp1DDpYC/VO9fmWVI1IlEaoI5fK9FXQ==",
+            "version": "1.52.0",
+            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.52.0.tgz",
+            "integrity": "sha512-uh6W7sb55hl7D6vsAeA+V2p5JnlAqzhqFyF0VcJkKZXkgnFcVG9PziERRHQfPLfNGx1C292a4JqbWzhR8L4R1g==",
             "dev": true,
             "dependencies": {
-                "playwright": "1.50.1"
+                "playwright": "1.52.0"
             },
             "bin": {
                 "playwright": "cli.js"
@@ -10107,6 +9989,19 @@
             "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
             "dev": true
         },
+        "node_modules/fsevents": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+            "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+            "hasInstallScript": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+            }
+        },
         "node_modules/function-bind": {
             "version": "1.1.2",
             "license": "MIT",
@@ -13541,12 +13436,12 @@
             "dev": true
         },
         "node_modules/playwright": {
-            "version": "1.50.1",
-            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.50.1.tgz",
-            "integrity": "sha512-G8rwsOQJ63XG6BbKj2w5rHeavFjy5zynBA9zsJMMtBoe/Uf757oG12NXz6e6OirF7RCrTVAKFXbLmn1RbL7Qaw==",
+            "version": "1.52.0",
+            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.52.0.tgz",
+            "integrity": "sha512-JAwMNMBlxJ2oD1kce4KPtMkDeKGHQstdpFPcPH3maElAXon/QZeTvtsfXmTMRyO9TslfoYOXkSsvao2nE1ilTw==",
             "dev": true,
             "dependencies": {
-                "playwright-core": "1.50.1"
+                "playwright-core": "1.52.0"
             },
             "bin": {
                 "playwright": "cli.js"
@@ -13559,9 +13454,9 @@
             }
         },
         "node_modules/playwright-core": {
-            "version": "1.50.1",
-            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.50.1.tgz",
-            "integrity": "sha512-ra9fsNWayuYumt+NiM069M6OkcRb1FZSK8bgi66AtpFoWkg2+y0bJSNmkFrWhMbEBbVKC/EruAHH3g0zmtwGmQ==",
+            "version": "1.52.0",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.52.0.tgz",
+            "integrity": "sha512-l2osTgLXSMeuLZOML9qYODUQoPPnUsKsb5/P6LJ2e6uPKXUdPK5WYhN4z03G+YNbWmGDY4YENauNu4ZKczreHg==",
             "dev": true,
             "bin": {
                 "playwright-core": "cli.js"
@@ -16577,6 +16472,19 @@
                 "picomatch": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/vite/node_modules/fsevents": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+            "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+            "hasInstallScript": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
             }
         },
         "node_modules/vite/node_modules/picomatch": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -27,7 +27,6 @@
                 "geojson": "^0.5.0",
                 "jotai": "^2.6.2",
                 "jotai-effect": "^1.0.0",
-                "jotai-scope": "^0.5.1",
                 "jotai-tanstack-query": "^0.9.0",
                 "lodash": "^4.17.21",
                 "pixi.js": "^7.1.0",
@@ -11660,8 +11659,9 @@
             }
         },
         "node_modules/jotai": {
-            "version": "2.6.2",
-            "license": "MIT",
+            "version": "2.12.4",
+            "resolved": "https://registry.npmjs.org/jotai/-/jotai-2.12.4.tgz",
+            "integrity": "sha512-eFXLJol4oOLM8BS1+QV+XwaYQITG8n1tatBCFl4F5HE3zR5j2WIK8QpMt7VJIYmlogNUZfvB7wjwLoVk+umB9Q==",
             "engines": {
                 "node": ">=12.20.0"
             },
@@ -11679,18 +11679,14 @@
             }
         },
         "node_modules/jotai-effect": {
-            "version": "1.0.0",
-            "license": "MIT",
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/jotai-effect/-/jotai-effect-1.1.6.tgz",
+            "integrity": "sha512-ZPLNZgRSxuTjyzMqLE9ervx1YjH6FwcaEC0kw77W7sEpZLgqjRm6UZTHjsyAxUWUCSwKQ8A3ai3Vkz0tZxSPgw==",
+            "engines": {
+                "node": ">=12.20.0"
+            },
             "peerDependencies": {
                 "jotai": ">=2.5.0"
-            }
-        },
-        "node_modules/jotai-scope": {
-            "version": "0.5.1",
-            "license": "MIT",
-            "peerDependencies": {
-                "jotai": ">=2.5.0",
-                "react": ">=17.0.0"
             }
         },
         "node_modules/jotai-tanstack-query": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,8 +8,8 @@
             "name": "webviz",
             "version": "0.0.0",
             "dependencies": {
-                "@equinor/eds-core-react": "^0.45.1",
-                "@equinor/esv-intersection": "^3.1.2",
+                "@equinor/eds-core-react": "^0.46.0",
+                "@equinor/esv-intersection": "^3.1.4",
                 "@headlessui/react": "^1.7.8",
                 "@hey-api/client-axios": "^0.4.0",
                 "@mui/base": "^5.0.0-beta.3",
@@ -461,9 +461,9 @@
             }
         },
         "node_modules/@deck.gl/aggregation-layers": {
-            "version": "9.1.11",
-            "resolved": "https://registry.npmjs.org/@deck.gl/aggregation-layers/-/aggregation-layers-9.1.11.tgz",
-            "integrity": "sha512-3sVHcNsLj8Lzevf/2uZUn4pv6Z5Bpz7CzwataQ0EWGjjzHJ/4uIi24EIYEJmTzLGueenFS+70s8hWujJaAJMoQ==",
+            "version": "9.1.12",
+            "resolved": "https://registry.npmjs.org/@deck.gl/aggregation-layers/-/aggregation-layers-9.1.12.tgz",
+            "integrity": "sha512-41u5ZBnpIUzUQ+S8u/8JBWN9BHTerRUcOv+1QmjWsp8noNWZN69cvOy3/AaaPA8UgSEycdnv+y8GGIMspBLHZQ==",
             "dependencies": {
                 "@luma.gl/constants": "^9.1.5",
                 "@luma.gl/shadertools": "^9.1.5",
@@ -479,9 +479,9 @@
             }
         },
         "node_modules/@deck.gl/core": {
-            "version": "9.1.11",
-            "resolved": "https://registry.npmjs.org/@deck.gl/core/-/core-9.1.11.tgz",
-            "integrity": "sha512-ibqeLgx7fRqvJeCWtugbPE/LcOl3uDy8wSSd+l0FBhOqOPQcLdluTVMs0JW2OyqMuR2eOqcfarxzXdDVM7CcJA==",
+            "version": "9.1.12",
+            "resolved": "https://registry.npmjs.org/@deck.gl/core/-/core-9.1.12.tgz",
+            "integrity": "sha512-N9ZCHgn0CCekOCYmXYG/JHqFJLLeS5/HN1dh+N4a1EyLk0bPhN7CfTJ9ypEK9fQvyiX1sdVgu1bkGWo3eazf9A==",
             "dependencies": {
                 "@loaders.gl/core": "^4.2.0",
                 "@loaders.gl/images": "^4.2.0",
@@ -503,9 +503,9 @@
             }
         },
         "node_modules/@deck.gl/extensions": {
-            "version": "9.1.11",
-            "resolved": "https://registry.npmjs.org/@deck.gl/extensions/-/extensions-9.1.11.tgz",
-            "integrity": "sha512-wnWUhd7yyQTdHB0x2fE/FPeZUz5ZzKNDx2FwY+bQuQVaiNcc5YpGKQSV0ahIKUg6NF+shxZIJ/WBVi3wc6RFRQ==",
+            "version": "9.1.12",
+            "resolved": "https://registry.npmjs.org/@deck.gl/extensions/-/extensions-9.1.12.tgz",
+            "integrity": "sha512-NIgHQRd0PNyZlwGMt4N5H3GRsTnzXMaZtuBi0O3EkwqULKftReomk/IrMNvAaokm/Hr9myY0NPu5lusJdLexTA==",
             "dependencies": {
                 "@luma.gl/constants": "^9.1.5",
                 "@luma.gl/shadertools": "^9.1.5",
@@ -518,9 +518,9 @@
             }
         },
         "node_modules/@deck.gl/geo-layers": {
-            "version": "9.1.11",
-            "resolved": "https://registry.npmjs.org/@deck.gl/geo-layers/-/geo-layers-9.1.11.tgz",
-            "integrity": "sha512-z2rYT9617JaIP+a1nKhbxu32a5BjiR5L0Tmd4x7UUOlipx6A5850SyPyIUx5ca7lpIlbukGRjg600pRKKk3XEA==",
+            "version": "9.1.12",
+            "resolved": "https://registry.npmjs.org/@deck.gl/geo-layers/-/geo-layers-9.1.12.tgz",
+            "integrity": "sha512-5I1rTmWAuqDeC6QfajuNkf4TgkSrZQhqCwfz/0QohfSPKEeP9A1B0fu6pYJvxj83qfZOxNLyzZqwwxqeboJ2nw==",
             "dependencies": {
                 "@loaders.gl/3d-tiles": "^4.2.0",
                 "@loaders.gl/gis": "^4.2.0",
@@ -550,9 +550,9 @@
             }
         },
         "node_modules/@deck.gl/json": {
-            "version": "9.1.11",
-            "resolved": "https://registry.npmjs.org/@deck.gl/json/-/json-9.1.11.tgz",
-            "integrity": "sha512-rSV5AqWqmt0/C9rgldk21Pbsfqk+OrrttG42VZBjCYW3RkosSOr0aUhSlAx3/tERXUNZoN46WBtzQWV1GQptxg==",
+            "version": "9.1.12",
+            "resolved": "https://registry.npmjs.org/@deck.gl/json/-/json-9.1.12.tgz",
+            "integrity": "sha512-NLh2xpZQGdkmGYJk8O+d1AjU16OjKPlWo3WfQ/US/dhRhSw03xeeel4OGhqKuQlxoyqJgYaa1YjPxumyYCVCUA==",
             "dependencies": {
                 "jsep": "^0.3.0"
             },
@@ -561,9 +561,9 @@
             }
         },
         "node_modules/@deck.gl/layers": {
-            "version": "9.1.11",
-            "resolved": "https://registry.npmjs.org/@deck.gl/layers/-/layers-9.1.11.tgz",
-            "integrity": "sha512-RDFF+YH4BP3HPUCtblnfTaWXBt1DBk0i7FbQ9jgcjdv4CB7MtEOHme5k2LJ0cBV4ROQtSHg/vjAvMayZewI4vg==",
+            "version": "9.1.12",
+            "resolved": "https://registry.npmjs.org/@deck.gl/layers/-/layers-9.1.12.tgz",
+            "integrity": "sha512-szRPS7W3jCMp3jPjQYleIJGE9nkcMIXbUGi7Wc/4reU1WLayo8wvDnRbyyW/TaU6TTUPuI/K5raCnG+xoj67KQ==",
             "dependencies": {
                 "@loaders.gl/images": "^4.2.0",
                 "@loaders.gl/schema": "^4.2.0",
@@ -582,9 +582,9 @@
             }
         },
         "node_modules/@deck.gl/mesh-layers": {
-            "version": "9.1.11",
-            "resolved": "https://registry.npmjs.org/@deck.gl/mesh-layers/-/mesh-layers-9.1.11.tgz",
-            "integrity": "sha512-9zdtRV8rVyJI4t8bPE3/jLEuiBfCp+53KneFrh/nmANVupZ5SP44TobSWJWl+nZ3Xs4LkJXaQPbI8gZR39lJBQ==",
+            "version": "9.1.12",
+            "resolved": "https://registry.npmjs.org/@deck.gl/mesh-layers/-/mesh-layers-9.1.12.tgz",
+            "integrity": "sha512-SOwN4bpYL+rNRsuD2KweJ6BsA2w7PlzAFjUe3P84XqhSBhawVRSMrmiEFW0L0BnvoJOCWftR4hpF6M8lOUpENw==",
             "dependencies": {
                 "@loaders.gl/gltf": "^4.2.0",
                 "@luma.gl/gltf": "^9.1.5",
@@ -597,9 +597,9 @@
             }
         },
         "node_modules/@deck.gl/react": {
-            "version": "9.1.11",
-            "resolved": "https://registry.npmjs.org/@deck.gl/react/-/react-9.1.11.tgz",
-            "integrity": "sha512-RYjVYMZteyGwlZtuAiVD54TqvFgtZEJYBju2E/a6Bg3LBZ1eNtGHCpx5dIVKiOOU99gOkw2g2h0yrRgQt1j1cQ==",
+            "version": "9.1.12",
+            "resolved": "https://registry.npmjs.org/@deck.gl/react/-/react-9.1.12.tgz",
+            "integrity": "sha512-0M7w8qVXJ2nLcaur+hC3CxZfmqCvoM+/CRWiuICVOkgdkrcO3nCj+x/YObYYn/dhI3l9xVnTm9cFNq1tOFf9KQ==",
             "peerDependencies": {
                 "@deck.gl/core": "^9.1.0",
                 "@deck.gl/widgets": "^9.1.0",
@@ -798,11 +798,11 @@
             "peer": true
         },
         "node_modules/@equinor/eds-core-react": {
-            "version": "0.45.1",
-            "resolved": "https://registry.npmjs.org/@equinor/eds-core-react/-/eds-core-react-0.45.1.tgz",
-            "integrity": "sha512-XMNjr7KLdUHULApRM3YoqBHVPoZVn5Z4rtVCGjAz2cwDcqMzv+R2cQ1flfBrb5ZD0/SUNpGMYOjSE1Z3RUyEaA==",
+            "version": "0.46.0",
+            "resolved": "https://registry.npmjs.org/@equinor/eds-core-react/-/eds-core-react-0.46.0.tgz",
+            "integrity": "sha512-jfwMOLnNVvVvQFOSypDK23upEwLWORV01eQzc8Yc7gIpv/ayDHOhRA5w3NUKorvkl5ZA5yujQRdykl3tMir3LQ==",
             "dependencies": {
-                "@babel/runtime": "^7.27.0",
+                "@babel/runtime": "^7.27.1",
                 "@equinor/eds-icons": "^0.22.0",
                 "@equinor/eds-tokens": "0.9.2",
                 "@equinor/eds-utils": "0.8.7",
@@ -812,7 +812,7 @@
                 "@react-stately/calendar": "^3.8.0",
                 "@react-stately/datepicker": "^3.14.0",
                 "@react-types/shared": "^3.29.0",
-                "@tanstack/react-virtual": "3.13.2",
+                "@tanstack/react-virtual": "3.13.6",
                 "downshift": "9.0.8",
                 "react-aria": "^3.39.0"
             },
@@ -873,9 +873,9 @@
             }
         },
         "node_modules/@equinor/esv-intersection": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/@equinor/esv-intersection/-/esv-intersection-3.1.2.tgz",
-            "integrity": "sha512-rl0BXjLN0VaEzFfOq+bafJMTfP78mIttU2Bk2jBz/bU7tDg87SNK44nsFj5l8RlVv41qFG41/r2RpewcktJ6CA==",
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/@equinor/esv-intersection/-/esv-intersection-3.1.4.tgz",
+            "integrity": "sha512-UEQcHU5R19ifN5dnsKHimx89FdWRlIOR1+bnbhM8CKdSYTz4bo/yZI761XxzZpkVt5K7VS54SH11RQ2xJXAEXQ==",
             "dependencies": {
                 "@equinor/videx-math": "^1.1.0",
                 "@equinor/videx-vector2": "^1.0.44",
@@ -4690,11 +4690,11 @@
             }
         },
         "node_modules/@tanstack/react-virtual": {
-            "version": "3.13.2",
-            "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.2.tgz",
-            "integrity": "sha512-LceSUgABBKF6HSsHK2ZqHzQ37IKV/jlaWbHm+NyTa3/WNb/JZVcThDuTainf+PixltOOcFCYXwxbLpOX9sCx+g==",
+            "version": "3.13.6",
+            "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.6.tgz",
+            "integrity": "sha512-WT7nWs8ximoQ0CDx/ngoFP7HbQF9Q2wQe4nh2NB+u2486eX3nZRE40P9g6ccCVq7ZfTSH5gFOuCoVH5DLNS/aA==",
             "dependencies": {
-                "@tanstack/virtual-core": "3.13.2"
+                "@tanstack/virtual-core": "3.13.6"
             },
             "funding": {
                 "type": "github",
@@ -4706,9 +4706,9 @@
             }
         },
         "node_modules/@tanstack/virtual-core": {
-            "version": "3.13.2",
-            "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.2.tgz",
-            "integrity": "sha512-Qzz4EgzMbO5gKrmqUondCjiHcuu4B1ftHb0pjCut661lXZdGoHeze9f/M8iwsK1t5LGR6aNuNGU7mxkowaW6RQ==",
+            "version": "3.13.6",
+            "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.6.tgz",
+            "integrity": "sha512-cnQUeWnhNP8tJ4WsGcYiX24Gjkc9ALstLbHcBj1t3E7EimN6n6kHH+DPV4PpDnuw00NApQp+ViojMj1GRdwYQg==",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/tannerlinsley"
@@ -6086,9 +6086,9 @@
             }
         },
         "node_modules/@webviz/group-tree-plot": {
-            "version": "1.5.3",
-            "resolved": "https://registry.npmjs.org/@webviz/group-tree-plot/-/group-tree-plot-1.5.3.tgz",
-            "integrity": "sha512-Wgbg73AKFt/xd+VMYvHu2/4qoQtfK52lHCDoT6aNKH3oMhGjtzXIO5VdxqxNaqT5NkqUdqZOcC4vr2EFRaUsTg==",
+            "version": "1.5.4",
+            "resolved": "https://registry.npmjs.org/@webviz/group-tree-plot/-/group-tree-plot-1.5.4.tgz",
+            "integrity": "sha512-82DA0f8ZIyvvtnPod4gKGwb2qtvafYUeaasmFQjvQ341jAuBTUpNVr8pE9GE5zTJlwIt4W/P22E4yQ4OHY7cGg==",
             "dependencies": {
                 "d3": "^7.8.2",
                 "lodash": "^4.17.21",
@@ -6100,25 +6100,25 @@
             }
         },
         "node_modules/@webviz/subsurface-viewer": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@webviz/subsurface-viewer/-/subsurface-viewer-1.11.1.tgz",
-            "integrity": "sha512-xLexNjh0HbYiL5o0vqr2ksqOlCiumpxnXPMTtu7HRuXYqjEkwoMLfvM6wwLD0nQ8+LnbRPU0kXoohIt0vSXmPw==",
+            "version": "1.11.6",
+            "resolved": "https://registry.npmjs.org/@webviz/subsurface-viewer/-/subsurface-viewer-1.11.6.tgz",
+            "integrity": "sha512-bYKpJYFtjbkq+q0dtj17LarzW3uRFE0gR+Wz+ph7kElLKzXEpQvHB8RfPmR6b5taQXWOO0nVz6pDIEf0gPqnvQ==",
             "dependencies": {
                 "@deck.gl-community/editable-layers": "^9.1.0-beta.4",
-                "@deck.gl/aggregation-layers": "^9.1.11",
-                "@deck.gl/core": "^9.1.11",
-                "@deck.gl/extensions": "^9.1.11",
-                "@deck.gl/geo-layers": "^9.1.11",
-                "@deck.gl/json": "^9.1.11",
-                "@deck.gl/layers": "^9.1.11",
-                "@deck.gl/mesh-layers": "^9.1.11",
-                "@deck.gl/react": "^9.1.11",
+                "@deck.gl/aggregation-layers": "^9.1.12",
+                "@deck.gl/core": "^9.1.12",
+                "@deck.gl/extensions": "^9.1.12",
+                "@deck.gl/geo-layers": "^9.1.12",
+                "@deck.gl/json": "^9.1.12",
+                "@deck.gl/layers": "^9.1.12",
+                "@deck.gl/mesh-layers": "^9.1.12",
+                "@deck.gl/react": "^9.1.12",
                 "@emerson-eps/color-tables": "^0.4.92",
                 "@equinor/eds-core-react": "^0.36.0",
                 "@equinor/eds-icons": "^0.21.0",
                 "@turf/simplify": "^7.1.0",
                 "@vivaxy/png": "^1.3.0",
-                "@webviz/wsc-common": "*",
+                "@webviz/wsc-common": "1.2.4",
                 "ajv": "^8.16.0",
                 "convert-units": "^2.3.4",
                 "d3": "^7.8.2",
@@ -6239,9 +6239,9 @@
             }
         },
         "node_modules/@webviz/well-completions-plot": {
-            "version": "1.7.3",
-            "resolved": "https://registry.npmjs.org/@webviz/well-completions-plot/-/well-completions-plot-1.7.3.tgz",
-            "integrity": "sha512-3cI2Wkjefq2xJYrLZfOwj6PR1Lqz140y9m3H4YXWa+Twi2nXGGlEHsqpemJr0wD8aCWchQPw9+HjJlYkvqckAQ==",
+            "version": "1.7.4",
+            "resolved": "https://registry.npmjs.org/@webviz/well-completions-plot/-/well-completions-plot-1.7.4.tgz",
+            "integrity": "sha512-OF2+PRvOxDoQcMHe3+hlpU10g6EkiHlKjU5zy+KCIPq3Huy8agZTzuKPxpW+96Ypi0i11yzqeZ5csHD1YpUc8w==",
             "dependencies": {
                 "react-resize-detector": "^11.0.1",
                 "react-tooltip": "^5.28.0"
@@ -6259,13 +6259,13 @@
             }
         },
         "node_modules/@webviz/well-log-viewer": {
-            "version": "2.4.4",
-            "resolved": "https://registry.npmjs.org/@webviz/well-log-viewer/-/well-log-viewer-2.4.4.tgz",
-            "integrity": "sha512-quduVDS8ZBMPgdW+5YbbUGycitMY44ZZ7+rr9YfrEvWSWi/wRTgFg1eh0AmzKNiP6NmPXZxmIZ7oMauyGbunhw==",
+            "version": "2.4.5",
+            "resolved": "https://registry.npmjs.org/@webviz/well-log-viewer/-/well-log-viewer-2.4.5.tgz",
+            "integrity": "sha512-QrmtYMMTgQfKvQHzyjhiRl2PTPjQsqe+GnwiwmWA35RWJ4aN8vRMqLVTB9P9RO4GeByKI7oxLJRxwDn6zCzqfQ==",
             "dependencies": {
                 "@emerson-eps/color-tables": "^0.4.92",
                 "@equinor/videx-wellog": "^0.11.3",
-                "@webviz/wsc-common": "*",
+                "@webviz/wsc-common": "1.2.4",
                 "convert-units": "^2.3.4",
                 "d3": "^7.8.2"
             },
@@ -6276,10 +6276,11 @@
             }
         },
         "node_modules/@webviz/wsc-common": {
-            "version": "1.0.6",
-            "license": "MPL-2.0",
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@webviz/wsc-common/-/wsc-common-1.2.4.tgz",
+            "integrity": "sha512-K3mz47780aaD+dTW4UHJOnJWstti97rqRhuBeVyVWD5viAygyv9Gwe/ust7m7vEXJqBfI7LnCDswrsbl4MKgGA==",
             "dependencies": {
-                "@deck.gl/core": "^9.0.33",
+                "@deck.gl/core": "^9.1.12",
                 "ajv": "^8.12.0"
             }
         },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,8 +23,8 @@
         "vite-plugin-node-polyfills is only installed as a workaround for an import issue in the map module. See webviz-subsurface-components issue #2540 for details"
     ],
     "dependencies": {
-        "@equinor/eds-core-react": "^0.45.1",
-        "@equinor/esv-intersection": "^3.1.2",
+        "@equinor/eds-core-react": "^0.46.0",
+        "@equinor/esv-intersection": "^3.1.4",
         "@headlessui/react": "^1.7.8",
         "@hey-api/client-axios": "^0.4.0",
         "@mui/base": "^5.0.0-beta.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -42,7 +42,6 @@
         "geojson": "^0.5.0",
         "jotai": "^2.6.2",
         "jotai-effect": "^1.0.0",
-        "jotai-scope": "^0.5.1",
         "jotai-tanstack-query": "^0.9.0",
         "lodash": "^4.17.21",
         "pixi.js": "^7.1.0",


### PR DESCRIPTION
Small update to some dependencies
* Playwright: **Resolves snyk errors**
  * Minor fixes + some smaller breaking changes that does not affect any of our tests
* Bumps equinor/webviz components (Intersection, log viewer, etc)
  * Mostly just updates to internal deps
* Updated jotai packages
  * Removed unsued package `jotai-scope`
  * `jotai-effect` has a version 2.0.0 available, but it changes some extra stuff we might want to leave for a dedicated update