### PR TITLE
[DPF]: Disable "Add" button when action list is empty

### DIFF
--- a/frontend/src/lib/components/MenuButton/menuButton.tsx
+++ b/frontend/src/lib/components/MenuButton/menuButton.tsx
@@ -2,6 +2,8 @@ import type React from "react";
 
 import { MenuButton as MuiMenuButton } from "@mui/base/MenuButton";
 
+import { resolveClassNames } from "@lib/utils/resolveClassNames";
+
 export type MenuButtonProps = {
     ref?: React.Ref<HTMLButtonElement>;
     label?: string;
@@ -13,7 +15,12 @@ export function MenuButton(props: MenuButtonProps): React.ReactNode {
     return (
         <MuiMenuButton
             {...props}
-            className="hover:bg-blue-200 focus:outline-blue-600 p-1 text-sm rounded-sm flex gap-1 items-center focus:outline focus:outline-1 hover:text-gray-900 text-gray-600"
+            className={resolveClassNames(
+                "p-1 text-sm rounded-sm flex gap-1 items-center text-gray-600",
+                "hover:bg-blue-200 hover:text-gray-900",
+                "focus:outline focus:outline-blue-600",
+                "disabled:pointer-events-none disabled:text-gray-400",
+            )}
         />
     );
 }

--- a/frontend/src/modules/_shared/DataProviderFramework/Actions.tsx
+++ b/frontend/src/modules/_shared/DataProviderFramework/Actions.tsx
@@ -68,7 +68,7 @@ export function Actions(props: ActionsProps): React.ReactNode {
 
     return (
         <Dropdown>
-            <MenuButton label="Add items">
+            <MenuButton label="Add items" disabled={!props.actionGroups.length}>
                 <Add fontSize="inherit" />
                 <span>Add</span>
                 <ArrowDropDown fontSize="inherit" />


### PR DESCRIPTION
Resolves #982 

* Set the ActionGroup menu button to disabled when action-list is empty
* Made the MenuButton component grayed out when disabled