### PR TITLE
Improve module loading in dev

### DIFF
--- a/frontend/src/framework/Module.tsx
+++ b/frontend/src/framework/Module.tsx
@@ -296,7 +296,7 @@ export class Module<TInterfaceTypes extends ModuleInterfaceTypes> {
 
         if (!importer) {
             console.error(`Module importer not found for ${path}`);
-            this.setImportState(ImportStatus.Failed);
+            this.setImportState(ImportState.Failed);
             return;
         }
 


### PR DESCRIPTION
This PR registers all module paths automatically in the HMR setup of Vite and does, hence, prevent full page reloads on module imports. Seems to work in almost all cases und improves the dev experience.