### PR TITLE
Updated virtualization logic to avoid re-rendering

### DIFF
--- a/frontend/src/lib/components/Virtualization/virtualization.tsx
+++ b/frontend/src/lib/components/Virtualization/virtualization.tsx
@@ -1,5 +1,7 @@
 import React from "react";
 
+import { isEqual } from "lodash";
+
 import { useElementSize } from "@lib/hooks/useElementSize";
 
 import { withDefaults } from "../_component-utils/components";
@@ -12,7 +14,7 @@ export type VirtualizationProps<T = any> = {
     itemSize: number;
     direction: "vertical" | "horizontal";
     startIndex?: number;
-    onScroll?: (newStartIndex: number) => void;
+    onScroll?: (newStartIndex: number, newEndIndex: number) => void;
 };
 
 const defaultProps = {
@@ -20,130 +22,55 @@ const defaultProps = {
     startIndex: 0,
 };
 
-type VirtualizationPropsSubset = Pick<VirtualizationProps, "items" | "startIndex" | "direction" | "itemSize"> | null;
-
-function checkEqualityOfProps(a: VirtualizationPropsSubset, b: VirtualizationPropsSubset): boolean {
-    if (a === null && b === null) {
-        return true;
-    }
-
-    if (a === null || b === null) {
-        return false;
-    }
-
-    return (
-        a.itemSize === b.itemSize &&
-        a.direction === b.direction &&
-        a.startIndex === b.startIndex &&
-        a.items.length === b.items.length
-    );
-}
-
 export const Virtualization = withDefaults<VirtualizationProps>()(defaultProps, (props) => {
     const { onScroll } = props;
 
-    const [isProgrammaticScroll, setIsProgrammaticScroll] = React.useState(false);
-    const [range, setRange] = React.useState<{ start: number; end: number }>({ start: props.startIndex, end: 0 });
-    const [prevPropsSubset, setPrevPropsSubset] = React.useState<VirtualizationPropsSubset>(null);
-    const [placeholderSizes, setPlaceholderSizes] = React.useState<{ start: number; end: number }>({
-        start: props.startIndex * props.itemSize,
-        end: 0,
-    });
-    const [initialScrollPositions, setInitialScrollPositions] = React.useState<
-        | {
-              top: number;
-              left: number;
-          }
-        | undefined
-    >(undefined);
-
     const containerSize = useElementSize(props.containerRef);
 
-    const currentPropsSubset = {
-        items: props.items,
-        startIndex: props.startIndex,
-        direction: props.direction,
-        itemSize: props.itemSize,
-    };
+    // Ref to avoid unnecessary callbacks
+    const lastScrolledRange = React.useRef({ start: -1, end: -1 });
+    const [range, setRange] = React.useState<{ start: number; end: number }>({ start: props.startIndex, end: 0 });
 
-    if (!checkEqualityOfProps(prevPropsSubset, currentPropsSubset)) {
-        if (props.containerRef.current) {
-            const newInitialScrollPositions = {
-                top: props.startIndex * props.itemSize,
-                left: props.startIndex * props.itemSize,
-            };
-            let size = containerSize.height;
-            let scrollPosition = newInitialScrollPositions?.top || 0;
-            if (props.direction === "horizontal") {
-                size = containerSize.width;
-                scrollPosition = newInitialScrollPositions?.left || 0;
-            }
-
-            const startIndex = Math.max(0, Math.floor(scrollPosition / props.itemSize) - 1);
-            const endIndex = Math.min(props.items.length - 1, Math.ceil((scrollPosition + size) / props.itemSize) + 1);
-
-            setRange({ start: startIndex, end: endIndex });
-            setPlaceholderSizes({
-                start: startIndex * props.itemSize,
-                end: (props.items.length - 1 - endIndex) * props.itemSize,
-            });
-            setInitialScrollPositions(newInitialScrollPositions);
-            setPrevPropsSubset({
-                items: props.items,
-                startIndex: props.startIndex,
-                direction: props.direction,
-                itemSize: props.itemSize,
-            });
-        }
-    }
+    const placeholderSizes = React.useMemo(() => {
+        return {
+            start: range.start * props.itemSize,
+            end: (props.items.length - range.end - 1) * props.itemSize,
+        };
+    }, [props.itemSize, props.items.length, range.end, range.start]);
 
     React.useEffect(
-        function applyInitialScrollPositionEffect() {
-            if (props.containerRef.current && initialScrollPositions) {
-                setIsProgrammaticScroll(true);
-                props.containerRef.current.scrollTop = initialScrollPositions.top;
-                props.containerRef.current.scrollLeft = initialScrollPositions.left;
-            }
+        // As the top index changes, scroll the index into view
+        function scrollToStartIndexEffect() {
+            if (!props.containerRef.current || props.startIndex === undefined) return;
+
+            const scrollSide = props.direction === "horizontal" ? "scrollLeft" : "scrollTop";
+
+            // ! This will trigger the onScroll event handler
+            props.containerRef.current[scrollSide] = Math.max(0, props.startIndex * props.itemSize);
         },
-        [props.containerRef, initialScrollPositions],
+        [props.containerRef, props.direction, props.itemSize, props.startIndex],
     );
 
     React.useEffect(
         function mountScrollEffect() {
-            let lastScrollPosition = -1;
             function handleScroll() {
-                if (isProgrammaticScroll) {
-                    setIsProgrammaticScroll(false);
-                    return;
-                }
                 if (props.containerRef.current) {
                     const scrollPosition =
                         props.direction === "vertical"
                             ? props.containerRef.current.scrollTop
                             : props.containerRef.current.scrollLeft;
 
-                    if (scrollPosition === lastScrollPosition) {
-                        return;
-                    }
-
-                    lastScrollPosition = scrollPosition;
-
                     const size = props.direction === "vertical" ? containerSize.height : containerSize.width;
 
-                    const startIndex = Math.max(0, Math.floor(scrollPosition / props.itemSize) - 1);
-                    const endIndex = Math.min(
-                        props.items.length - 1,
-                        Math.ceil((scrollPosition + size) / props.itemSize) + 1,
-                    );
+                    const newRange = {
+                        start: Math.max(0, Math.floor(scrollPosition / props.itemSize) - 1),
+                        end: Math.min(props.items.length - 1, Math.ceil((scrollPosition + size) / props.itemSize)),
+                    };
 
-                    setRange({ start: startIndex, end: endIndex });
-                    setPlaceholderSizes({
-                        start: startIndex * props.itemSize,
-                        end: (props.items.length - 1 - endIndex) * props.itemSize,
-                    });
-
-                    if (onScroll) {
-                        onScroll(startIndex);
+                    if (!isEqual(newRange, lastScrolledRange.current)) {
+                        lastScrolledRange.current = newRange;
+                        setRange(newRange);
+                        onScroll?.(newRange.start, newRange.end);
                     }
                 }
             }
@@ -151,6 +78,8 @@ export const Virtualization = withDefaults<VirtualizationProps>()(defaultProps, 
             if (props.containerRef.current) {
                 props.containerRef.current.addEventListener("scroll", handleScroll);
             }
+
+            // Run once to give initial scroll values
             handleScroll();
 
             return function unmountScrollEffect() {
@@ -167,7 +96,6 @@ export const Virtualization = withDefaults<VirtualizationProps>()(defaultProps, 
             containerSize.height,
             containerSize.width,
             onScroll,
-            isProgrammaticScroll,
         ],
     );
 


### PR DESCRIPTION
Updates the `Virtualization` component:
* Made the `onScroll` give the end-index aswell
* Fixed a re-render loop that would occur if a given `onScroll` handler wasn't stable
  * Basically: there was a "previousIndex" variable that was being reset everytime the effect was remade
* Fixed the table scroll jumping back to the top (or `props.startIndex` everytime the data list updates)
  * The scroll position will now stick within it's range as data is added. 
  * If `props.startIndex` changes, the component will scroll to it's value