### PR TITLE
[DPF]: Improve cancellation logic by tightening query fetches to Tanstack QueryObserver

### DIFF
--- a/frontend/src/lib/utils/CancelableQueryRunner.ts
+++ b/frontend/src/lib/utils/CancelableQueryRunner.ts
@@ -1,0 +1,84 @@
+import type { FetchQueryOptions, QueryClient, QueryKey, QueryObserverResult } from "@tanstack/react-query";
+import { QueryObserver } from "@tanstack/react-query";
+
+/**
+ * Manages a single active query fetch via a QueryObserver, with built-in cancellation
+ * and race-condition-safe lifecycle.
+ */
+export class CancelableQueryRunner {
+    private _queryClient: QueryClient;
+    private _activeObserver: QueryObserver<any, any, any, any, any> | null = null;
+    private _unsubscribeFn: (() => void) | null = null;
+
+    constructor(queryClient: QueryClient) {
+        this._queryClient = queryClient;
+    }
+
+    cancelActiveFetch(): void {
+        this.cleanup();
+    }
+
+    private cleanup() {
+        if (this._unsubscribeFn) {
+            this._unsubscribeFn();
+            this._unsubscribeFn = null;
+        }
+        if (this._activeObserver) {
+            this._activeObserver.destroy();
+            this._activeObserver = null;
+        }
+    }
+
+    async run<TQueryFnData, TError = Error, TData = TQueryFnData, TQueryKey extends QueryKey = QueryKey>(
+        options: FetchQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+    ): Promise<TData> {
+        this.cancelActiveFetch();
+
+        const observer = new QueryObserver<TQueryFnData, TError, TData, TData, TQueryKey>(this._queryClient, {
+            ...options,
+        });
+
+        this._activeObserver = observer;
+
+        return new Promise<TData>((resolve, reject) => {
+            const initial = observer.getCurrentResult();
+
+            if (initial.isError && initial.error) {
+                this.cleanup();
+                reject(initial.error);
+                return;
+            }
+
+            if (initial.isSuccess) {
+                if (!initial.isStale) {
+                    this.cleanup();
+                    resolve(initial.data);
+                    return;
+                }
+                const current = observer;
+                observer.refetch().finally(() => {
+                    if (this._activeObserver === current) {
+                        this.cancelActiveFetch();
+                    }
+                });
+                resolve(initial.data);
+                return;
+            }
+
+            this._unsubscribeFn = observer.subscribe((result: QueryObserverResult<TData, TError>) => {
+                if (result.isError && result.error) {
+                    this.cleanup();
+                    reject(result.error);
+                } else if (result.isSuccess) {
+                    this.cleanup();
+                    resolve(result.data);
+                }
+            });
+
+            observer.refetch().catch((err) => {
+                this.cleanup();
+                reject(err);
+            });
+        });
+    }
+}

--- a/frontend/src/lib/utils/ScopedQueryController.ts
+++ b/frontend/src/lib/utils/ScopedQueryController.ts
@@ -20,7 +20,7 @@ export class ScopedQueryController {
         this.cleanup();
     }
 
-    async run<TQueryFnData, TError = Error, TData = TQueryFnData, TQueryKey extends QueryKey = QueryKey>(
+    async fetchQuery<TQueryFnData, TError = Error, TData = TQueryFnData, TQueryKey extends QueryKey = QueryKey>(
         options: FetchQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
     ): Promise<TData> {
         this.cleanup();

--- a/frontend/src/modules/2DViewer/DataProviderFramework/customDataProviderImplementations/ObservedSurfaceProvider.ts
+++ b/frontend/src/modules/2DViewer/DataProviderFramework/customDataProviderImplementations/ObservedSurfaceProvider.ts
@@ -16,7 +16,6 @@ import type { SurfaceDataFloat_trans } from "@modules/_shared/Surface/queryDataT
 import { transformSurfaceData } from "@modules/_shared/Surface/queryDataTransforms";
 import { encodeSurfAddrStr } from "@modules/_shared/Surface/surfaceAddress";
 
-
 const observedSurfaceSettings = [
     Setting.ENSEMBLE,
     Setting.ATTRIBUTE,
@@ -170,8 +169,7 @@ export class ObservedSurfaceProvider
 
     fetchData({
         getSetting,
-        registerQueryKey,
-        queryClient,
+        fetchQuery,
     }: FetchDataParams<ObservedSurfaceSettings, ObservedSurfaceData>): Promise<ObservedSurfaceData> {
         let surfaceAddress: FullSurfaceAddress | null = null;
         const addrBuilder = new SurfaceAddressBuilder();
@@ -199,12 +197,11 @@ export class ObservedSurfaceProvider
                 resample_to_def_str: null,
             },
         });
-    
-        registerQueryKey(surfaceDataOptions.queryKey);
 
-        const promise = queryClient
-            .fetchQuery(surfaceDataOptions)
-            .then((data) => ({ format: this._dataFormat, surfaceData: transformSurfaceData(data) }));
+        const promise = fetchQuery(surfaceDataOptions).then((data) => ({
+            format: this._dataFormat,
+            surfaceData: transformSurfaceData(data),
+        }));
 
         return promise as Promise<ObservedSurfaceData>;
     }

--- a/frontend/src/modules/2DViewer/DataProviderFramework/customDataProviderImplementations/RealizationGridProvider.ts
+++ b/frontend/src/modules/2DViewer/DataProviderFramework/customDataProviderImplementations/RealizationGridProvider.ts
@@ -74,8 +74,7 @@ export class RealizationGridProvider
     fetchData({
         getSetting,
         getStoredData,
-        registerQueryKey,
-        queryClient,
+        fetchQuery,
     }: FetchDataParams<RealizationGridSettings, RealizationGridData, StoredData>): Promise<{
         gridSurfaceData: GridSurface_trans;
         gridParameterData: GridMappedProperty_trans;
@@ -114,8 +113,6 @@ export class RealizationGridProvider
             },
         });
 
-        registerQueryKey(gridParameterOptions.queryKey);
-
         const gridSurfaceOptions = getGridSurfaceOptions({
             query: {
                 case_uuid: ensembleIdent?.getCaseUuid() ?? "",
@@ -131,11 +128,9 @@ export class RealizationGridProvider
             },
         });
 
-        registerQueryKey(gridSurfaceOptions.queryKey);
+        const gridParameterPromise = fetchQuery(gridParameterOptions).then(transformGridMappedProperty);
 
-        const gridParameterPromise = queryClient.fetchQuery(gridParameterOptions).then(transformGridMappedProperty);
-
-        const gridSurfacePromise = queryClient.fetchQuery(gridSurfaceOptions).then(transformGridSurface);
+        const gridSurfacePromise = fetchQuery(gridSurfaceOptions).then(transformGridSurface);
 
         return Promise.all([gridSurfacePromise, gridParameterPromise]).then(([gridSurfaceData, gridParameterData]) => ({
             gridSurfaceData,

--- a/frontend/src/modules/2DViewer/DataProviderFramework/customDataProviderImplementations/RealizationPolygonsProvider.ts
+++ b/frontend/src/modules/2DViewer/DataProviderFramework/customDataProviderImplementations/RealizationPolygonsProvider.ts
@@ -10,7 +10,6 @@ import type { DefineDependenciesArgs } from "@modules/_shared/DataProviderFramew
 import type { MakeSettingTypesMap } from "@modules/_shared/DataProviderFramework/settings/settingsDefinitions";
 import { Setting } from "@modules/_shared/DataProviderFramework/settings/settingsDefinitions";
 
-
 const realizationPolygonsSettings = [
     Setting.ENSEMBLE,
     Setting.REALIZATION,
@@ -117,8 +116,7 @@ export class RealizationPolygonsProvider
 
     fetchData({
         getSetting,
-        registerQueryKey,
-        queryClient,
+        fetchQuery,
     }: FetchDataParams<RealizationPolygonsSettings, RealizationPolygonsData>): Promise<PolygonData_api[]> {
         const ensembleIdent = getSetting(Setting.ENSEMBLE);
         const realizationNum = getSetting(Setting.REALIZATION);
@@ -135,18 +133,8 @@ export class RealizationPolygonsProvider
             },
         });
 
-        registerQueryKey(queryOptions.queryKey);
-
-        const promise = queryClient.fetchQuery({
-            ...getPolygonsDataOptions({
-                query: {
-                    case_uuid: ensembleIdent?.getCaseUuid() ?? "",
-                    ensemble_name: ensembleIdent?.getEnsembleName() ?? "",
-                    realization_num: realizationNum ?? 0,
-                    name: polygonsName ?? "",
-                    attribute: polygonsAttribute ?? "",
-                },
-            }),
+        const promise = fetchQuery({
+            ...queryOptions,
         });
 
         return promise;

--- a/frontend/src/modules/2DViewer/DataProviderFramework/customDataProviderImplementations/RealizationSurfaceProvider.ts
+++ b/frontend/src/modules/2DViewer/DataProviderFramework/customDataProviderImplementations/RealizationSurfaceProvider.ts
@@ -16,7 +16,6 @@ import type { SurfaceDataFloat_trans } from "@modules/_shared/Surface/queryDataT
 import { transformSurfaceData } from "@modules/_shared/Surface/queryDataTransforms";
 import { encodeSurfAddrStr } from "@modules/_shared/Surface/surfaceAddress";
 
-
 const realizationSurfaceSettings = [
     Setting.ENSEMBLE,
     Setting.REALIZATION,
@@ -207,8 +206,7 @@ export class RealizationSurfaceProvider
 
     fetchData({
         getSetting,
-        registerQueryKey,
-        queryClient,
+        fetchQuery,
     }: FetchDataParams<RealizationSurfaceSettings, RealizationSurfaceData>): Promise<RealizationSurfaceData> {
         let surfaceAddress: FullSurfaceAddress | null = null;
         const addrBuilder = new SurfaceAddressBuilder();
@@ -244,13 +242,10 @@ export class RealizationSurfaceProvider
             },
         });
 
-        registerQueryKey(surfaceDataOptions.queryKey);
-
-        const promise = queryClient
-            .fetchQuery(
-                surfaceDataOptions,
-            )
-            .then((data) => ({ format: this._dataFormat, surfaceData: transformSurfaceData(data) }));
+        const promise = fetchQuery(surfaceDataOptions).then((data) => ({
+            format: this._dataFormat,
+            surfaceData: transformSurfaceData(data),
+        }));
 
         return promise as Promise<RealizationSurfaceData>;
     }

--- a/frontend/src/modules/2DViewer/DataProviderFramework/customDataProviderImplementations/StatisticalSurfaceProvider.ts
+++ b/frontend/src/modules/2DViewer/DataProviderFramework/customDataProviderImplementations/StatisticalSurfaceProvider.ts
@@ -235,8 +235,7 @@ export class StatisticalSurfaceProvider
         getSetting,
         getStoredData,
         getWorkbenchSession,
-        registerQueryKey,
-        queryClient,
+        fetchQuery,
     }: FetchDataParams<StatisticalSurfaceSettings, StatisticalSurfaceData>): Promise<StatisticalSurfaceData> {
         let surfaceAddress: FullSurfaceAddress | null = null;
         const addrBuilder = new SurfaceAddressBuilder();
@@ -297,13 +296,10 @@ export class StatisticalSurfaceProvider
             },
         });
 
-        registerQueryKey(queryOptions.queryKey);
-
-        const promise = queryClient
-            .fetchQuery({
-                ...queryOptions,
-            })
-            .then((data) => ({ format: this._dataFormat, surfaceData: transformSurfaceData(data) }));
+        const promise = fetchQuery({ ...queryOptions }).then((data) => ({
+            format: this._dataFormat,
+            surfaceData: transformSurfaceData(data),
+        }));
 
         return promise as Promise<StatisticalSurfaceData>;
     }

--- a/frontend/src/modules/Intersection/DataProviderFramework/customDataProviderImplementations/RealizationSurfacesProvider.ts
+++ b/frontend/src/modules/Intersection/DataProviderFramework/customDataProviderImplementations/RealizationSurfacesProvider.ts
@@ -236,8 +236,7 @@ export class RealizationSurfacesProvider
     fetchData({
         getSetting,
         getStoredData,
-        registerQueryKey,
-        queryClient,
+        fetchQuery,
     }: FetchDataParams<
         RealizationSurfacesSettings,
         RealizationSurfacesData,
@@ -291,9 +290,7 @@ export class RealizationSurfacesProvider
                     },
                 });
 
-                registerQueryKey(queryOptions.queryKey);
-
-                return queryClient.fetchQuery(queryOptions);
+                return fetchQuery(queryOptions);
             }),
         );
 

--- a/frontend/src/modules/Intersection/DataProviderFramework/customDataProviderImplementations/SurfacesPerRealizationValuesProvider.ts
+++ b/frontend/src/modules/Intersection/DataProviderFramework/customDataProviderImplementations/SurfacesPerRealizationValuesProvider.ts
@@ -259,8 +259,7 @@ export class SurfacesPerRealizationValuesProvider
     fetchData({
         getSetting,
         getStoredData,
-        registerQueryKey,
-        queryClient,
+        fetchQuery,
     }: FetchDataParams<
         SurfacesPerRealizationValuesSettings,
         SurfacesPerRealizationValuesData,
@@ -299,9 +298,7 @@ export class SurfacesPerRealizationValuesProvider
                 },
             });
 
-            registerQueryKey(queryOptions.queryKey);
-
-            return { surfaceName: surfaceName, fetchPromise: queryClient.fetchQuery(queryOptions) };
+            return { surfaceName: surfaceName, fetchPromise: fetchQuery(queryOptions) };
         });
 
         // Assemble into one promise

--- a/frontend/src/modules/WellLogViewer/DataProviderFramework/dataProviders/plots/_shared.ts
+++ b/frontend/src/modules/WellLogViewer/DataProviderFramework/dataProviders/plots/_shared.ts
@@ -70,14 +70,14 @@ export function verifyBasePlotSettings<T extends readonly Setting[]>(
 export function fetchLogCurveData<T extends Settings>(
     args: FetchDataParams<T, WellboreLogCurveData_api>,
 ): Promise<WellboreLogCurveData_api> {
-    const { getSetting, getGlobalSetting, queryClient } = args;
+    const { getSetting, getGlobalSetting, fetchQuery } = args;
 
     const wellboreId = getGlobalSetting("wellboreUuid");
     const curveHeader = getSetting(Setting.LOG_CURVE);
 
     if (!wellboreId || !curveHeader) return Promise.reject();
 
-    return queryClient.fetchQuery({
+    return fetchQuery({
         ...getLogCurveDataOptions({
             query: {
                 wellbore_uuid: wellboreId,

--- a/frontend/src/modules/_shared/DataProviderFramework/dataProviders/implementations/DrilledWellTrajectoriesProvider.ts
+++ b/frontend/src/modules/_shared/DataProviderFramework/dataProviders/implementations/DrilledWellTrajectoriesProvider.ts
@@ -5,7 +5,6 @@ import { getDrilledWellboreHeadersOptions, getWellTrajectoriesOptions } from "@a
 import type { MakeSettingTypesMap } from "@modules/_shared/DataProviderFramework/settings/settingsDefinitions";
 import { Setting } from "@modules/_shared/DataProviderFramework/settings/settingsDefinitions";
 
-
 import type {
     CustomDataProviderImplementation,
     FetchDataParams,
@@ -34,8 +33,7 @@ export class DrilledWellTrajectoriesProvider
     fetchData({
         getSetting,
         getGlobalSetting,
-        registerQueryKey,
-        queryClient,
+        fetchQuery,
     }: FetchDataParams<
         DrilledWellTrajectoriesSettings,
         DrilledWellTrajectoriesData
@@ -51,17 +49,13 @@ export class DrilledWellTrajectoriesProvider
             query: { field_identifier: fieldIdentifier ?? "" },
         });
 
-        registerQueryKey(queryOptions.queryKey);
-
-        const promise = queryClient
-            .fetchQuery({
-                ...queryOptions,
-                staleTime: 1800000, // TODO: Both stale and gcTime are set to 30 minutes for now since SMDA is quite slow for fields with many wells - this should be adjusted later
-                gcTime: 1800000,
-            })
-            .then((response: DrilledWellTrajectoriesData) => {
-                return response.filter((trajectory) => selectedWellboreUuids.includes(trajectory.wellboreUuid));
-            });
+        const promise = fetchQuery({
+            ...queryOptions,
+            staleTime: 1800000, // TODO: Both stale and gcTime are set to 30 minutes for now since SMDA is quite slow for fields with many wells - this should be adjusted later
+            gcTime: 1800000,
+        }).then((response: DrilledWellTrajectoriesData) => {
+            return response.filter((trajectory) => selectedWellboreUuids.includes(trajectory.wellboreUuid));
+        });
 
         return promise;
     }

--- a/frontend/src/modules/_shared/DataProviderFramework/dataProviders/implementations/DrilledWellborePicksProvider.ts
+++ b/frontend/src/modules/_shared/DataProviderFramework/dataProviders/implementations/DrilledWellborePicksProvider.ts
@@ -9,7 +9,6 @@ import {
 import type { MakeSettingTypesMap } from "@modules/_shared/DataProviderFramework/settings/settingsDefinitions";
 import { Setting } from "@modules/_shared/DataProviderFramework/settings/settingsDefinitions";
 
-
 import type {
     CustomDataProviderImplementation,
     DataProviderInformationAccessors,
@@ -40,8 +39,7 @@ export class DrilledWellborePicksProvider
     fetchData({
         getSetting,
         getGlobalSetting,
-        registerQueryKey,
-        queryClient,
+        fetchQuery,
     }: FetchDataParams<DrilledWellborePicksSettings, DrilledWellborePicksData>): Promise<WellborePick_api[]> {
         const selectedWellboreHeaders = getSetting(Setting.SMDA_WELLBORE_HEADERS);
         let selectedWellboreUuids: string[] = [];
@@ -58,13 +56,9 @@ export class DrilledWellborePicksProvider
             },
         });
 
-        registerQueryKey(queryOptions.queryKey);
-
-        const promise = queryClient
-            .fetchQuery(queryOptions)
-            .then((response: WellborePick_api[]) => {
-                return response.filter((trajectory) => selectedWellboreUuids.includes(trajectory.wellboreUuid));
-            });
+        const promise = fetchQuery(queryOptions).then((response: WellborePick_api[]) => {
+            return response.filter((trajectory) => selectedWellboreUuids.includes(trajectory.wellboreUuid));
+        });
 
         return promise;
     }

--- a/frontend/src/modules/_shared/DataProviderFramework/dataProviders/implementations/IntersectionRealizationGridProvider.ts
+++ b/frontend/src/modules/_shared/DataProviderFramework/dataProviders/implementations/IntersectionRealizationGridProvider.ts
@@ -301,8 +301,7 @@ export class IntersectionRealizationGridProvider
     fetchData({
         getSetting,
         getStoredData,
-        registerQueryKey,
-        queryClient,
+        fetchQuery,
     }: FetchDataParams<
         IntersectionRealizationGridSettings,
         IntersectionRealizationGridData,
@@ -337,9 +336,7 @@ export class IntersectionRealizationGridProvider
             body: { polyline_utm_xy: polylineWithSectionLengths.polylineUtmXy },
         });
 
-        registerQueryKey(queryOptions.queryKey);
-
-        const gridIntersectionPromise = queryClient.fetchQuery(queryOptions).then(transformPolylineIntersection);
+        const gridIntersectionPromise = fetchQuery(queryOptions).then(transformPolylineIntersection);
 
         return gridIntersectionPromise;
     }

--- a/frontend/src/modules/_shared/DataProviderFramework/dataProviders/implementations/IntersectionRealizationSeismicProvider.ts
+++ b/frontend/src/modules/_shared/DataProviderFramework/dataProviders/implementations/IntersectionRealizationSeismicProvider.ts
@@ -324,8 +324,7 @@ export class IntersectionRealizationSeismicProvider
     fetchData({
         getSetting,
         getStoredData,
-        registerQueryKey,
-        queryClient,
+        fetchQuery,
     }: FetchDataParams<
         IntersectionRealizationSeismicSettings,
         IntersectionRealizationSeismicData,
@@ -359,9 +358,7 @@ export class IntersectionRealizationSeismicProvider
             },
         });
 
-        registerQueryKey(queryOptions.queryKey);
-
-        const seismicFenceDataPromise = queryClient.fetchQuery(queryOptions).then(transformSeismicFenceData);
+        const seismicFenceDataPromise = fetchQuery(queryOptions).then(transformSeismicFenceData);
 
         return seismicFenceDataPromise;
     }

--- a/frontend/src/modules/_shared/DataProviderFramework/framework/DataProvider/DataProvider.ts
+++ b/frontend/src/modules/_shared/DataProviderFramework/framework/DataProvider/DataProvider.ts
@@ -4,10 +4,10 @@ import { clone, isEqual } from "lodash";
 
 import type { StatusMessage } from "@framework/ModuleInstanceStatusController";
 import { ApiErrorHelper } from "@framework/utils/ApiErrorHelper";
-import { CancelableQueryRunner } from "@lib/utils/CancelableQueryRunner";
 import { isDevMode } from "@lib/utils/devMode";
 import type { PublishSubscribe } from "@lib/utils/PublishSubscribeDelegate";
 import { PublishSubscribeDelegate } from "@lib/utils/PublishSubscribeDelegate";
+import { ScopedQueryController } from "@lib/utils/ScopedQueryController";
 
 import { ItemDelegate } from "../../delegates/ItemDelegate";
 import {
@@ -127,7 +127,7 @@ export class DataProvider<
     private _settingsErrorMessages: string[] = [];
     private _revisionNumber: number = 0;
     private _progressMessage: string | null = null;
-    private _queryRunner: CancelableQueryRunner;
+    private _queryRunner: ScopedQueryController;
     private _refetchScheduled: boolean = false;
 
     constructor(params: DataProviderParams<TSettings, TData, TStoredData, TSettingTypes, TSettingKey>) {
@@ -147,7 +147,7 @@ export class DataProvider<
                 customDataProviderImplementation.getDefaultSettingsValues?.() ?? {},
             ),
         );
-        this._queryRunner = new CancelableQueryRunner(params.dataProviderManager.getQueryClient());
+        this._queryRunner = new ScopedQueryController(params.dataProviderManager.getQueryClient());
         this._customDataProviderImpl = customDataProviderImplementation;
         this._itemDelegate = new ItemDelegate(
             instanceName ?? customDataProviderImplementation.getDefaultName(),

--- a/frontend/src/modules/_shared/DataProviderFramework/interfacesAndTypes/customDataProviderImplementation.ts
+++ b/frontend/src/modules/_shared/DataProviderFramework/interfacesAndTypes/customDataProviderImplementation.ts
@@ -1,4 +1,4 @@
-import type { QueryClient } from "@tanstack/query-core";
+import type { DefaultError, FetchQueryOptions, QueryKey } from "@tanstack/query-core";
 
 import type { WorkbenchSession } from "@framework/WorkbenchSession";
 import type { WorkbenchSettings } from "@framework/WorkbenchSettings";
@@ -109,20 +109,27 @@ export type FetchDataParams<
     TData,
     TStoredData extends StoredData = Record<string, never>,
 > = {
-    queryClient: QueryClient;
-
-    /**
-     * Register a query key for the data provider.
-     * @param key The query key to register.
-     */
-    registerQueryKey: (key: unknown[]) => void;
-
     /**
      * Set progress message for the data provider.
      * This message can be used to keep the user informed about the progress of the data provider.
      * @param message The progress message to set.
      */
     setProgressMessage: (message: string | null) => void;
+
+    /**
+     * Fetch data by using the Tanstack Query client.
+     *
+     * @param options Options for the query to fetch data.
+     * @returns A promise that resolves to the fetched data.
+     */
+    fetchQuery: <
+        TQueryFnData = unknown,
+        TError = DefaultError,
+        TData = TQueryFnData,
+        TQueryKey extends QueryKey = QueryKey,
+    >(
+        options: FetchQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+    ) => Promise<TData>;
 } & DataProviderInformationAccessors<TSettings, TData, TStoredData>;
 
 export interface CustomDataProviderImplementation<


### PR DESCRIPTION
This gives a more Tanstack-Query-native experience and fits better into the ecosystem. Cancellation is automatically performed by Tanstack when there are no more observers for a query. This plays well with `useQuery` hooks and `atomWithQuery/ies` as we let the QueryCache handle everything.