### PR TITLE
Gathered and moved timestamp related utilities in core_utils lib

### DIFF
--- a/backend_py/libs/core_utils/tests/test_timestamp_utils.py
+++ b/backend_py/libs/core_utils/tests/test_timestamp_utils.py
@@ -1,0 +1,32 @@
+from webviz_pkg.core_utils.timestamp_utils import timestamp_utc_ms_to_iso_str, timestamp_utc_ms_to_compact_iso_str
+from webviz_pkg.core_utils.timestamp_utils import iso_str_to_timestamp_utc_ms
+
+
+def test_convert_timestamp_to_iso_str() -> None:
+    # Test data generated with: https://www.timestamp-converter.com/
+    assert timestamp_utc_ms_to_iso_str(1514764800000) == "2018-01-01T00:00:00.000Z"
+    assert timestamp_utc_ms_to_iso_str(1514764800000, always_include_milliseconds=False) == "2018-01-01T00:00:00Z"
+
+    assert timestamp_utc_ms_to_iso_str(1514764800001) == "2018-01-01T00:00:00.001Z"
+    assert timestamp_utc_ms_to_iso_str(1514764799999) == "2017-12-31T23:59:59.999Z"
+
+
+def test_convert_timestamp_to_compact_iso_str() -> None:
+    # Test data generated with: https://www.timestamp-converter.com/
+    assert timestamp_utc_ms_to_compact_iso_str(1514764799999) == "2017-12-31T23:59:59.999Z"
+    assert timestamp_utc_ms_to_compact_iso_str(1514764800001) == "2018-01-01T00:00:00.001Z"
+    assert timestamp_utc_ms_to_compact_iso_str(1514764801000) == "2018-01-01T00:00:01Z"
+    assert timestamp_utc_ms_to_compact_iso_str(1514764800000) == "2018-01-01"
+
+
+def test_convert_iso_str_to_timestamp() -> None:
+    # Test data generated with: https://www.timestamp-converter.com/
+    assert iso_str_to_timestamp_utc_ms("2018-01-01T00:00:00Z") == 1514764800000
+    assert iso_str_to_timestamp_utc_ms("2018-01-01T00:00:00") == 1514764800000
+
+    assert iso_str_to_timestamp_utc_ms("2018-01-01") == 1514764800000
+
+    assert iso_str_to_timestamp_utc_ms("2018-01-01T00:00:00.001") == 1514764800001
+    assert iso_str_to_timestamp_utc_ms("2018-01-01T00:00:00.001Z") == 1514764800001
+    assert iso_str_to_timestamp_utc_ms("2017-12-31T23:59:59.999") == 1514764799999
+    assert iso_str_to_timestamp_utc_ms("2017-12-31T23:59:59.999Z") == 1514764799999

--- a/backend_py/libs/core_utils/webviz_pkg/core_utils/timestamp_utils.py
+++ b/backend_py/libs/core_utils/webviz_pkg/core_utils/timestamp_utils.py
@@ -1,0 +1,70 @@
+import datetime
+
+
+def timestamp_utc_ms_to_iso_str(timestamp_utc_ms: int, always_include_milliseconds: bool = True) -> str:
+    """
+    Convert integer timestamp in milliseconds UTC to ISO 8601 string
+    The returned string will always be one of these formats:
+      YYYY-MM-DDTHH:MM:SS.fffZ
+      YYYY-MM-DDTHH:MM:SSZ
+    """
+    dt_obj = datetime.datetime.fromtimestamp(timestamp_utc_ms / 1000, tz=datetime.timezone.utc)
+
+    # Include milliseconds only if present or forced by flag
+    if dt_obj.microsecond != 0 or always_include_milliseconds:
+        isostr = dt_obj.isoformat(timespec="milliseconds")
+    else:
+        isostr = dt_obj.isoformat()
+
+    # Since dt_obj has time zone, isoformat() always returns string with UTC offset, which for UTC will be: "+00:00"
+    # Replace with Z which is the convention we use
+    isostr = isostr.replace("+00:00", "Z")
+
+    return isostr
+
+
+def timestamp_utc_ms_to_iso_str_strip_tz(timestamp_utc_ms: int, always_include_milliseconds: bool = True) -> str:
+    """
+    Same as timestamp_utc_ms_to_iso_str(), but does not include timezone information (no trailing Z)
+    """
+    isostr_with_tz = timestamp_utc_ms_to_iso_str(timestamp_utc_ms, always_include_milliseconds)
+    return isostr_with_tz.replace("Z", "")
+
+
+def timestamp_utc_ms_to_compact_iso_str(timestamp_utc_ms: int) -> str:
+    """
+    Convert integer timestamp in milliseconds a compact UTC to ISO 8601 string
+    The returned string will be one of these formats depending on the input data:
+      YYYY-MM-DDTHH:MM:SS.fffZ
+      YYYY-MM-DDTHH:MM:SSZ
+      YYYY-MM-DD
+    """
+    dt_obj = datetime.datetime.fromtimestamp(timestamp_utc_ms / 1000, tz=datetime.timezone.utc)
+
+    if dt_obj.hour == 0 and dt_obj.minute == 0 and dt_obj.second == 0 and dt_obj.microsecond == 0:
+        isostr = dt_obj.date().isoformat()
+    elif dt_obj.microsecond == 0:
+        isostr = dt_obj.isoformat(timespec="seconds")
+    else:
+        isostr = dt_obj.isoformat(timespec="milliseconds")
+
+    # Since dt_obj has time zone, isoformat() always returns string with UTC offset, which for UTC will be: "+00:00"
+    # Replace with Z which is the convention we use
+    isostr = isostr.replace("+00:00", "Z")
+
+    return isostr
+
+
+def iso_str_to_timestamp_utc_ms(iso_str: str) -> int:
+    """
+    Convert ISO 8601 string to timestamp in milliseconds UTC
+    Note that for date-time strings that do not contain timezone information, this function assumes
+    that the date-time string is in UTC
+    """
+    dt_obj = datetime.datetime.fromisoformat(iso_str)
+
+    if dt_obj.tzinfo is None:
+        # Assume UTC if no timezone is given
+        dt_obj = dt_obj.replace(tzinfo=datetime.timezone.utc)
+
+    return int(dt_obj.timestamp() * 1000)

--- a/backend_py/primary/primary/services/sumo_access/_helpers.py
+++ b/backend_py/primary/primary/services/sumo_access/_helpers.py
@@ -24,14 +24,3 @@ async def create_sumo_case_async(client: SumoClient, case_uuid: str) -> Case:
     LOGGER.debug(timer.to_string())
 
     return case
-
-
-def datetime_string_to_utc_ms(date_string: str) -> int:
-
-    # Some entries occasionally exclude the milliseconds-part
-    try:
-        timestamp_dt = datetime.strptime(date_string, "%Y-%m-%dT%H:%M:%S.%fZ")
-    except ValueError:
-        timestamp_dt = datetime.strptime(date_string, "%Y-%m-%dT%H:%M:%SZ")
-
-    return int(timestamp_dt.timestamp() * 1000)

--- a/backend_py/primary/primary/services/sumo_access/case_inspector.py
+++ b/backend_py/primary/primary/services/sumo_access/case_inspector.py
@@ -5,13 +5,14 @@ from fmu.sumo.explorer.explorer import SumoClient
 from fmu.sumo.explorer.objects import Case, SearchContext
 
 from webviz_pkg.core_utils.perf_metrics import PerfMetrics
+from webviz_pkg.core_utils.timestamp_utils import iso_str_to_timestamp_utc_ms
 from primary.services.service_exceptions import (
     Service,
     NoDataError,
     MultipleDataMatchesError,
 )
 
-from ._helpers import create_sumo_case_async, datetime_string_to_utc_ms
+from ._helpers import create_sumo_case_async
 from .sumo_client_factory import create_sumo_client
 
 
@@ -51,7 +52,7 @@ class CaseInspector:
     async def get_case_updated_timestamp_async(self) -> int:
         case = await self._get_or_create_case_context_async()
         timestamp_str = case.metadata["_sumo"]["timestamp"]  # Returns a datetime string.
-        return datetime_string_to_utc_ms(timestamp_str)
+        return iso_str_to_timestamp_utc_ms(timestamp_str)
 
     async def get_iteration_data_update_timestamp_async(self, iteration_name: str | None = None) -> int:
         timer = PerfMetrics()

--- a/backend_py/primary/primary/services/sumo_access/queries/surface_queries.py
+++ b/backend_py/primary/primary/services/sumo_access/queries/surface_queries.py
@@ -4,6 +4,7 @@ import logging
 from dataclasses import dataclass
 
 from sumo.wrapper import SumoClient
+from webviz_pkg.core_utils.timestamp_utils import timestamp_utc_ms_to_iso_str_strip_tz
 
 LOGGER = logging.getLogger(__name__)
 
@@ -242,8 +243,8 @@ async def _run_query_and_aggregate_time_intervals_async(
     for bucket in response_dict["aggregations"]["unique_time_intervals"]["buckets"]:
         t0_ms = bucket["key"]["k_t0"]
         t1_ms = bucket["key"]["k_t1"]
-        t0_isostr = _timestamp_utc_ms_to_iso_str(t0_ms)
-        t1_isostr = _timestamp_utc_ms_to_iso_str(t1_ms)
+        t0_isostr = timestamp_utc_ms_to_iso_str_strip_tz(t0_ms, False)
+        t1_isostr = timestamp_utc_ms_to_iso_str_strip_tz(t1_ms, False)
         ret_arr.append(TimeInterval(t0_ms=t0_ms, t1_ms=t1_ms, t0_isostr=t0_isostr, t1_isostr=t1_isostr))
 
     return ret_arr
@@ -274,17 +275,10 @@ async def _run_query_and_aggregate_time_points_async(sumo_client: SumoClient, qu
     ret_arr: list[TimePoint] = []
     for bucket in response_dict["aggregations"]["unique_time_points"]["buckets"]:
         t0_ms = bucket["key"]["k_t0"]
-        t0_isostr = _timestamp_utc_ms_to_iso_str(t0_ms)
+        t0_isostr = timestamp_utc_ms_to_iso_str_strip_tz(t0_ms, False)
         ret_arr.append(TimePoint(t0_ms=t0_ms, t0_isostr=t0_isostr))
 
     return ret_arr
-
-
-# --------------------------------------------------------------------------------------
-def _timestamp_utc_ms_to_iso_str(timestamp_utc_ms: int) -> str:
-    isostr = datetime.datetime.fromtimestamp(timestamp_utc_ms / 1000, datetime.timezone.utc).isoformat()
-    isostr = isostr.replace("+00:00", "")
-    return isostr
 
 
 # --------------------------------------------------------------------------------------

--- a/backend_py/primary/primary/services/sumo_access/sumo_inspector.py
+++ b/backend_py/primary/primary/services/sumo_access/sumo_inspector.py
@@ -6,10 +6,9 @@ from pydantic import BaseModel
 
 from fmu.sumo.explorer.explorer import SearchContext, SumoClient
 from webviz_pkg.core_utils.perf_metrics import PerfMetrics
+from webviz_pkg.core_utils.timestamp_utils import iso_str_to_timestamp_utc_ms
 
 from .sumo_client_factory import create_sumo_client
-
-from ._helpers import datetime_string_to_utc_ms
 
 LOGGER = logging.getLogger(__name__)
 
@@ -50,7 +49,7 @@ class SumoInspector:
             name=case.name,
             status=case.status,
             user=case.user,
-            updated_at_utc_ms=datetime_string_to_utc_ms(timestamp_str),
+            updated_at_utc_ms=iso_str_to_timestamp_utc_ms(timestamp_str),
         )
 
     async def get_cases_async(self, field_identifier: str) -> List[CaseInfo]:


### PR DESCRIPTION
Implemented utility functions for conversion between UTC/ms timestamps and ISO date/time strings in core_utils library
* Refactored `datetime_string_to_utc_ms()` in `backend_py/primary/primary/services/sumo_access/_helpers.py` into `iso_str_to_timestamp_utc_ms()` in `core_utils`, ensuring that the output timestamp is actually in UTC
* Utilize new `iso_str_to_timestamp_utc_ms()` in `CaseInspector` and `SumoInspector`
* Utilize new utility function, `timestamp_utc_ms_to_iso_str_strip_tz()` in `backend_py/primary/primary/services/sumo_access/queries/surface_queries.py`