### PR TITLE
Fix: Realization filter is ignored for Inplace volumes statistics

### DIFF
--- a/backend_py/primary/primary/routers/inplace_volumes/router.py
+++ b/backend_py/primary/primary/routers/inplace_volumes/router.py
@@ -176,6 +176,7 @@ async def post_get_aggregated_statistical_table_data(
             result_names,
             indices_with_values,
             group_by_indices,
+            realizations,
         )
 
     assembler = InplaceVolumesTableAssembler(access)


### PR DESCRIPTION
Closes: #1095

Note: Was only for the deprecated inplace volumes format