### PR TITLE
Enable `useBuildKit` in `radixconfig.yml`

### DIFF
--- a/radixconfig.yml
+++ b/radixconfig.yml
@@ -3,6 +3,8 @@ kind: RadixApplication
 metadata:
   name: webviz
 spec:
+  build:
+    useBuildKit: true
   environments:
     - name: prod
     - name: preprod


### PR DESCRIPTION
See https://www.radix.equinor.com/radix-config/#usebuildkit. 

This is said to be a way to mitigate rate limitation towards `docker.io` (according to Slack communication from Radix, enabling this flag will also tell Radix to user a Radix-managed Docker user and authenticate with this when pulling images). It might be that we in addition need to change Docker-instructions from `FROM ubuntu...` to `FROM docker.io/ubuntu...`, but maybe first check if enabling this flag is enough.

This flag will later be the default in Radix. Benefits of enabling it:

* Secure handling of [build secrets](https://www.radix.equinor.com/guides/build-secrets/#build-secrets-with-buildkit).
* Caching support that can reduce build time, see [useBuildCache](https://www.radix.equinor.com/radix-config/#usebuildcache).
* Use images from protected container registries defined in [privateImageHubs](https://www.radix.equinor.com/radix-config/#privateimagehubs), in the Dockerfile's FROM instructions.
* Faster builds due to less steps involved and higher performance nodes.

