### PR TITLE
fix: avoid mutating input array in sort operation

### DIFF
--- a/frontend/src/modules/_shared/utils/math/statistics.ts
+++ b/frontend/src/modules/_shared/utils/math/statistics.ts
@@ -10,7 +10,7 @@ export const computeQuantile = (data: number[], quantile: number): number => {
     if (data.length === 1) {
         return data[0];
     }
-    const sortedValues = data.slice().sort((a, b) => a - b);
+    const sortedValues = [...data].sort((a, b) => a - b);
 
     // Calculate the index, which may be a decimal.
     const rank = (sortedValues.length - 1) * quantile;


### PR DESCRIPTION
Function to calculate quantiles sorts the input array in place, which can cause interesting things.

=> Fix: Create copy before sorting