### PR TITLE
Change Dialog to perform close from onPointerDown to onClick

### DIFF
--- a/frontend/src/lib/components/Dialog/dialog.tsx
+++ b/frontend/src/lib/components/Dialog/dialog.tsx
@@ -73,7 +73,7 @@ export const Dialog: React.FC<DialogProps> = (props) => {
                     {props.showCloseCross && (
                         <div
                             className="hover:text-slate-500 cursor-pointer ml-4"
-                            onPointerDown={handleClose}
+                            onClick={handleClose}
                             title="Close dialog"
                         >
                             <Close width={24} />


### PR DESCRIPTION
Dialog closed with onPointerDown event, which prevents user to "regret" the mouse click and move mouse away from the close element.