### PR TITLE
nginx: let frontend app act as SPA - handle routing itself

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -59,6 +59,12 @@ http {
         location / {
             proxy_http_version 1.1;
             root /usr/share/nginx/dist;
+            # Always serve index.html for SPA routing if the requested file is not found
+            # This allows the frontend to handle routing instead of nginx
+            # Important for routing sessions and snapshot links
+            index index.html;
+            try_files $uri $uri/ /index.html;
+
             add_header Cache-Control "no-cache";
             # At the moment we need the "connect-src 'self' data:"" entry in order to use PNG images as data format
             add_header Content-Security-Policy "default-src 'self'; connect-src 'self' data:; style-src 'self' 'unsafe-inline' https://cdn.eds.equinor.com; script-src 'self' 'unsafe-eval' blob:; font-src https://cdn.eds.equinor.com; img-src 'self' data:; form-action 'self'; base-uri 'none'; frame-ancestors 'none';";


### PR DESCRIPTION
We need this to have a single entry point to our frontend app in order to have session and snapshot links work and not being routed to non-existent paths.

For instance, in the current setup a URL like `/session/edgi78sdf` would cause `nginx` to look for a path `/session/edgi78sdf` which does not exist, resulting in a 404. We want this to be routed to `index.html` such that our SPA can handle URL changes.