### PR TITLE
fix default color value in PolygonVisualizationSetting

### DIFF
--- a/frontend/src/modules/_shared/DataProviderFramework/settings/implementations/PolygonVisualizationSetting.tsx
+++ b/frontend/src/modules/_shared/DataProviderFramework/settings/implementations/PolygonVisualizationSetting.tsx
@@ -18,7 +18,7 @@ type ValueType = PolygonVisualizationSpec | null;
 
 export class PolygonVisualizationSetting implements CustomSettingImplementation<ValueType, SettingCategory.STATIC> {
     defaultValue: ValueType = {
-        color: "#000",
+        color: "#000000",
         lineThickness: 2,
         lineOpacity: 1,
         fill: false,


### PR DESCRIPTION
The default color value was invalid (3 digits instead 6) and resetted the dialog during validation.