### PR TITLE
Explicitly set `permissions` on `GITHUB_TOKEN`

### DIFF
--- a/.github/workflows/webviz.yml
+++ b/.github/workflows/webviz.yml
@@ -1,5 +1,8 @@
 name: webviz
 
+permissions:
+  contents: read
+
 on:
   push:
   pull_request:


### PR DESCRIPTION
Remove ~4 CodeQL warnings.

https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#permissions