### PR TITLE
Add `trivy` scan

### DIFF
--- a/.github/workflows/trivy_scan.yml
+++ b/.github/workflows/trivy_scan.yml
@@ -19,7 +19,7 @@ jobs:
         id: extract
         run: |
           echo "Searching for Dockerfiles..."
-          find . -type f -iname 'Dockerfile*' > dockerfiles.txt
+          find . -type f \( -iname 'Dockerfile' -o -iname '*.Dockerfile' \) > dockerfiles.txt
           echo "Found:"
           cat dockerfiles.txt
 

--- a/.github/workflows/trivy_scan.yml
+++ b/.github/workflows/trivy_scan.yml
@@ -1,38 +1,41 @@
-name: Trivy Scan of Docker config/images
+name: Trivy Base Image Scan
 
 on:
   pull_request:
 
 jobs:
-  trivy-scan:
-    name: Trivy Scan docker-compose and images
+  scan-base-images:
     runs-on: ubuntu-latest
+    name: Scan base images from Dockerfiles
 
     steps:
-      - name: Checkout repository
+      - name: Checkout code
         uses: actions/checkout@v3
 
       - name: Install Trivy
         uses: aquasecurity/trivy-action@master
 
-      # 1. Scan docker-compose.yml for misconfigurations
-      - name: Trivy config scan
-        uses: aquasecurity/trivy-action@master
-        with:
-          scan-type: 'config'
-          scan-ref: 'docker-compose.yml'
-
-      # 2. Extract image names from docker-compose.yml
-      - name: Extract image names
+      - name: Find Dockerfiles and extract base images
+        id: extract
         run: |
-          grep 'image:' docker-compose.yml | awk '{print $2}' > images.txt
-          echo "Images to scan:"
-          cat images.txt
+          echo "Searching for Dockerfiles..."
+          find . -type f -iname 'Dockerfile*' > dockerfiles.txt
+          echo "Found:"
+          cat dockerfiles.txt
 
-      # 3. Scan each image for vulnerabilities
-      - name: Trivy image scan
+          echo "Extracting base images..."
+          > base_images.txt
+          while read file; do
+            grep -i '^FROM' "$file" | awk '{print $2}' >> base_images.txt
+          done < dockerfiles.txt
+
+          sort -u base_images.txt > unique_base_images.txt
+          echo "Base images to scan:"
+          cat unique_base_images.txt
+
+      - name: Scan base images with Trivy
         run: |
           while read image; do
-            echo "Scanning image: $image"
+            echo "🔍 Scanning $image"
             trivy image --severity HIGH,CRITICAL --exit-code 1 "$image"
-          done < images.txt
+          done < unique_base_images.txt

--- a/.github/workflows/trivy_scan.yml
+++ b/.github/workflows/trivy_scan.yml
@@ -14,22 +14,43 @@ jobs:
 
       - name: Install Trivy
         uses: aquasecurity/setup-trivy@v0.2.3
-
-      - name: Find Dockerfiles and extract base images
-        id: extract
+      
+      - name: Extract and resolve base images from Dockerfiles
         run: |
-          echo "Searching for Dockerfiles..."
           find . -type f \( -iname 'Dockerfile' -o -iname '*.Dockerfile' \) > dockerfiles.txt
+          > resolved_images.txt
+
           echo "Found:"
           cat dockerfiles.txt
 
-          echo "Extracting base images..."
-          > base_images.txt
           while read file; do
-            grep -i '^FROM' "$file" | awk '{print $2}' >> base_images.txt
-          done < dockerfiles.txt
-
-          sort -u base_images.txt > unique_base_images.txt
+            echo "Processing $file"
+      
+            # Extract ARG definitions
+            declare -A args
+            while IFS= read -r line; do
+              if [[ "$line" =~ ^ARG[[:space:]]+([A-Za-z0-9_]+)=([^\"]+) ]]; then
+                key="${BASH_REMATCH[1]}"
+                value="${BASH_REMATCH[2]}"
+                args[$key]="$value"
+              fi
+            done < "$file"
+      
+            # Extract FROM lines and resolve variables
+            while IFS= read -r line; do
+              if [[ "$line" =~ ^FROM[[:space:]]+(.+) ]]; then
+                raw="${BASH_REMATCH[1]}"
+                resolved="$raw"
+                for key in "${!args[@]}"; do
+                  resolved="${resolved//\$\{$key\}/${args[$key]}}"
+                done
+                echo "$resolved" >> resolved_images.txt
+              fi
+            done < "$file"
+          done
+      
+          # Clean and deduplicate
+          grep -v '^$' resolved_images.txt | sort -u > unique_base_images.txt
           echo "Base images to scan:"
           cat unique_base_images.txt
 

--- a/.github/workflows/trivy_scan.yml
+++ b/.github/workflows/trivy_scan.yml
@@ -1,4 +1,7 @@
-name: Trivy Base Image Scan
+name: Docker Base Image Scan
+
+permissions:
+  contents: read
 
 on:
   pull_request:

--- a/.github/workflows/trivy_scan.yml
+++ b/.github/workflows/trivy_scan.yml
@@ -17,41 +17,44 @@ jobs:
       
       - name: Extract and resolve base images from Dockerfiles
         run: |
-          find . -type f \( -iname 'Dockerfile' -o -iname '*.Dockerfile' \) > dockerfiles.txt
-          > resolved_images.txt
-
-          echo "Found:"
+          find . -type f -name '*Dockerfile*' > dockerfiles.txt
+          > base_images.txt
+          
+          echo "Found following Dockerfiles:"
           cat dockerfiles.txt
-
-          while read file; do
-            echo "Processing $file"
-      
-            # Extract ARG definitions
-            declare -A args
+          
+          for file in $(cat dockerfiles.txt); do
+            declare -A args=()
+          
+            # Collect ARG values
             while IFS= read -r line; do
-              if [[ "$line" =~ ^ARG[[:space:]]+([A-Za-z0-9_]+)=([^\"]+) ]]; then
+              if [[ "$line" =~ ^ARG[[:space:]]+([A-Za-z0-9_]+)=?\"?([^\"]*)\"?$ ]]; then
                 key="${BASH_REMATCH[1]}"
                 value="${BASH_REMATCH[2]}"
                 args[$key]="$value"
               fi
             done < "$file"
-      
-            # Extract FROM lines and resolve variables
+          
+            # Resolve FROM lines
             while IFS= read -r line; do
               if [[ "$line" =~ ^FROM[[:space:]]+(.+) ]]; then
                 raw="${BASH_REMATCH[1]}"
                 resolved="$raw"
                 for key in "${!args[@]}"; do
                   resolved="${resolved//\$\{$key\}/${args[$key]}}"
+                  resolved="${resolved//\$$key/${args[$key]}}"
                 done
-                echo "$resolved" >> resolved_images.txt
+                image=$(echo "$resolved" | awk '{print $1}')
+                if [[ -n "$image" && "$image" != *'${'* && "$image" != *'$'* ]]; then
+                  echo "$image" >> base_images.txt
+                fi
               fi
             done < "$file"
           done
-      
-          # Clean and deduplicate
-          grep -v '^$' resolved_images.txt | sort -u > unique_base_images.txt
-          echo "Base images to scan:"
+          
+          sort -u base_images.txt > unique_base_images.txt
+          
+          echo "Docker base images to scan:"
           cat unique_base_images.txt
 
       - name: Scan base images with Trivy

--- a/.github/workflows/trivy_scan.yml
+++ b/.github/workflows/trivy_scan.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     name: Scan base images from Dockerfiles
 
+    continue-on-error: true
+    
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/trivy_scan.yml
+++ b/.github/workflows/trivy_scan.yml
@@ -60,7 +60,7 @@ jobs:
           echo "Docker base images to scan:"
           cat unique_base_images.txt
 
-      - name: Scan base images with Trivy
+      - name: Scan base images with Trivy - fail if HIGH or CRITICAL vulnerability found
         run: |
           while read image; do
             echo "🔍 Scanning $image"

--- a/.github/workflows/trivy_scan.yml
+++ b/.github/workflows/trivy_scan.yml
@@ -1,0 +1,38 @@
+name: Trivy Scan of Docker config/images
+
+on:
+  pull_request:
+
+jobs:
+  trivy-scan:
+    name: Trivy Scan docker-compose and images
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install Trivy
+        uses: aquasecurity/trivy-action@master
+
+      # 1. Scan docker-compose.yml for misconfigurations
+      - name: Trivy config scan
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: 'config'
+          scan-ref: 'docker-compose.yml'
+
+      # 2. Extract image names from docker-compose.yml
+      - name: Extract image names
+        run: |
+          grep 'image:' docker-compose.yml | awk '{print $2}' > images.txt
+          echo "Images to scan:"
+          cat images.txt
+
+      # 3. Scan each image for vulnerabilities
+      - name: Trivy image scan
+        run: |
+          while read image; do
+            echo "Scanning image: $image"
+            trivy image --severity HIGH,CRITICAL --exit-code 1 "$image"
+          done < images.txt

--- a/.github/workflows/trivy_scan.yml
+++ b/.github/workflows/trivy_scan.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Trivy
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/setup-trivy@v0.2.3
 
       - name: Find Dockerfiles and extract base images
         id: extract


### PR DESCRIPTION
Since GitHub Advanced Security does not (yet) support scanning of Docker base images, we include `trivy` (Equinor suggested tool) to scan them.

Currently implementing this as a non-required GitHub actions workflow, which will be marked as red/failed if there are found high/critical vulnerabilities in base images.

If some CVEs are marked as noise, we can filter by e.g. ID going forward:
https://trivy.dev/v0.16.0/examples/filter/#by-vulnerability-ids