### PR TITLE
Add error and warning flag for CollapsibleGroup-component

### DIFF
--- a/frontend/src/lib/components/CollapsibleGroup/collapsibleGroup.tsx
+++ b/frontend/src/lib/components/CollapsibleGroup/collapsibleGroup.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { ExpandLess, ExpandMore } from "@mui/icons-material";
+import { Error, ExpandLess, ExpandMore, Warning } from "@mui/icons-material";
 
 import { Tooltip } from "@lib/components/Tooltip";
 import { resolveClassNames } from "@lib/utils/resolveClassNames";
@@ -14,6 +14,8 @@ export type CollapsibleGroupProps = {
     title: string;
     children: React.ReactNode;
     expanded?: boolean;
+    hasError?: boolean;
+    hasWarning?: boolean;
     onChange?: (expanded: boolean) => void;
 } & BaseComponentProps;
 
@@ -35,12 +37,24 @@ function CollapsibleGroupComponent(props: CollapsibleGroupProps, ref: React.Forw
         <BaseComponent ref={ref} disabled={props.disabled}>
             <div
                 className={resolveClassNames(
-                    "flex flex-row justify-between items-center bg-slate-100 cursor-pointer p-1.5 select-none gap-2 hover:bg-slate-200 shadow-sm",
+                    "flex flex-row justify-between items-center cursor-pointer p-1.5 select-none gap-2 shadow-sm",
+                    { "bg-slate-100 hover:bg-slate-200": !props.hasError && !props.hasWarning },
+                    { "bg-red-100 hover:bg-red-200": props.hasError },
+                    { "bg-yellow-100 hover:bg-yellow-200": props.hasWarning && !props.hasError },
                 )}
                 onClick={handleClick}
             >
                 {props.icon && React.cloneElement(props.icon, { className: "w-4 h-4" })}
                 <h3 className="text-sm font-semibold grow leading-none">{props.title}</h3>
+                {(props.hasError || props.hasWarning) && (
+                    <Tooltip title={`There are ${props.hasError ? "errors" : "warnings"} in this section`}>
+                        {props.hasError ? (
+                            <Error fontSize="inherit" color="error" />
+                        ) : (
+                            <Warning fontSize="inherit" color="warning" />
+                        )}
+                    </Tooltip>
+                )}
                 <Tooltip title={expanded ? "Collapse" : "Expand"}>
                     <DenseIconButton aria-label={expanded ? "Collapse" : "Expand"} onClick={handleClick}>
                         {expanded ? <ExpandLess fontSize="inherit" /> : <ExpandMore fontSize="inherit" />}

--- a/frontend/src/modules/MyModule2/settings.tsx
+++ b/frontend/src/modules/MyModule2/settings.tsx
@@ -11,6 +11,7 @@ import type { ModuleSettingsProps } from "@framework/Module";
 import type { RegularEnsembleIdent } from "@framework/RegularEnsembleIdent";
 import { useEnsembleRealizationFilterFunc, useEnsembleSet } from "@framework/WorkbenchSession";
 import { Checkbox } from "@lib/components/Checkbox";
+import { CollapsibleGroup } from "@lib/components/CollapsibleGroup";
 import { Dropdown } from "@lib/components/Dropdown";
 import { Label } from "@lib/components/Label";
 import { PendingWrapper } from "@lib/components/PendingWrapper";
@@ -149,7 +150,12 @@ export function Settings({ workbenchSession }: ModuleSettingsProps<Interfaces>):
                 <div className="p-1">This text has a tooltip with long delay</div>
             </Tooltip>
 
-            <Label text="Status message" wrapperClassName="pt-2">
+            <CollapsibleGroup
+                title="Status and Pending Wrapper Examples"
+                expanded={true}
+                hasError={statusMessage === "This is an error message"}
+                hasWarning={statusMessage === "This is a warning message"}
+            >
                 <div className="pt-2 flex flex-col gap-2">
                     <Dropdown
                         value={statusMessage ?? ""}
@@ -194,7 +200,7 @@ export function Settings({ workbenchSession }: ModuleSettingsProps<Interfaces>):
                         </>
                     </Label>
                 </div>
-            </Label>
+            </CollapsibleGroup>
         </>
     );
 }


### PR DESCRIPTION
Add flag for highlight of possible error/warning for child components. 

E.g. to highlight error/invalid value for settings in a group when collapsed.

Error has highest priority, second warning Highlight header in red or yellow color, based on active prioritized flag. With corresponding icon and tooltip text for description.

---

Closes: #1296

