### PR TITLE
[Bugfix]: Preventing error related to missing module instance atom store

### DIFF
--- a/frontend/src/framework/AtomStoreMaster.ts
+++ b/frontend/src/framework/AtomStoreMaster.ts
@@ -35,10 +35,11 @@ export class AtomStoreMaster {
         return atomStore;
     }
 
-    getAtomStoreForModuleInstance(moduleInstanceId: string): AtomStore {
+    getAtomStoreForModuleInstance(moduleInstanceId: string): AtomStore | null {
         const atomStore = this._atomStores.get(moduleInstanceId);
         if (!atomStore) {
-            throw new Error(`No atom store found for module instance with id: ${moduleInstanceId}`);
+            console.debug(`No atom store found for module instance with id ${moduleInstanceId}`);
+            return null;
         }
         return atomStore;
     }

--- a/frontend/src/framework/internal/components/Content/private-components/ViewWrapper/private-components/viewContent.tsx
+++ b/frontend/src/framework/internal/components/Content/private-components/ViewWrapper/private-components/viewContent.tsx
@@ -38,8 +38,6 @@ export const ViewContent = React.memo((props: ViewContentProps) => {
         ModuleInstanceTopic.HAS_INVALID_PERSISTED_VIEW,
     );
 
-    const atomStore = workbenchSession.getAtomStoreMaster().getAtomStoreForModuleInstance(props.moduleInstance.getId());
-
     const handleModuleInstanceReload = React.useCallback(
         function handleModuleInstanceReload() {
             props.moduleInstance.reset();
@@ -125,6 +123,11 @@ export const ViewContent = React.memo((props: ViewContentProps) => {
                 />
             );
         }
+    }
+
+    const atomStore = workbenchSession.getAtomStoreMaster().getAtomStoreForModuleInstance(props.moduleInstance.getId());
+    if (!atomStore) {
+        return null;
     }
 
     const View = props.moduleInstance.getViewFC();

--- a/frontend/src/framework/internal/components/LeftSettingsPanel/private-components/moduleSettings.tsx
+++ b/frontend/src/framework/internal/components/LeftSettingsPanel/private-components/moduleSettings.tsx
@@ -49,10 +49,6 @@ export const ModuleSettings: React.FC<ModuleSettingsProps> = (props) => {
 
     const isSerializable = props.moduleInstance.getModule().canBeSerialized();
 
-    const atomStore = workbenchSession!
-        .getAtomStoreMaster()
-        .getAtomStoreForModuleInstance(props.moduleInstance.getId());
-
     if (importState !== ImportStatus.Imported || !props.moduleInstance.isInitialized()) {
         return null;
     }
@@ -103,6 +99,14 @@ export const ModuleSettings: React.FC<ModuleSettingsProps> = (props) => {
                     </Button>
                 </div>
             );
+        }
+
+        const atomStore = workbenchSession
+            .getAtomStoreMaster()
+            .getAtomStoreForModuleInstance(props.moduleInstance.getId());
+
+        if (!atomStore) {
+            return null;
         }
 
         return (


### PR DESCRIPTION
- Changed call order in consumer components (after initialization) and added check
- Changed to fail softly if store not found

Fixes #1350.