### PR TITLE
Fix backend failure when polling for result of surface statistics computation

### DIFF
--- a/backend_py/libs/services/src/webviz_services/sumo_access/surface_access.py
+++ b/backend_py/libs/services/src/webviz_services/sumo_access/surface_access.py
@@ -3,6 +3,7 @@ import logging
 from dataclasses import dataclass
 from io import BytesIO
 from typing import Sequence
+from urllib.parse import urlparse
 
 import httpx
 import xtgeo
@@ -437,7 +438,10 @@ class SurfaceAccess:
             if not task_state.result_url:
                 raise InvalidDataError("No result_url was found in the Sumo task response", Service.SUMO)
 
-            relative_result_url = task_state.result_url.removeprefix(self._sumo_client.base_url)
+            # Both the result_url and the sumo_client.base_url contain the API prefix (e.g. /api/v1),
+            # so we need to strip that from the result_url to get the relative path before passing it to the sumo client
+            api_prefix = _extract_api_prefix(self._sumo_client.base_url)
+            relative_result_url = _strip_api_prefix(task_state.result_url, api_prefix)
             result_resp = await self._sumo_client.get_async(relative_result_url)
             sumo_obj_meta_dict = result_resp.json()
 
@@ -673,3 +677,25 @@ def _map_to_sumo_aggregation_operation(statistic_function: StatisticFunction) ->
         raise ValueError(f"Unhandled statistic function: {statistic_function}")
 
     return sumo_agg_op
+
+
+def _extract_api_prefix(base_url: str) -> str:
+    # Extract the path part of the base_url to get the API prefix, e.g. /api/v1
+    parsed = urlparse(base_url)
+    path = parsed.path.rstrip("/")
+    return path or "/"
+
+
+def _strip_api_prefix(path: str, api_prefix: str) -> str:
+    # Remove the specified api_prefix from the given path, if it starts with it
+
+    # Ensure there is one, and only one, leading slash
+    path = "/" + path.lstrip("/")
+
+    if api_prefix != "/" and path.startswith(api_prefix + "/"):
+        return path[len(api_prefix) :]
+
+    if path == api_prefix:
+        return "/"
+
+    return path


### PR DESCRIPTION
Fix result_url handling when polling for aggregation result by extracting and stripping API prefix that is contained in result_url before passing it on to SumoClient.

This error was triggered by a change in the polling response format from Sumo surface aggregation service.