### PR TITLE
Bump @webviz/group-tree-plot package

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,7 +15,7 @@
                 "@tanstack/query-core": "^5.62.16",
                 "@tanstack/react-query": "^5.63",
                 "@tanstack/react-query-devtools": "^5.63",
-                "@webviz/group-tree-plot": "^1.6.9",
+                "@webviz/group-tree-plot": "^1.6.19",
                 "@webviz/subsurface-viewer": "^1.14.11",
                 "@webviz/well-completions-plot": "^1.8.9",
                 "@webviz/well-log-viewer": "^2.6.10",
@@ -7137,9 +7137,9 @@
             }
         },
         "node_modules/@webviz/group-tree-plot": {
-            "version": "1.6.9",
-            "resolved": "https://registry.npmjs.org/@webviz/group-tree-plot/-/group-tree-plot-1.6.9.tgz",
-            "integrity": "sha512-bM7IFFrwqoU+U4/R1qRv7N1s18ZkU9oai8eQYwjb0H0HQP78djXwKkGp/MaM/iROFqezgQJQrJsqjyOXD4GC3A==",
+            "version": "1.6.19",
+            "resolved": "https://registry.npmjs.org/@webviz/group-tree-plot/-/group-tree-plot-1.6.19.tgz",
+            "integrity": "sha512-hv/RnnjEbY1sLszqW0D2GzRmdybvBBxp15msV9OcL+S+Gc1QsbU5qv3ZMR0lTwE6V3sdtKFLmUo2zG1t1HuYMQ==",
             "license": "MPL-2.0",
             "dependencies": {
                 "d3": "^7.8.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -40,7 +40,7 @@
         "@tanstack/query-core": "^5.62.16",
         "@tanstack/react-query": "^5.63",
         "@tanstack/react-query-devtools": "^5.63",
-        "@webviz/group-tree-plot": "^1.6.9",
+        "@webviz/group-tree-plot": "^1.6.19",
         "@webviz/subsurface-viewer": "^1.14.11",
         "@webviz/well-completions-plot": "^1.8.9",
         "@webviz/well-log-viewer": "^2.6.10",

--- a/frontend/src/modules/ModuleSerializedStateMap.ts
+++ b/frontend/src/modules/ModuleSerializedStateMap.ts
@@ -112,6 +112,10 @@ export type ModuleSerializedStateMap = {
     settings?: never,
     view?: never,
   },
+  "TopographicMap": {
+    settings?: never,
+    view?: never,
+  },
   "Vfp": {
     settings?: never,
     view?: never,


### PR DESCRIPTION
Bump package

Fixes issue with incorrect date when switching Tree Type. Old version of component did not render with selected date when providing new/updating tree data (used first date in data array).

---

Closes: #1400