### PR TITLE
[bug]: Fix correct update of user created polylines fieldId

### DIFF
--- a/frontend/src/framework/userCreatedItems/IntersectionPolylines.ts
+++ b/frontend/src/framework/userCreatedItems/IntersectionPolylines.ts
@@ -78,11 +78,31 @@ export class IntersectionPolylines {
     }
 
     updatePolyline(id: string, polyline: IntersectionPolylineWithoutId): void {
-        const index = this._polylines.findIndex((polyline) => polyline.id === id);
-        this._polylines[index] = {
+        // Creating a new array to avoid mutation wrt reference checks
+        const newPolylinesArray: IntersectionPolyline[] = [...this._polylines];
+        const index = newPolylinesArray.findIndex((polyline) => polyline.id === id);
+        newPolylinesArray[index] = {
             id,
             ...polyline,
         };
+        this._polylines = newPolylinesArray;
+        this.notifySubscribers(IntersectionPolylinesEvent.CHANGE);
+    }
+
+    updatePolylines(polylines: IntersectionPolyline[]): void {
+        // Creating a new array to avoid mutation wrt reference checks
+        const newPolylinesArray: IntersectionPolyline[] = [...this._polylines];
+        for (const updatedPolyline of polylines) {
+            const index = newPolylinesArray.findIndex((p) => p.id === updatedPolyline.id);
+            if (index === -1) {
+                // New polyline, add it
+                newPolylinesArray.push(updatedPolyline);
+            } else {
+                // Existing polyline, update it
+                newPolylinesArray[index] = { ...updatedPolyline };
+            }
+        }
+        this._polylines = newPolylinesArray;
         this.notifySubscribers(IntersectionPolylinesEvent.CHANGE);
     }
 

--- a/frontend/src/modules/_shared/components/SubsurfaceViewer/_components/InteractionWrapper.tsx
+++ b/frontend/src/modules/_shared/components/SubsurfaceViewer/_components/InteractionWrapper.tsx
@@ -115,7 +115,9 @@ export function InteractionWrapper(props: InteractionWrapperProps): React.ReactN
 
             const polylinesPlugin = new PolylinesPlugin(manager, colorGenerator());
             polylinesPlugin.setPolylines(
-                convertIntersectionPolylinesToPolylines([...intersectionPolylines.getPolylines()]),
+                convertIntersectionPolylinesToPolylines([
+                    ...intersectionPolylines.getPolylines().filter((p) => p.fieldId === props.fieldId),
+                ]),
             );
             manager.addPlugin(polylinesPlugin);
             polylinesPluginRef.current = polylinesPlugin;
@@ -124,8 +126,10 @@ export function InteractionWrapper(props: InteractionWrapperProps): React.ReactN
                 .getPublishSubscribeDelegate()
                 .makeSubscriberFunction(PolylinesPluginTopic.EDITING_POLYLINE_ID)(() => {
                 const editingId = polylinesPlugin.getCurrentEditingPolylineId();
-                if (editingId == null) {
-                    intersectionPolylines.setPolylines(
+                // Only update intersection polylines when not editing a polyline
+                if (editingId === null) {
+                    // We haven't changed all polylines, only the ones related to this field
+                    intersectionPolylines.updatePolylines(
                         convertPolylinesToIntersectionPolylines(polylinesPlugin.getPolylines(), props.fieldId),
                     );
                 } else {
@@ -138,7 +142,9 @@ export function InteractionWrapper(props: InteractionWrapperProps): React.ReactN
                 IntersectionPolylinesEvent.CHANGE,
                 () => {
                     polylinesPlugin.setPolylines(
-                        convertIntersectionPolylinesToPolylines([...intersectionPolylines.getPolylines()]),
+                        convertIntersectionPolylinesToPolylines([
+                            ...intersectionPolylines.getPolylines().filter((p) => p.fieldId === props.fieldId),
+                        ]),
                     );
                 },
             );


### PR DESCRIPTION
When user created polylines the fieldId of the currently active field was written to all created polylines. Thus fieldId becomes incorrect when creating polylines using different field 3D models.

---

Closes: #1430