### PR TITLE
Only log status of variables in create_credential_for_azure_services()

### DIFF
--- a/backend_py/primary/primary/utils/azure_service_credentials.py
+++ b/backend_py/primary/primary/utils/azure_service_credentials.py
@@ -88,6 +88,7 @@ def _secret_status(secret: str | None) -> str:
 
     return "present"
 
+
 def _show_start_of_secret(secret: str | None, num_chars: int = 4) -> str | None:
     if secret is None:
         return None


### PR DESCRIPTION
Only log the status (missing/empty/present) of variables in `create_credential_for_azure_services()`