### PR TITLE
Refactor timeseries router 

### DIFF
--- a/backend_py/libs/services/src/webviz_services/summary_delta_vectors.py
+++ b/backend_py/libs/services/src/webviz_services/summary_delta_vectors.py
@@ -9,6 +9,7 @@ from webviz_services.utils.arrow_helpers import validate_summary_vector_table_pa
 
 @dataclass
 class DeltaVectorMetadata:
+    name: str
     is_rate: bool
     unit: str
 

--- a/backend_py/libs/services/src/webviz_services/summary_delta_vectors.py
+++ b/backend_py/libs/services/src/webviz_services/summary_delta_vectors.py
@@ -62,18 +62,18 @@ def create_delta_vector_table(
 
 
 def create_realization_delta_vector_list(
-    delta_vector_table: pa.Table, vector_name: str, is_rate: bool, unit: str
+    delta_vector_table: pa.Table, delta_vector_metadata: DeltaVectorMetadata
 ) -> list[RealizationDeltaVector]:
     """
     Create a list of RealizationDeltaVector from the delta vector table.
     """
-    validate_summary_vector_table_pa(delta_vector_table, vector_name)
+    validate_summary_vector_table_pa(delta_vector_table, delta_vector_metadata.name)
 
     real_arr_np = delta_vector_table.column("REAL").to_numpy()
     unique_reals, first_occurrence_idx, real_counts = np.unique(real_arr_np, return_index=True, return_counts=True)
 
     whole_date_np_arr = delta_vector_table.column("DATE").to_numpy()
-    whole_value_np_arr = delta_vector_table.column(vector_name).to_numpy()
+    whole_value_np_arr = delta_vector_table.column(delta_vector_metadata.name).to_numpy()
 
     ret_arr: list[RealizationDeltaVector] = []
     for i, real in enumerate(unique_reals):
@@ -87,8 +87,8 @@ def create_realization_delta_vector_list(
                 realization=real,
                 timestamps_utc_ms=date_np_arr.astype(int).tolist(),
                 values=value_np_arr.tolist(),
-                is_rate=is_rate,
-                unit=unit,
+                is_rate=delta_vector_metadata.is_rate,
+                unit=delta_vector_metadata.unit,
             )
         )
 

--- a/backend_py/libs/services/src/webviz_services/summary_derived_vectors.py
+++ b/backend_py/libs/services/src/webviz_services/summary_derived_vectors.py
@@ -298,18 +298,19 @@ def create_per_day_vector_table_pa(total_vector_table_pa: pa.Table) -> pa.Table:
 
 
 def create_derived_realization_vector_list(
-    derived_vector_table: pa.Table, vector_name: str, is_rate: bool, unit: str
+    derived_vector_table: pa.Table,
+    derived_vector_metadata: DerivedVectorMetadata,
 ) -> list[DerivedRealizationVector]:
     """
     Create a list of DerivedRealizationVector from the derived vector table.
     """
-    validate_summary_vector_table_pa(derived_vector_table, vector_name)
+    validate_summary_vector_table_pa(derived_vector_table, derived_vector_metadata.name)
 
     real_arr_np = derived_vector_table.column("REAL").to_numpy()
     unique_reals, first_occurrence_idx, real_counts = np.unique(real_arr_np, return_index=True, return_counts=True)
 
     whole_date_np_arr = derived_vector_table.column("DATE").to_numpy()
-    whole_value_np_arr = derived_vector_table.column(vector_name).to_numpy()
+    whole_value_np_arr = derived_vector_table.column(derived_vector_metadata.name).to_numpy()
 
     ret_arr: list[DerivedRealizationVector] = []
     for i, real in enumerate(unique_reals):
@@ -323,8 +324,8 @@ def create_derived_realization_vector_list(
                 realization=real,
                 timestamps_utc_ms=date_np_arr.astype(int).tolist(),
                 values=value_np_arr.tolist(),
-                is_rate=is_rate,
-                unit=unit,
+                is_rate=derived_vector_metadata.is_rate,
+                unit=derived_vector_metadata.unit,
             )
         )
 

--- a/backend_py/primary/primary/routers/timeseries/_delta_ensemble_utils.py
+++ b/backend_py/primary/primary/routers/timeseries/_delta_ensemble_utils.py
@@ -70,7 +70,7 @@ async def get_vector_tables_and_create_delta_vector_table_and_metadata_async(
 
     # Create metadata from reference vector
     delta_vector_metadata = DeltaVectorMetadata(
-        name=reference_metadata.name, unit=reference_metadata.unit, is_rate=reference_metadata.is_rate
+        name=vector_name, unit=reference_metadata.unit, is_rate=reference_metadata.is_rate
     )
 
     # Create delta ensemble table

--- a/backend_py/primary/primary/routers/timeseries/_delta_ensemble_utils.py
+++ b/backend_py/primary/primary/routers/timeseries/_delta_ensemble_utils.py
@@ -1,0 +1,84 @@
+import asyncio
+
+import pyarrow as pa
+from fastapi import HTTPException
+
+from webviz_services.sumo_access.summary_access import Frequency, SummaryAccess
+from webviz_services.utils.authenticated_user import AuthenticatedUser
+from webviz_services.summary_delta_vectors import (
+    create_delta_vector_table,
+    DeltaVectorMetadata,
+)
+from primary.utils.response_perf_metrics import ResponsePerfMetrics
+
+
+async def get_vector_tables_and_create_delta_vector_table_and_metadata_async(
+    authenticated_user: AuthenticatedUser,
+    comparison_case_uuid: str,
+    comparison_ensemble_name: str,
+    reference_case_uuid: str,
+    reference_ensemble_name: str,
+    vector_name: str,
+    realizations: list[int] | None,
+    resampling_frequency: Frequency,
+    perf_metrics: ResponsePerfMetrics | None,
+) -> tuple[pa.Table, DeltaVectorMetadata]:
+    """
+    Get vector tables for comparison and reference ensembles and create delta ensemble vector pa.Table
+    and metadata
+    """
+    # Separate summary access to comparison and reference ensemble
+    comparison_ensemble_access = SummaryAccess.from_ensemble_name(
+        authenticated_user.get_sumo_access_token(), comparison_case_uuid, comparison_ensemble_name
+    )
+    reference_ensemble_access = SummaryAccess.from_ensemble_name(
+        authenticated_user.get_sumo_access_token(), reference_case_uuid, reference_ensemble_name
+    )
+
+    # Get tables parallel
+    # - Resampled data is assumed to be such that dates/timestamps are comparable between ensembles
+    #   and cases, i.e. timestamps for a resampling of a daily vector in both ensembles should be
+    #   the same.
+    (comparison_vector_table_pa, comparison_metadata), (
+        reference_vector_table_pa,
+        reference_metadata,
+    ) = await asyncio.gather(
+        comparison_ensemble_access.get_vector_table_async(
+            vector_name=vector_name,
+            resampling_frequency=resampling_frequency,
+            realizations=realizations,
+        ),
+        reference_ensemble_access.get_vector_table_async(
+            vector_name=vector_name,
+            resampling_frequency=resampling_frequency,
+            realizations=realizations,
+        ),
+    )
+
+    if perf_metrics:
+        perf_metrics.record_lap("get-vector-tables-to-create-delta-vector-table")
+
+    # Check for mismatching metadata
+    if comparison_metadata.is_rate != reference_metadata.is_rate:
+        raise HTTPException(
+            status_code=400, detail="Rate mismatch between ensembles for delta ensemble statistical vector data"
+        )
+    if comparison_metadata.unit != reference_metadata.unit:
+        raise HTTPException(
+            status_code=400, detail="Unit mismatch between ensembles for delta ensemble statistical vector data"
+        )
+
+    # Create metadata from reference vector
+    delta_vector_metadata = DeltaVectorMetadata(
+        name=reference_metadata.name, unit=reference_metadata.unit, is_rate=reference_metadata.is_rate
+    )
+
+    # Create delta ensemble table
+    delta_vector_table_pa = create_delta_vector_table(
+        comparison_vector_table_pa, reference_vector_table_pa, vector_name
+    )
+
+    if perf_metrics:
+        perf_metrics.record_lap("create-delta-vector-table")
+
+    return delta_vector_table_pa, delta_vector_metadata

--- a/backend_py/primary/primary/routers/timeseries/_derived_vector_utils.py
+++ b/backend_py/primary/primary/routers/timeseries/_derived_vector_utils.py
@@ -30,7 +30,7 @@ def create_derived_vector_realization_data_list(
         )
     )
     derived_realization_vector_list = create_derived_realization_vector_list(
-        derived_vector_table_pa, derived_vector_name, source_vector_metadata.is_rate, derived_vector_metadata.unit
+        derived_vector_table_pa, derived_vector_metadata
     )
 
     return converters.derived_realization_vector_list_and_info_to_api_vector_realization_data_list(

--- a/backend_py/primary/primary/routers/timeseries/_derived_vector_utils.py
+++ b/backend_py/primary/primary/routers/timeseries/_derived_vector_utils.py
@@ -1,0 +1,98 @@
+import pyarrow as pa
+from fastapi import HTTPException
+
+from webviz_services.sumo_access.summary_types import VectorMetadata
+from webviz_services.utils.statistic_function import StatisticFunction
+from webviz_services.summary_derived_vectors import (
+    create_per_day_vector_name,
+    create_per_interval_vector_name,
+    create_derived_realization_vector_list,
+    create_derived_vector_table_and_metadata_and_info,
+    is_total_vector,
+)
+from webviz_services.summary_vector_statistics import compute_vector_statistics
+from webviz_services.summary_delta_vectors import (
+    DeltaVectorMetadata,
+)
+
+from . import schemas, converters
+
+
+def create_derived_vector_realization_data_list(
+    derived_vector_name: str,
+    source_vector_table_pa: pa.Table,
+    source_vector_metadata: VectorMetadata | DeltaVectorMetadata,
+) -> list[schemas.VectorRealizationData]:
+    """Create vector realization data for derived vector on API format"""
+    derived_vector_table_pa, derived_vector_metadata, derived_vector_info = (
+        create_derived_vector_table_and_metadata_and_info(
+            derived_vector_name, source_vector_table_pa, source_vector_metadata
+        )
+    )
+    derived_realization_vector_list = create_derived_realization_vector_list(
+        derived_vector_table_pa, derived_vector_name, source_vector_metadata.is_rate, derived_vector_metadata.unit
+    )
+
+    return converters.derived_realization_vector_list_and_info_to_api_vector_realization_data_list(
+        derived_realization_vector_list, derived_vector_info
+    )
+
+
+def create_derived_statistics_vector_data(
+    derived_vector_name: str,
+    source_vector_table_pa: pa.Table,
+    source_vector_metadata: VectorMetadata | DeltaVectorMetadata,
+    statistics_to_compute: list[StatisticFunction] | None,
+) -> schemas.VectorStatisticData:
+    """Create vector statistics data for derived vector on API format"""
+    derived_vector_table_pa, derived_vector_metadata, derived_vector_info = (
+        create_derived_vector_table_and_metadata_and_info(
+            derived_vector_name, source_vector_table_pa, source_vector_metadata
+        )
+    )
+    derived_vector_statistics = compute_vector_statistics(
+        derived_vector_table_pa, derived_vector_name, statistics_to_compute
+    )
+
+    if not derived_vector_statistics:
+        raise HTTPException(status_code=404, detail="Could not compute statistics")
+
+    return converters.derived_vector_statistics_data_to_api_vector_statistic_data(
+        derived_vector_statistics, derived_vector_metadata, derived_vector_info
+    )
+
+
+def create_vector_descriptions_for_derived_vectors(
+    vector_names: list[str] | set[str],
+) -> list[schemas.VectorDescription]:
+    """
+    Create vector descriptions for derived vectors from list of vector names on API format
+    """
+    ret_arr: list[schemas.VectorDescription] = []
+    for vector_name in vector_names:
+        if not is_total_vector(vector_name):
+            continue
+
+        per_day_vector_name = create_per_day_vector_name(vector_name)
+        per_interval_vector_name = create_per_interval_vector_name(vector_name)
+        ret_arr.extend(
+            [
+                schemas.VectorDescription(
+                    name=per_day_vector_name,
+                    descriptiveName=per_day_vector_name,
+                    hasHistorical=False,
+                    derivedVectorInfo=schemas.DerivedVectorInfo(
+                        type=schemas.DerivedVectorType.PER_DAY, sourceVector=vector_name
+                    ),
+                ),
+                schemas.VectorDescription(
+                    name=per_interval_vector_name,
+                    descriptiveName=per_interval_vector_name,
+                    hasHistorical=False,
+                    derivedVectorInfo=schemas.DerivedVectorInfo(
+                        type=schemas.DerivedVectorType.PER_INTVL, sourceVector=vector_name
+                    ),
+                ),
+            ]
+        )
+    return ret_arr

--- a/backend_py/primary/primary/routers/timeseries/_sensitivity_case_utils.py
+++ b/backend_py/primary/primary/routers/timeseries/_sensitivity_case_utils.py
@@ -1,0 +1,40 @@
+import pyarrow as pa
+import pyarrow.compute as pc
+from fastapi import HTTPException
+
+from webviz_services.utils.statistic_function import StatisticFunction
+from webviz_services.summary_vector_statistics import compute_vector_statistics, VectorStatistics
+
+
+def compute_sensitivity_case_vector_statistics(
+    vector_table: pa.Table,
+    vector_name: str,
+    case_realizations: list[int],
+    requested_realizations: list[int] | None,
+    statistics_to_compute: list[StatisticFunction] | None,
+) -> VectorStatistics:
+    """Compute vector statistics for a single sensitivity case.
+
+    Raises HTTPException if the combination of realizations yields no data,
+    or if statistics could not be computed.
+    """
+    requested_mask = (
+        pc.is_in(vector_table["REAL"], value_set=pa.array(requested_realizations)) if requested_realizations else None
+    )
+    case_mask = pc.is_in(vector_table["REAL"], value_set=pa.array(case_realizations))
+    if requested_mask is not None:
+        case_mask = pc.and_(requested_mask, case_mask)
+
+    case_table = vector_table.filter(case_mask)
+
+    if case_table.num_rows == 0 and requested_mask is not None:
+        raise HTTPException(
+            status_code=404,
+            detail="The combination of realizations to include and sensitivity case realizations results in no valid realizations",
+        )
+
+    vector_statistics = compute_vector_statistics(case_table, vector_name, statistics_to_compute)
+    if not vector_statistics:
+        raise HTTPException(status_code=404, detail="Could not compute statistics")
+
+    return vector_statistics

--- a/backend_py/primary/primary/routers/timeseries/router.py
+++ b/backend_py/primary/primary/routers/timeseries/router.py
@@ -251,12 +251,7 @@ async def get_delta_ensemble_realizations_vector_data(
         service_freq,
         perf_metrics,
     )
-    realization_delta_vector_list = create_realization_delta_vector_list(
-        delta_vector_table_pa,
-        vector_name,
-        delta_vector_metadata.is_rate,
-        delta_vector_metadata.unit,
-    )
+    realization_delta_vector_list = create_realization_delta_vector_list(delta_vector_table_pa, delta_vector_metadata)
     perf_metrics.record_lap("create-realization-delta-vector-list")
 
     LOGGER.info(f"Loaded realization delta ensemble summary data in: {perf_metrics.to_string()}")

--- a/backend_py/primary/primary/routers/timeseries/router.py
+++ b/backend_py/primary/primary/routers/timeseries/router.py
@@ -2,8 +2,6 @@ import asyncio
 import logging
 from typing import Annotated
 
-import pyarrow as pa
-import pyarrow.compute as pc
 from fastapi import APIRouter, Depends, HTTPException, Query, Response
 
 from webviz_services.summary_vector_statistics import compute_vector_statistics
@@ -12,17 +10,9 @@ from webviz_services.sumo_access.parameter_access import ParameterAccess
 from webviz_services.sumo_access.summary_access import Frequency, SummaryAccess
 from webviz_services.utils.authenticated_user import AuthenticatedUser
 from webviz_services.summary_delta_vectors import (
-    DeltaVectorMetadata,
-    create_delta_vector_table,
     create_realization_delta_vector_list,
 )
 from webviz_services.summary_derived_vectors import (
-    create_derived_vector_table_for_type,
-    create_per_day_vector_name,
-    create_per_interval_vector_name,
-    create_derived_vector_unit,
-    create_derived_realization_vector_list,
-    get_derived_vector_type,
     get_total_vector_name,
     is_derived_vector,
     is_total_vector,
@@ -33,8 +23,7 @@ from primary.middleware.cache_control_middleware import cache_time, CacheTime
 from primary.utils.response_perf_metrics import ResponsePerfMetrics
 from primary.utils.query_string_utils import decode_uint_list_str
 
-
-from . import converters, schemas
+from . import _sensitivity_case_utils, converters, schemas, _derived_vector_utils, _delta_ensemble_utils
 
 
 LOGGER = logging.getLogger(__name__)
@@ -77,7 +66,7 @@ async def get_vector_list(
     # Create derived vectors if requested
     if include_derived_vectors:
         total_vectors = {vector for vector in vector_names if is_total_vector(vector)}
-        ret_arr.extend(_create_vector_descriptions_for_derived_vectors(total_vectors))
+        ret_arr.extend(_derived_vector_utils.create_vector_descriptions_for_derived_vectors(total_vectors))
 
     LOGGER.info(f"Got vector list in: {perf_metrics.to_string()}")
     return ret_arr
@@ -133,7 +122,7 @@ async def get_delta_ensemble_vector_list(
     # Create derived vectors if requested
     if include_derived_vectors:
         total_vectors = {vector for vector in vector_names if is_total_vector(vector)}
-        ret_arr.extend(_create_vector_descriptions_for_derived_vectors(total_vectors))
+        ret_arr.extend(_derived_vector_utils.create_vector_descriptions_for_derived_vectors(total_vectors))
 
     LOGGER.info(f"Got delta ensemble vector list in: {perf_metrics.to_string()}")
     return ret_arr
@@ -164,42 +153,27 @@ async def get_realizations_vector_data(
     access = SummaryAccess.from_ensemble_name(authenticated_user.get_sumo_access_token(), case_uuid, ensemble_name)
     sumo_freq = Frequency.from_string_value(resampling_frequency.value if resampling_frequency else "dummy")
 
-    is_vector_derived = is_derived_vector(vector_name)
-    vector_name_to_fetch = vector_name if not is_vector_derived else get_total_vector_name(vector_name)
-
-    ret_arr: list[schemas.VectorRealizationData] = []
-    if not is_vector_derived:
-        sumo_vec_arr = await access.get_vector_async(
-            vector_name=vector_name_to_fetch,
-            resampling_frequency=sumo_freq,
-            realizations=realizations,
-        )
-        perf_metrics.record_lap("get-vector")
-
-        ret_arr = converters.realization_vector_list_to_api_vector_realization_data_list(sumo_vec_arr)
-    else:
-        # Handle derived vectors
-        vector_table_pa, vector_metadata = await access.get_vector_table_async(
-            vector_name=vector_name_to_fetch,
-            resampling_frequency=sumo_freq,
+    if is_derived_vector(vector_name):
+        source_vector_name = get_total_vector_name(vector_name)
+        source_vector_table_pa, source_vector_metadata = await access.get_vector_table_async(
+            vector_name=source_vector_name,
+            resampling_frequency=resampling_frequency,
             realizations=realizations,
         )
 
-        derived_vector_type = get_derived_vector_type(vector_name)
-        derived_vector_unit = create_derived_vector_unit(vector_metadata.unit, derived_vector_type)
-        derived_vector_info = converters.to_api_derived_vector_info(derived_vector_type, vector_name_to_fetch)
-
-        derived_vector_table_pa = create_derived_vector_table_for_type(vector_table_pa, derived_vector_type)
-        derived_realization_vector_list = create_derived_realization_vector_list(
-            derived_vector_table_pa, vector_name, vector_metadata.is_rate, derived_vector_unit
+        return _derived_vector_utils.create_derived_vector_realization_data_list(
+            vector_name, source_vector_table_pa, source_vector_metadata
         )
 
-        ret_arr = converters.derived_vector_realizations_to_api_vector_realization_data_list(
-            derived_realization_vector_list, derived_vector_info
-        )
-
+    sumo_vec_arr = await access.get_vector_async(
+        vector_name=vector_name,
+        resampling_frequency=sumo_freq,
+        realizations=realizations,
+    )
+    perf_metrics.record_lap("get-vector")
     LOGGER.info(f"Loaded realization summary data in: {perf_metrics.to_string()}")
-    return ret_arr
+
+    return converters.realization_vector_list_to_api_vector_realization_data_list(sumo_vec_arr)
 
 
 @router.get("/delta_ensemble_realizations_vector_data/")
@@ -238,57 +212,55 @@ async def get_delta_ensemble_realizations_vector_data(
             status_code=400, detail="Resampling frequency must be specified to create delta ensemble vector"
         )
 
-    is_vector_derived = is_derived_vector(vector_name)
-    vector_name_to_fetch = vector_name if not is_vector_derived else get_total_vector_name(vector_name)
+    if is_derived_vector(vector_name):
+        source_vector_name = get_total_vector_name(vector_name)
+
+        # Create delta ensemble vector table and metadata for source vector:
+        (
+            source_delta_vector_table_pa,
+            source_delta_vector_metadata,
+        ) = await _delta_ensemble_utils.get_vector_tables_and_create_delta_vector_table_and_metadata_async(
+            authenticated_user,
+            comparison_case_uuid,
+            comparison_ensemble_name,
+            reference_case_uuid,
+            reference_ensemble_name,
+            source_vector_name,
+            realizations,
+            service_freq,
+            perf_metrics,
+        )
+
+        # Create derived vector realization data and convert to API format:
+        return _derived_vector_utils.create_derived_vector_realization_data_list(
+            vector_name, source_delta_vector_table_pa, source_delta_vector_metadata
+        )
 
     # Create delta ensemble table and metadata:
     (
         delta_vector_table_pa,
         delta_vector_metadata,
-    ) = await _get_vector_tables_and_create_delta_vector_table_and_metadata_async(
+    ) = await _delta_ensemble_utils.get_vector_tables_and_create_delta_vector_table_and_metadata_async(
         authenticated_user,
         comparison_case_uuid,
         comparison_ensemble_name,
         reference_case_uuid,
         reference_ensemble_name,
-        vector_name_to_fetch,
+        vector_name,
         realizations,
         service_freq,
         perf_metrics,
     )
-
-    # Create realization delta vectors
-    ret_arr: list[schemas.VectorRealizationData] = []
-    if not is_vector_derived:
-        realization_delta_vector_list = create_realization_delta_vector_list(
-            delta_vector_table_pa,
-            vector_name_to_fetch,
-            delta_vector_metadata.is_rate,
-            delta_vector_metadata.unit,
-        )
-        perf_metrics.record_lap("create-realization-delta-vector-list")
-
-        ret_arr = converters.realization_delta_vector_list_to_api_vector_realization_data_list(
-            realization_delta_vector_list
-        )
-    else:
-        derived_vector_type = get_derived_vector_type(vector_name)
-        derived_vector_unit = create_derived_vector_unit(delta_vector_metadata.unit, derived_vector_type)
-        derived_vector_info = converters.to_api_derived_vector_info(derived_vector_type, vector_name_to_fetch)
-
-        # Create derived vectors if requested
-        delta_derived_vector_table_pa = create_derived_vector_table_for_type(delta_vector_table_pa, derived_vector_type)
-        realization_delta_vector_list = create_realization_delta_vector_list(
-            delta_derived_vector_table_pa, vector_name, delta_vector_metadata.is_rate, derived_vector_unit
-        )
-        perf_metrics.record_lap("create-realization-delta-derived-vector-list")
-
-        ret_arr = converters.realization_delta_vector_list_to_api_vector_realization_data_list(
-            realization_delta_vector_list, derived_vector_info
-        )
+    realization_delta_vector_list = create_realization_delta_vector_list(
+        delta_vector_table_pa,
+        vector_name,
+        delta_vector_metadata.is_rate,
+        delta_vector_metadata.unit,
+    )
+    perf_metrics.record_lap("create-realization-delta-vector-list")
 
     LOGGER.info(f"Loaded realization delta ensemble summary data in: {perf_metrics.to_string()}")
-    return ret_arr
+    return converters.realization_delta_vector_list_to_api_vector_realization_data_list(realization_delta_vector_list)
 
 
 @router.get("/timestamps_list/")
@@ -366,50 +338,38 @@ async def get_statistical_vector_data(
     service_freq = Frequency.from_string_value(resampling_frequency.value)
     service_stat_funcs_to_compute = converters.to_service_statistic_functions(statistic_functions)
 
-    is_vector_derived = is_derived_vector(vector_name)
-    vector_name_to_fetch = vector_name if not is_vector_derived else get_total_vector_name(vector_name)
+    if is_derived_vector(vector_name):
+        source_vector_name = get_total_vector_name(vector_name)
+        source_vector_table_pa, source_vector_metadata = await access.get_vector_table_async(
+            vector_name=source_vector_name,
+            resampling_frequency=service_freq,
+            realizations=realizations,
+        )
+
+        return _derived_vector_utils.create_derived_statistics_vector_data(
+            vector_name, source_vector_table_pa, source_vector_metadata, service_stat_funcs_to_compute
+        )
 
     # Get vector table
-    vector_table, vector_metadata = await access.get_vector_table_async(
-        vector_name=vector_name_to_fetch,
+    vector_table_pa, vector_metadata = await access.get_vector_table_async(
+        vector_name=vector_name,
         resampling_frequency=service_freq,
         realizations=realizations,
     )
-    perf_metrics.record_lap("get-table")
 
-    # Calculate statistics
-    ret_data: schemas.VectorStatisticData | None = None
-    if not is_vector_derived:
-        statistics = compute_vector_statistics(vector_table, vector_name, service_stat_funcs_to_compute)
-        if not statistics:
-            raise HTTPException(status_code=404, detail="Could not compute statistics")
-
-        ret_data = converters.to_api_vector_statistic_data(statistics, vector_metadata.is_rate, vector_metadata.unit)
-    else:
-        derived_vector_type = get_derived_vector_type(vector_name)
-        derived_vector_unit = create_derived_vector_unit(vector_metadata.unit, derived_vector_type)
-        derived_vector_info = converters.to_api_derived_vector_info(derived_vector_type, vector_name_to_fetch)
-
-        derived_vector_table_pa = create_derived_vector_table_for_type(vector_table, derived_vector_type)
-        statistics = compute_vector_statistics(derived_vector_table_pa, vector_name, service_stat_funcs_to_compute)
-
-        if not statistics:
-            raise HTTPException(status_code=404, detail="Could not compute statistics")
-
-        ret_data = converters.to_api_vector_statistic_data(
-            statistics, vector_metadata.is_rate, derived_vector_unit, derived_vector_info
-        )
+    vector_statistics = compute_vector_statistics(vector_table_pa, vector_name, service_stat_funcs_to_compute)
+    if not vector_statistics:
+        raise HTTPException(status_code=404, detail="Could not compute statistics")
 
     perf_metrics.record_lap("calc-stat")
     LOGGER.info(f"Loaded and computed statistical summary data in: {perf_metrics.to_string()}")
 
-    return ret_data
+    return converters.to_api_vector_statistic_data(vector_statistics, vector_metadata.is_rate, vector_metadata.unit)
 
 
 @router.get("/delta_ensemble_statistical_vector_data/")
 @cache_time(CacheTime.LONG)
 # pylint: disable=too-many-arguments
-# pylint: disable-next=too-many-locals
 async def get_delta_ensemble_statistical_vector_data(
     # fmt:off
     response: Response,
@@ -446,57 +406,59 @@ async def get_delta_ensemble_statistical_vector_data(
             status_code=400, detail="Resampling frequency must be specified to create delta ensemble vector"
         )
 
-    is_vector_derived = is_derived_vector(vector_name)
-    vector_name_to_fetch = vector_name if not is_vector_derived else get_total_vector_name(vector_name)
+    if is_derived_vector(vector_name):
+        source_vector_name = get_total_vector_name(vector_name)
+
+        # Create delta ensemble table and metadata:
+        (
+            source_delta_vector_table_pa,
+            source_delta_vector_metadata,
+        ) = await _delta_ensemble_utils.get_vector_tables_and_create_delta_vector_table_and_metadata_async(
+            authenticated_user,
+            comparison_case_uuid,
+            comparison_ensemble_name,
+            reference_case_uuid,
+            reference_ensemble_name,
+            source_vector_name,
+            realizations,
+            service_freq,
+            perf_metrics,
+        )
+
+        return _derived_vector_utils.create_derived_statistics_vector_data(
+            vector_name,
+            source_delta_vector_table_pa,
+            source_delta_vector_metadata,
+            service_stat_funcs_to_compute,
+        )
 
     # Create delta ensemble table and metadata:
     (
-        delta_vector_table_pa,
-        delta_vector_metadata,
-    ) = await _get_vector_tables_and_create_delta_vector_table_and_metadata_async(
+        source_delta_vector_table_pa,
+        source_delta_vector_metadata,
+    ) = await _delta_ensemble_utils.get_vector_tables_and_create_delta_vector_table_and_metadata_async(
         authenticated_user,
         comparison_case_uuid,
         comparison_ensemble_name,
         reference_case_uuid,
         reference_ensemble_name,
-        vector_name_to_fetch,
+        vector_name,
         realizations,
         service_freq,
         perf_metrics,
     )
 
-    # Calculate statistics
-    ret_data: schemas.VectorStatisticData | None = None
-    if not is_vector_derived:
-        statistics = compute_vector_statistics(delta_vector_table_pa, vector_name, service_stat_funcs_to_compute)
+    statistics = compute_vector_statistics(source_delta_vector_table_pa, vector_name, service_stat_funcs_to_compute)
 
-        if not statistics:
-            raise HTTPException(status_code=404, detail="Could not compute statistics")
-
-        ret_data = converters.to_api_delta_ensemble_vector_statistic_data(
-            statistics, delta_vector_metadata.is_rate, delta_vector_metadata.unit
-        )
-    else:
-        derived_vector_type = get_derived_vector_type(vector_name)
-        derived_vector_unit = create_derived_vector_unit(delta_vector_metadata.unit, derived_vector_type)
-        derived_vector_info = converters.to_api_derived_vector_info(derived_vector_type, vector_name_to_fetch)
-
-        delta_derived_vector_table_pa = create_derived_vector_table_for_type(delta_vector_table_pa, derived_vector_type)
-        statistics = compute_vector_statistics(
-            delta_derived_vector_table_pa, vector_name, service_stat_funcs_to_compute
-        )
-
-        if not statistics:
-            raise HTTPException(status_code=404, detail="Could not compute statistics")
-
-        ret_data = converters.to_api_delta_ensemble_vector_statistic_data(
-            statistics, delta_vector_metadata.is_rate, derived_vector_unit, derived_vector_info
-        )
+    if not statistics:
+        raise HTTPException(status_code=404, detail="Could not compute statistics")
 
     perf_metrics.record_lap("calc-delta-vector-stat")
     LOGGER.info(f"Loaded and computed statistical delta ensemble summary data in: {perf_metrics.to_string()}")
 
-    return ret_data
+    return converters.to_api_vector_statistic_data(
+        statistics, source_delta_vector_metadata.is_rate, source_delta_vector_metadata.unit
+    )
 
 
 @router.get("/statistical_vector_data_per_sensitivity/")
@@ -536,39 +498,16 @@ async def get_statistical_vector_data_per_sensitivity(
     if not sensitivities:
         return ret_data
 
-    requested_realizations_mask = (
-        pc.is_in(vector_table["REAL"], value_set=pa.array(realizations)) if realizations else None
-    )
     for sensitivity in sensitivities:
         for case in sensitivity.cases:
-            sens_case_realization_mask = pc.is_in(vector_table["REAL"], value_set=pa.array(case.realizations))
-            if requested_realizations_mask is not None:
-                sens_case_realization_mask = pc.and_(requested_realizations_mask, sens_case_realization_mask)
-            table = vector_table.filter(sens_case_realization_mask)
-
-            if table.num_rows == 0 and requested_realizations_mask is not None:
-                raise HTTPException(
-                    status_code=404,
-                    detail="The combination of realizations to include and sensitivity case realizations results in no valid realizations",
+            vector_statistics = _sensitivity_case_utils.compute_sensitivity_case_vector_statistics(
+                vector_table, vector_name, case.realizations, realizations, service_stat_funcs_to_compute
+            )
+            ret_data.append(
+                converters.to_api_vector_statistic_sensitivity_data(
+                    vector_statistics, vector_metadata.is_rate, vector_metadata.unit, sensitivity.name, case.name
                 )
-
-            statistics = compute_vector_statistics(table, vector_name, service_stat_funcs_to_compute)
-            if not statistics:
-                raise HTTPException(status_code=404, detail="Could not compute statistics")
-
-            statistic_data: schemas.VectorStatisticData = converters.to_api_vector_statistic_data(
-                statistics, vector_metadata.is_rate, vector_metadata.unit, None
             )
-            sensitivity_statistic_data = schemas.VectorStatisticSensitivityData(
-                sensitivityName=sensitivity.name,
-                sensitivityCase=case.name,
-                realizations=statistic_data.realizations,
-                timestampsUtcMs=statistic_data.timestampsUtcMs,
-                valueObjects=statistic_data.valueObjects,
-                unit=statistic_data.unit,
-                isRate=statistic_data.isRate,
-            )
-            ret_data.append(sensitivity_statistic_data)
     return ret_data
 
 
@@ -589,106 +528,3 @@ async def get_realization_vector_at_timestamp(
         vector_name=vector_name, timestamp_utc_ms=timestamp_utc_ms, realizations=None
     )
     return ensemble_response
-
-
-def _create_vector_descriptions_for_derived_vectors(
-    vector_names: list[str] | set[str],
-) -> list[schemas.VectorDescription]:
-    """
-    Create vector descriptions for derived vectors from list of vector names
-    """
-    ret_arr: list[schemas.VectorDescription] = []
-    for vector_name in vector_names:
-        if not is_total_vector(vector_name):
-            continue
-
-        per_day_vector_name = create_per_day_vector_name(vector_name)
-        per_interval_vector_name = create_per_interval_vector_name(vector_name)
-        ret_arr.extend(
-            [
-                schemas.VectorDescription(
-                    name=per_day_vector_name,
-                    descriptiveName=per_day_vector_name,
-                    hasHistorical=False,
-                    derivedVectorInfo=schemas.DerivedVectorInfo(
-                        type=schemas.DerivedVectorType.PER_DAY, sourceVector=vector_name
-                    ),
-                ),
-                schemas.VectorDescription(
-                    name=per_interval_vector_name,
-                    descriptiveName=per_interval_vector_name,
-                    hasHistorical=False,
-                    derivedVectorInfo=schemas.DerivedVectorInfo(
-                        type=schemas.DerivedVectorType.PER_INTVL, sourceVector=vector_name
-                    ),
-                ),
-            ]
-        )
-    return ret_arr
-
-
-async def _get_vector_tables_and_create_delta_vector_table_and_metadata_async(
-    authenticated_user: AuthenticatedUser,
-    comparison_case_uuid: str,
-    comparison_ensemble_name: str,
-    reference_case_uuid: str,
-    reference_ensemble_name: str,
-    vector_name: str,
-    realizations: list[int] | None,
-    resampling_frequency: Frequency,
-    perf_metrics: ResponsePerfMetrics | None,
-) -> tuple[pa.Table, DeltaVectorMetadata]:
-    """
-    Get vector tables for comparison and reference ensembles and create delta ensemble vector table and metadata
-    """
-    # Separate summary access to comparison and reference ensemble
-    comparison_ensemble_access = SummaryAccess.from_ensemble_name(
-        authenticated_user.get_sumo_access_token(), comparison_case_uuid, comparison_ensemble_name
-    )
-    reference_ensemble_access = SummaryAccess.from_ensemble_name(
-        authenticated_user.get_sumo_access_token(), reference_case_uuid, reference_ensemble_name
-    )
-
-    # Get tables parallel
-    # - Resampled data is assumed to be such that dates/timestamps are comparable between ensembles and cases, i.e. timestamps
-    #   for a resampling of a daily vector in both ensembles should be the same
-    (comparison_vector_table_pa, comparison_metadata), (
-        reference_vector_table_pa,
-        reference_metadata,
-    ) = await asyncio.gather(
-        comparison_ensemble_access.get_vector_table_async(
-            vector_name=vector_name,
-            resampling_frequency=resampling_frequency,
-            realizations=realizations,
-        ),
-        reference_ensemble_access.get_vector_table_async(
-            vector_name=vector_name,
-            resampling_frequency=resampling_frequency,
-            realizations=realizations,
-        ),
-    )
-
-    if perf_metrics:
-        perf_metrics.record_lap("get-vector-tables-to-create-delta-vector-table")
-
-    # Check for mismatching metadata
-    if comparison_metadata.is_rate != reference_metadata.is_rate:
-        raise HTTPException(
-            status_code=400, detail="Rate mismatch between ensembles for delta ensemble statistical vector data"
-        )
-    if comparison_metadata.unit != reference_metadata.unit:
-        raise HTTPException(
-            status_code=400, detail="Unit mismatch between ensembles for delta ensemble statistical vector data"
-        )
-
-    delta_vector_metadata = DeltaVectorMetadata(unit=reference_metadata.unit, is_rate=reference_metadata.is_rate)
-
-    # Create delta ensemble table
-    delta_vector_table_pa = create_delta_vector_table(
-        comparison_vector_table_pa, reference_vector_table_pa, vector_name
-    )
-
-    if perf_metrics:
-        perf_metrics.record_lap("create-delta-vector-table")
-
-    return delta_vector_table_pa, delta_vector_metadata

--- a/backend_py/primary/tests/unit/services/test_summary_delta_vectors.py
+++ b/backend_py/primary/tests/unit/services/test_summary_delta_vectors.py
@@ -4,6 +4,7 @@ import pyarrow as pa
 from webviz_services.summary_delta_vectors import (
     create_delta_vector_table,
     create_realization_delta_vector_list,
+    DeltaVectorMetadata,
     RealizationDeltaVector,
 )
 
@@ -79,6 +80,7 @@ def test_create_delta_vector_table_with_different_reals() -> None:
 
 def test_create_realization_delta_vector_list() -> None:
     # Create sample data for delta_vector_table
+    delta_vector_metadata = DeltaVectorMetadata(name="vector", unit="unit", is_rate=True)
     delta_data = {"DATE": [1, 2, 3, 4], "REAL": [1, 1, 2, 2], "vector": [5.0, 10.0, 15.0, 20.0]}
     delta_vector_table = pa.table(delta_data, schema=VECTOR_TABLE_SCHEMA)
 
@@ -89,7 +91,7 @@ def test_create_realization_delta_vector_list() -> None:
     ]
 
     # Call the function
-    result = create_realization_delta_vector_list(delta_vector_table, "vector", is_rate=True, unit="unit")
+    result = create_realization_delta_vector_list(delta_vector_table, delta_vector_metadata)
 
     # Validate the result
     assert result == expected_result
@@ -97,6 +99,7 @@ def test_create_realization_delta_vector_list() -> None:
 
 def test_create_realization_delta_vector_list_with_single_real() -> None:
     # Create sample data for delta_vector_table
+    delta_vector_metadata = DeltaVectorMetadata(name="vector", unit="unit", is_rate=False)
     delta_data = {"DATE": [1, 2, 3, 4], "REAL": [1, 1, 1, 1], "vector": [5.0, 10.0, 15.0, 20.0]}
     delta_vector_table = pa.table(delta_data, schema=VECTOR_TABLE_SCHEMA)
 
@@ -108,7 +111,7 @@ def test_create_realization_delta_vector_list_with_single_real() -> None:
     ]
 
     # Call the function
-    result = create_realization_delta_vector_list(delta_vector_table, "vector", is_rate=False, unit="unit")
+    result = create_realization_delta_vector_list(delta_vector_table, delta_vector_metadata)
 
     # Validate the result
     assert result == expected_result
@@ -116,13 +119,14 @@ def test_create_realization_delta_vector_list_with_single_real() -> None:
 
 def test_create_realization_delta_vector_list_with_empty_table() -> None:
     # Create an empty delta_vector_table
+    delta_vector_metadata = DeltaVectorMetadata(name="vector", unit="unit", is_rate=True)
     delta_vector_table = pa.table({"DATE": [], "REAL": [], "vector": []}, schema=VECTOR_TABLE_SCHEMA)
 
     # Expected result
     expected_result: list[RealizationDeltaVector] = []
 
     # Call the function
-    result = create_realization_delta_vector_list(delta_vector_table, "vector", is_rate=True, unit="unit")
+    result = create_realization_delta_vector_list(delta_vector_table, delta_vector_metadata)
 
     # Validate the result
     assert result == expected_result

--- a/backend_py/primary/tests/unit/services/test_summary_derived_vectors.py
+++ b/backend_py/primary/tests/unit/services/test_summary_derived_vectors.py
@@ -8,6 +8,7 @@ from webviz_services.service_exceptions import InvalidDataError
 from webviz_services.summary_derived_vectors import (
     DerivedRealizationVector,
     DerivedVectorType,
+    DerivedVectorMetadata,
     create_derived_realization_vector_list,
     create_derived_vector_unit,
     create_per_day_vector_table_pa,
@@ -279,6 +280,12 @@ def test_create_per_day_vector_table_pa_invalid_column_type() -> None:
 
 
 def test_create_derived_realization_vector_list() -> None:
+    derived_vector_metadata = DerivedVectorMetadata(
+        name="DERIVED_VECTOR",
+        unit="unit",
+        is_rate=False,
+    )
+
     # Create a sample derived vector table
     derived_vector_table = pa.table(
         {
@@ -287,7 +294,9 @@ def test_create_derived_realization_vector_list() -> None:
                 type=pa.timestamp("ms"),
             ),
             "REAL": pa.array([1, 1, 1, 2, 2, 2, 4, 4, 4], type=pa.int16()),
-            "DERIVED_VECTOR": pa.array([10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0, 90.0], type=pa.float32()),
+            derived_vector_metadata.name: pa.array(
+                [10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0, 90.0], type=pa.float32()
+            ),
         }
     )
 
@@ -316,16 +325,20 @@ def test_create_derived_realization_vector_list() -> None:
         ),
     ]
 
-    is_rate = False
-
     # Call the function
-    result_list = create_derived_realization_vector_list(derived_vector_table, "DERIVED_VECTOR", is_rate, "unit")
+    result_list = create_derived_realization_vector_list(derived_vector_table, derived_vector_metadata)
 
     # Assert the result
     assert result_list == expected_list
 
 
 def test_create_derived_realization_vector_list_invalid_column_name() -> None:
+    derived_vector_metadata = DerivedVectorMetadata(
+        name="DERIVED_VECTOR",
+        unit="unit",
+        is_rate=False,
+    )
+
     # Create a sample derived vector table with invalid column name
     derived_vector_table = pa.table(
         {
@@ -334,32 +347,36 @@ def test_create_derived_realization_vector_list_invalid_column_name() -> None:
                 type=pa.timestamp("ms"),
             ),
             "REAL": pa.array([1, 1, 1, 2, 2, 2, 4, 4, 4], type=pa.int16()),
-            "DERIVED_VECTOR": pa.array([10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0, 90.0], type=pa.float32()),
+            derived_vector_metadata.name: pa.array(
+                [10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0, 90.0], type=pa.float32()
+            ),
         }
     )
 
-    is_rate = False
-
     # Call the function and expect an InvalidDataError
     with pytest.raises(InvalidDataError):
-        create_derived_realization_vector_list(derived_vector_table, "DERIVED_VECTOR", is_rate, "unit")
+        create_derived_realization_vector_list(derived_vector_table, derived_vector_metadata)
 
 
 def test_create_derived_realization_vector_list_invalid_column_type() -> None:
+    derived_vector_metadata = DerivedVectorMetadata(
+        name="DERIVED_VECTOR",
+        unit="unit",
+        is_rate=False,
+    )
+
     # Create a sample derived vector table with invalid column type
     derived_vector_table = pa.table(
         {
             "DATE": pa.array([1, 2, 3, 4], type=pa.int32()),
             "REAL": pa.array([1, 1, 1, 1], type=pa.int16()),
-            "DERIVED_VECTOR": pa.array([10.0, 20.0, 30.0, 40.0], type=pa.float32()),
+            derived_vector_metadata.name: pa.array([10.0, 20.0, 30.0, 40.0], type=pa.float32()),
         }
     )
 
-    is_rate = False
-
     # Call the function and expect an InvalidDataError
     with pytest.raises(InvalidDataError):
-        create_derived_realization_vector_list(derived_vector_table, "DERIVED_VECTOR", is_rate, "unit")
+        create_derived_realization_vector_list(derived_vector_table, derived_vector_metadata)
 
 
 def test_get_total_vector_name_per_day() -> None:


### PR DESCRIPTION
Refactor code for derived vectors, create of delta ensembles vector tables and sensitivity statistics calculation.

The refactoring was initiated by `pylint` error: `too-many-locals`.

Pylint was temporarily disabled in PR: https://github.com/equinor/webviz/pull/1476

----
### Summary

Refactor code in router for reduced code and enhanced readability.

- Add dataclasses and util-functions for derived vectors in service-layer (in summary_derived_vectors.py`)
- Extract code into utils for `router`-layer
   - _derived_vector_utils
   - _delta_ensemble_utils
   - _sensitivity_case_utils

---

Closes: #1491