### PR TITLE
Implement even more defensive way of logging the prescense of config variables

### DIFF
--- a/backend_py/primary/primary/utils/azure_service_credentials.py
+++ b/backend_py/primary/primary/utils/azure_service_credentials.py
@@ -64,9 +64,9 @@ def create_credential_for_azure_services(
     # we insert an explicitly created ClientSecretCredential first in a ChainedTokenCredential.
     if secret_vars_for_local_dev is not None:
         LOGGER.info("Creating local development credential for Azure services using ChainedTokenCredential")
-        LOGGER.info(f"ClientSecretVars.tenant_id present: {secret_vars_for_local_dev.tenant_id is not None}")
-        LOGGER.info(f"ClientSecretVars.client_id present: {secret_vars_for_local_dev.client_id is not None}")
-        LOGGER.info(f"ClientSecretVars.client_secret present: {secret_vars_for_local_dev.client_secret is not None}")
+        LOGGER.info(f"ClientSecretVars.tenant_id present: {bool(secret_vars_for_local_dev.tenant_id)}")
+        LOGGER.info(f"ClientSecretVars.client_id present: {bool(secret_vars_for_local_dev.client_id)}")
+        LOGGER.info(f"ClientSecretVars.client_secret present: {bool(secret_vars_for_local_dev.client_secret)}")
 
         client_secret_credential = ClientSecretCredential(
             tenant_id=secret_vars_for_local_dev.tenant_id,


### PR DESCRIPTION
Try and convince GitHub CodeQL security scanning that we're not logging any secrets.
It incorrectly flags the existing method as a security risk, but this should make it clearer that we're just logging the prescense of the variables.