### PR TITLE
Dependencies - bump node and npm minor versions. Reinstall package lock

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -82,7 +82,7 @@
             },
             "engines": {
                 "node": "^24.13.0",
-                "npm": "^11.6.2"
+                "npm": "^11.9.0"
             }
         },
         "node_modules/@babel/code-frame": {
@@ -115,7 +115,6 @@
             "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
             "devOptional": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.29.0",
                 "@babel/generator": "^7.29.0",
@@ -333,7 +332,6 @@
             "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
             "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.28.6",
                 "@babel/parser": "^7.28.6",
@@ -435,6 +433,7 @@
         "node_modules/@choojs/findup": {
             "version": "0.2.1",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "commander": "^2.15.1"
             },
@@ -563,7 +562,6 @@
             "resolved": "https://registry.npmjs.org/@deck.gl/core/-/core-9.1.15.tgz",
             "integrity": "sha512-2Tx2aKNskDS8SZ6EB7V53exo3SVntCJJGjrAnz3KhNj4fA4BVqOH++LSpjCFhuG9m4WOWDSDq9s7w4DQnTiT+Q==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@loaders.gl/core": "^4.2.0",
                 "@loaders.gl/images": "^4.2.0",
@@ -589,7 +587,6 @@
             "resolved": "https://registry.npmjs.org/@deck.gl/extensions/-/extensions-9.1.15.tgz",
             "integrity": "sha512-pH3SArgiEibHwrYwbKTknUurgpUndUFa+O97in+zRVF6KFGNZSLm1AePERh1gQjcpuQ+GwrxJ/ijmVmuH2zOow==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@luma.gl/constants": "~9.1.9",
                 "@luma.gl/shadertools": "~9.1.9",
@@ -606,7 +603,6 @@
             "resolved": "https://registry.npmjs.org/@deck.gl/geo-layers/-/geo-layers-9.1.15.tgz",
             "integrity": "sha512-dehvciiUyCnklCfY5v0JgGAgJfbQ0Rn/ml55Maqdw5c5K6fIQzi4xMglu1NdgO3L+MOutWWA1eFD9WLT2X0mkA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@loaders.gl/3d-tiles": "^4.2.0",
                 "@loaders.gl/gis": "^4.2.0",
@@ -652,7 +648,6 @@
             "resolved": "https://registry.npmjs.org/@deck.gl/layers/-/layers-9.1.15.tgz",
             "integrity": "sha512-4C8LaCXnd/cHGMGwuLu6YUqcf/4dyz82Im+C0IrY56OgJnVOKf2f75zwAKa1Uekq4XEsyPgqg9k5MWEohBzGYw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@loaders.gl/images": "^4.2.0",
                 "@loaders.gl/schema": "^4.2.0",
@@ -675,7 +670,6 @@
             "resolved": "https://registry.npmjs.org/@deck.gl/mesh-layers/-/mesh-layers-9.1.15.tgz",
             "integrity": "sha512-/GuXxa2Y5Bv/6DSOA6sgPalCZAPN137cTE5SDbOH88yKAY0ggn5FmgcimhGNRcR28tGy+yOCy/PbtIDoba6dpw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@loaders.gl/gltf": "^4.2.0",
                 "@luma.gl/gltf": "~9.1.9",
@@ -768,6 +762,7 @@
         "node_modules/@emotion/babel-plugin": {
             "version": "11.12.0",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/helper-module-imports": "^7.16.7",
                 "@babel/runtime": "^7.18.3",
@@ -784,11 +779,13 @@
         },
         "node_modules/@emotion/babel-plugin/node_modules/@emotion/memoize": {
             "version": "0.9.0",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@emotion/cache": {
             "version": "11.11.0",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@emotion/memoize": "^0.8.1",
                 "@emotion/sheet": "^1.2.2",
@@ -799,12 +796,12 @@
         },
         "node_modules/@emotion/hash": {
             "version": "0.9.2",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@emotion/is-prop-valid": {
             "version": "1.2.2",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@emotion/memoize": "^0.8.1"
             }
@@ -839,6 +836,7 @@
         "node_modules/@emotion/serialize": {
             "version": "1.3.2",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@emotion/hash": "^0.9.2",
                 "@emotion/memoize": "^0.9.0",
@@ -849,19 +847,23 @@
         },
         "node_modules/@emotion/serialize/node_modules/@emotion/memoize": {
             "version": "0.9.0",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@emotion/serialize/node_modules/@emotion/unitless": {
             "version": "0.10.0",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@emotion/sheet": {
             "version": "1.2.2",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@emotion/styled": {
             "version": "11.13.0",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.18.3",
                 "@emotion/babel-plugin": "^11.12.0",
@@ -883,32 +885,38 @@
         "node_modules/@emotion/styled/node_modules/@emotion/is-prop-valid": {
             "version": "1.3.1",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@emotion/memoize": "^0.9.0"
             }
         },
         "node_modules/@emotion/styled/node_modules/@emotion/memoize": {
             "version": "0.9.0",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@emotion/unitless": {
             "version": "0.8.1",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
             "version": "1.1.0",
             "license": "MIT",
+            "peer": true,
             "peerDependencies": {
                 "react": ">=16.8.0"
             }
         },
         "node_modules/@emotion/utils": {
             "version": "1.4.1",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@emotion/weak-memoize": {
             "version": "0.3.1",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@equinor/eds-core-react": {
             "version": "0.48.0",
@@ -1762,7 +1770,6 @@
             "version": "4.3.3",
             "resolved": "https://registry.npmjs.org/@loaders.gl/core/-/core-4.3.3.tgz",
             "integrity": "sha512-RaQ3uNg4ZaVqDRgvJ2CjaOjeeHdKvbKuzFFgbGnflVB9is5bu+h3EKc3Jke7NGVvLBsZ6oIXzkwHijVsMfxv8g==",
-            "peer": true,
             "dependencies": {
                 "@loaders.gl/loader-utils": "4.3.3",
                 "@loaders.gl/schema": "4.3.3",
@@ -1981,6 +1988,7 @@
             "resolved": "https://registry.npmjs.org/@loaders.gl/i3s/-/i3s-4.3.4.tgz",
             "integrity": "sha512-U71BwsLZ6wqDUxBWPWwdsAhZEwYjEluixmEPdif40KD318YoPEU7CU+w/gEE6JhlTijDhmEgsFCpRC+yvs15qw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@loaders.gl/compression": "4.3.4",
                 "@loaders.gl/crypto": "4.3.4",
@@ -2005,6 +2013,7 @@
             "resolved": "https://registry.npmjs.org/@loaders.gl/loader-utils/-/loader-utils-4.3.4.tgz",
             "integrity": "sha512-tjMZvlKQSaMl2qmYTAxg+ySR6zd6hQn5n3XaU8+Ehp90TD3WzxvDKOMNDqOa72fFmIV+KgPhcmIJTpq4lAdC4Q==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@loaders.gl/schema": "4.3.4",
                 "@loaders.gl/worker-utils": "4.3.4",
@@ -2020,6 +2029,7 @@
             "resolved": "https://registry.npmjs.org/@loaders.gl/schema/-/schema-4.3.4.tgz",
             "integrity": "sha512-1YTYoatgzr/6JTxqBLwDiD3AVGwQZheYiQwAimWdRBVB0JAzych7s1yBuE0CVEzj4JDPKOzVAz8KnU1TiBvJGw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/geojson": "^7946.0.7"
             },
@@ -2032,6 +2042,7 @@
             "resolved": "https://registry.npmjs.org/@loaders.gl/worker-utils/-/worker-utils-4.3.4.tgz",
             "integrity": "sha512-EbsszrASgT85GH3B7jkx7YXfQyIYo/rlobwMx6V3ewETapPUwdSAInv+89flnk5n2eu2Lpdeh+2zS6PvqbL2RA==",
             "license": "MIT",
+            "peer": true,
             "peerDependencies": {
                 "@loaders.gl/core": "^4.3.0"
             }
@@ -2594,14 +2605,12 @@
         "node_modules/@luma.gl/constants": {
             "version": "9.1.9",
             "resolved": "https://registry.npmjs.org/@luma.gl/constants/-/constants-9.1.9.tgz",
-            "integrity": "sha512-yc9fml04OeTTcwK+7gmDMxoLQ67j4ZiAFXjmYvPomYyBVzS0NZxTDuwcCBmnxjLOiroOZW8FRRrVc/yOiFug2w==",
-            "peer": true
+            "integrity": "sha512-yc9fml04OeTTcwK+7gmDMxoLQ67j4ZiAFXjmYvPomYyBVzS0NZxTDuwcCBmnxjLOiroOZW8FRRrVc/yOiFug2w=="
         },
         "node_modules/@luma.gl/core": {
             "version": "9.1.9",
             "resolved": "https://registry.npmjs.org/@luma.gl/core/-/core-9.1.9.tgz",
             "integrity": "sha512-1i9N7+I/UbFjx3axSMlc3/NufA+C2iBv/7mw51gRE/ypQPgvFmY/QqXBVZRe+nthF+OhlUMhO19TBndzYFTWhA==",
-            "peer": true,
             "dependencies": {
                 "@math.gl/types": "^4.1.0",
                 "@probe.gl/env": "^4.0.8",
@@ -2614,7 +2623,6 @@
             "version": "9.1.9",
             "resolved": "https://registry.npmjs.org/@luma.gl/engine/-/engine-9.1.9.tgz",
             "integrity": "sha512-n1GLK1sUMFkWxdb+aZYn6ZBFltFEMi7X+6ZPxn2pBsNT6oeF4AyvH5AyqhOpvHvUnCLDt3Zsf1UIfx3MI//YSw==",
-            "peer": true,
             "dependencies": {
                 "@math.gl/core": "^4.1.0",
                 "@math.gl/types": "^4.1.0",
@@ -2646,7 +2654,6 @@
             "version": "9.1.9",
             "resolved": "https://registry.npmjs.org/@luma.gl/shadertools/-/shadertools-9.1.9.tgz",
             "integrity": "sha512-Uqp2xfgIEunRMLXTeCJ4uEMlWcUGcYMZGJ8GAOrAeDzn4bMKVRKmZDC71vkuTctnaodM3UdrI9W6s1sJlrXsxw==",
-            "peer": true,
             "dependencies": {
                 "@math.gl/core": "^4.1.0",
                 "@math.gl/types": "^4.1.0",
@@ -2673,6 +2680,7 @@
             "version": "0.5.2",
             "resolved": "https://registry.npmjs.org/@mapbox/geojson-rewind/-/geojson-rewind-0.5.2.tgz",
             "integrity": "sha512-tJaT+RbYGJYStt7wI3cq4Nl4SXxG8W7JDG5DMJu97V25RnbNg3QtQtf+KD+VLjNpWKYsRvXDNmNrBgEETr1ifA==",
+            "peer": true,
             "dependencies": {
                 "get-stream": "^6.0.1",
                 "minimist": "^1.2.6"
@@ -2684,12 +2692,14 @@
         "node_modules/@mapbox/geojson-types": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@mapbox/geojson-types/-/geojson-types-1.0.2.tgz",
-            "integrity": "sha512-e9EBqHHv3EORHrSfbR9DqecPNn+AmuAoQxV6aL8Xu30bJMJR1o8PZLZzpk1Wq7/NfCbuhmakHTPYRhoqLsXRnw=="
+            "integrity": "sha512-e9EBqHHv3EORHrSfbR9DqecPNn+AmuAoQxV6aL8Xu30bJMJR1o8PZLZzpk1Wq7/NfCbuhmakHTPYRhoqLsXRnw==",
+            "peer": true
         },
         "node_modules/@mapbox/jsonlint-lines-primitives": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
             "integrity": "sha512-rY0o9A5ECsTQRVhv7tL/OyDpGAoUB4tTvLiW1DSzQGq4bvTPhNw1VpSNjDJc5GFZ2XuyOtSWSVN05qOtcD71qQ==",
+            "peer": true,
             "engines": {
                 "node": ">= 0.6"
             }
@@ -2698,6 +2708,7 @@
             "version": "1.5.0",
             "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-1.5.0.tgz",
             "integrity": "sha512-/PT1P6DNf7vjEEiPkVIRJkvibbqWtqnyGaBz3nfRdcxclNSnSdaLU5tfAgcD7I8Yt5i+L19s406YLl1koLnLbg==",
+            "peer": true,
             "peerDependencies": {
                 "mapbox-gl": ">=0.32.1 <2.0.0"
             }
@@ -2719,7 +2730,8 @@
         "node_modules/@mapbox/unitbezier": {
             "version": "0.0.0",
             "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.0.tgz",
-            "integrity": "sha512-HPnRdYO0WjFjRTSwO3frz1wKaU649OBFPX3Zo/2WZvuRi6zMiRGui8SnPQiQABgqCf8YikDe5t3HViTVw1WUzA=="
+            "integrity": "sha512-HPnRdYO0WjFjRTSwO3frz1wKaU649OBFPX3Zo/2WZvuRi6zMiRGui8SnPQiQABgqCf8YikDe5t3HViTVw1WUzA==",
+            "peer": true
         },
         "node_modules/@mapbox/vector-tile": {
             "version": "1.3.1",
@@ -2732,6 +2744,7 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/@mapbox/whoots-js/-/whoots-js-3.1.0.tgz",
             "integrity": "sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==",
+            "peer": true,
             "engines": {
                 "node": ">=6.0.0"
             }
@@ -2740,6 +2753,7 @@
             "version": "20.4.0",
             "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-20.4.0.tgz",
             "integrity": "sha512-AzBy3095fTFPjDjmWpR2w6HVRAZJ6hQZUCwk5Plz6EyfnfuQW1odeW5i2Ai47Y6TBA2hQnC+azscjBSALpaWgw==",
+            "peer": true,
             "dependencies": {
                 "@mapbox/jsonlint-lines-primitives": "~2.0.2",
                 "@mapbox/unitbezier": "^0.0.1",
@@ -2758,17 +2772,18 @@
         "node_modules/@maplibre/maplibre-gl-style-spec/node_modules/@mapbox/unitbezier": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.1.tgz",
-            "integrity": "sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw=="
+            "integrity": "sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==",
+            "peer": true
         },
         "node_modules/@maplibre/maplibre-gl-style-spec/node_modules/tinyqueue": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-3.0.0.tgz",
-            "integrity": "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g=="
+            "integrity": "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==",
+            "peer": true
         },
         "node_modules/@math.gl/core": {
             "version": "4.1.0",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@math.gl/types": "4.1.0"
             }
@@ -2852,6 +2867,7 @@
         "node_modules/@mui/core-downloads-tracker": {
             "version": "5.14.7",
             "license": "MIT",
+            "peer": true,
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/mui"
@@ -2862,7 +2878,6 @@
             "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.18.0.tgz",
             "integrity": "sha512-1s0vEZj5XFXDMmz3Arl/R7IncFqJ+WQ95LDp1roHWGDE2oCO3IS4/hmiOv1/8SD9r6B7tv9GLiqVZYHo+6PkTg==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.23.9"
             },
@@ -2931,6 +2946,7 @@
         "node_modules/@mui/private-theming": {
             "version": "5.14.7",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.22.10",
                 "@mui/utils": "^5.14.7",
@@ -2956,6 +2972,7 @@
         "node_modules/@mui/styled-engine": {
             "version": "5.14.7",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.22.10",
                 "@emotion/cache": "^11.11.0",
@@ -3468,7 +3485,6 @@
             "resolved": "https://registry.npmjs.org/@pixi/assets/-/assets-7.4.3.tgz",
             "integrity": "sha512-StvjiJBSp/j9hHkGu8AFHNvwYUazXq64WhyhytztyDMRkg/l/cL7EcttY5T0qZNWlIpccdr60LUKrWDOuMpkiw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/css-font-loading-module": "^0.0.12"
             },
@@ -3512,7 +3528,6 @@
             "resolved": "https://registry.npmjs.org/@pixi/core/-/core-7.4.3.tgz",
             "integrity": "sha512-5YDs11faWgVVTL8VZtLU05/Fl47vaP5Tnsbf+y/WRR0VSW3KhRRGTBU1J3Gdc2xEWbJhUK07KGP7eSZpvtPVgA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@pixi/color": "7.4.3",
                 "@pixi/constants": "7.4.3",
@@ -3533,7 +3548,6 @@
             "resolved": "https://registry.npmjs.org/@pixi/display/-/display-7.4.3.tgz",
             "integrity": "sha512-b5m2dAaoNAVdxz1oDaxl3XZ059NEOcNtGkxTOZ4EYCw/jcp9sZXkgSROHRzsGn4k+NugH7+9MP4Id2Z0kkdUhw==",
             "license": "MIT",
-            "peer": true,
             "peerDependencies": {
                 "@pixi/core": "7.4.3"
             }
@@ -3543,7 +3557,6 @@
             "resolved": "https://registry.npmjs.org/@pixi/events/-/events-7.4.3.tgz",
             "integrity": "sha512-o3j/5Dxq6WDVS6eHfURB/cf/MP+NcsF/eC5PnbSHjXxJmDE7PoTVwLvxexm5uuvNRpFh/6/Fn0V8Vl4gV8sc8w==",
             "license": "MIT",
-            "peer": true,
             "peerDependencies": {
                 "@pixi/core": "7.4.3",
                 "@pixi/display": "7.4.3"
@@ -3623,7 +3636,6 @@
             "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-7.4.3.tgz",
             "integrity": "sha512-wWLivD8/URb8A7X4TqCZGG39C91IE+aOuWY/z9NCz5Z6WvA/VWnsc5fLTlO+ggjGHgKF0cSucCXZfUe1wm0AOQ==",
             "license": "MIT",
-            "peer": true,
             "peerDependencies": {
                 "@pixi/core": "7.4.3",
                 "@pixi/display": "7.4.3",
@@ -3641,7 +3653,6 @@
             "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-7.4.3.tgz",
             "integrity": "sha512-CikqFPtKvU3Zj986/MSoC8X39CWv5CEpiEW/tYp47p4tgQNDSkNWYnDiNYgb+4VX6pNsBrgX4DALLdTR17SlSA==",
             "license": "MIT",
-            "peer": true,
             "peerDependencies": {
                 "@pixi/core": "7.4.3",
                 "@pixi/display": "7.4.3"
@@ -3732,7 +3743,6 @@
             "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-7.4.3.tgz",
             "integrity": "sha512-iNBrpOFF9nXDT6m2jcyYy6l/sRzklLDDck1eFHprHZwvNquY2nzRfh+RGBCecxhBcijiLJ3fsZN33fP0LDXkvw==",
             "license": "MIT",
-            "peer": true,
             "peerDependencies": {
                 "@pixi/core": "7.4.3",
                 "@pixi/display": "7.4.3"
@@ -3774,7 +3784,6 @@
             "resolved": "https://registry.npmjs.org/@pixi/text/-/text-7.4.3.tgz",
             "integrity": "sha512-IAF0iu04rPg3oiL0HZsEZI44fpJxq3UZ4xTmx8l1RyhhSXiElLvvSlSH57vt/BKMQZtCs+AqEit7yn8heK2+nQ==",
             "license": "MIT",
-            "peer": true,
             "peerDependencies": {
                 "@pixi/core": "7.4.3",
                 "@pixi/sprite": "7.4.3"
@@ -3920,11 +3929,13 @@
         "node_modules/@plotly/d3": {
             "version": "3.8.2",
             "resolved": "https://registry.npmjs.org/@plotly/d3/-/d3-3.8.2.tgz",
-            "integrity": "sha512-wvsNmh1GYjyJfyEBPKJLTMzgf2c2bEbSIL50lmqVUi+o1NHaLPi1Lb4v7VxXXJn043BhNyrxUrWI85Q+zmjOVA=="
+            "integrity": "sha512-wvsNmh1GYjyJfyEBPKJLTMzgf2c2bEbSIL50lmqVUi+o1NHaLPi1Lb4v7VxXXJn043BhNyrxUrWI85Q+zmjOVA==",
+            "peer": true
         },
         "node_modules/@plotly/d3-sankey": {
             "version": "0.7.2",
             "license": "BSD-3-Clause",
+            "peer": true,
             "dependencies": {
                 "d3-array": "1",
                 "d3-collection": "1",
@@ -3934,6 +3945,7 @@
         "node_modules/@plotly/d3-sankey-circular": {
             "version": "0.33.1",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "d3-array": "^1.2.1",
                 "d3-collection": "^1.0.4",
@@ -3943,30 +3955,36 @@
         },
         "node_modules/@plotly/d3-sankey-circular/node_modules/d3-array": {
             "version": "1.2.4",
-            "license": "BSD-3-Clause"
+            "license": "BSD-3-Clause",
+            "peer": true
         },
         "node_modules/@plotly/d3-sankey-circular/node_modules/d3-path": {
             "version": "1.0.9",
-            "license": "BSD-3-Clause"
+            "license": "BSD-3-Clause",
+            "peer": true
         },
         "node_modules/@plotly/d3-sankey-circular/node_modules/d3-shape": {
             "version": "1.3.7",
             "license": "BSD-3-Clause",
+            "peer": true,
             "dependencies": {
                 "d3-path": "1"
             }
         },
         "node_modules/@plotly/d3-sankey/node_modules/d3-array": {
             "version": "1.2.4",
-            "license": "BSD-3-Clause"
+            "license": "BSD-3-Clause",
+            "peer": true
         },
         "node_modules/@plotly/d3-sankey/node_modules/d3-path": {
             "version": "1.0.9",
-            "license": "BSD-3-Clause"
+            "license": "BSD-3-Clause",
+            "peer": true
         },
         "node_modules/@plotly/d3-sankey/node_modules/d3-shape": {
             "version": "1.3.7",
             "license": "BSD-3-Clause",
+            "peer": true,
             "dependencies": {
                 "d3-path": "1"
             }
@@ -3975,6 +3993,7 @@
             "version": "1.13.4",
             "resolved": "https://registry.npmjs.org/@plotly/mapbox-gl/-/mapbox-gl-1.13.4.tgz",
             "integrity": "sha512-sR3/Pe5LqT/fhYgp4rT4aSFf1rTsxMbGiH6Hojc7PH36ny5Bn17iVFUjpzycafETURuFbLZUfjODO8LvSI+5zQ==",
+            "peer": true,
             "dependencies": {
                 "@mapbox/geojson-rewind": "^0.5.2",
                 "@mapbox/geojson-types": "^1.0.2",
@@ -4006,11 +4025,13 @@
         "node_modules/@plotly/mapbox-gl/node_modules/@mapbox/tiny-sdf": {
             "version": "1.2.5",
             "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-1.2.5.tgz",
-            "integrity": "sha512-cD8A/zJlm6fdJOk6DqPUV8mcpyJkRz2x2R+/fYcWDYG3oWbG7/L7Yl/WqQ1VZCjnL9OTIMAn6c+BC5Eru4sQEw=="
+            "integrity": "sha512-cD8A/zJlm6fdJOk6DqPUV8mcpyJkRz2x2R+/fYcWDYG3oWbG7/L7Yl/WqQ1VZCjnL9OTIMAn6c+BC5Eru4sQEw==",
+            "peer": true
         },
         "node_modules/@plotly/point-cluster": {
             "version": "3.1.9",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "array-bounds": "^1.0.1",
                 "binary-search-bounds": "^2.0.4",
@@ -4028,7 +4049,8 @@
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/@plotly/regl/-/regl-2.1.2.tgz",
             "integrity": "sha512-Mdk+vUACbQvjd0m/1JJjOOafmkp/EpmHjISsopEz5Av44CBq7rPC05HHNbYGKVyNUF2zmEoBS/TT0pd0SPFFyw==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@popperjs/core": {
             "version": "2.11.8",
@@ -6319,7 +6341,6 @@
             "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.20.tgz",
             "integrity": "sha512-OMD2HLpNouXEfZJWcKeVKUgQ5n+n3A2JFmBaScpNDUqSrQSjiveC7dKMe53uJUg1nDG16ttFPz2xfilz6i2uVg==",
             "license": "MIT",
-            "peer": true,
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/tannerlinsley"
@@ -6340,7 +6361,6 @@
             "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.21.tgz",
             "integrity": "sha512-0Lu6y5t+tvlTJMTO7oh5NSpJfpg/5D41LlThfepTixPYkJ0sE2Jj0m0f6yYqujBwIXlId87e234+MxG3D3g7kg==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@tanstack/query-core": "5.90.20"
             },
@@ -7110,6 +7130,7 @@
             "version": "3.2.5",
             "resolved": "https://registry.npmjs.org/@types/geojson-vt/-/geojson-vt-3.2.5.tgz",
             "integrity": "sha512-qDO7wqtprzlpe8FfQ//ClPV9xiuoh2nkIgiouIptON9w5jvD/fA4szvP9GBlDVdJ5dldAl0kX/sy3URbWwLx0g==",
+            "peer": true,
             "dependencies": {
                 "@types/geojson": "*"
             }
@@ -7141,12 +7162,14 @@
         "node_modules/@types/mapbox__point-geometry": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/@types/mapbox__point-geometry/-/mapbox__point-geometry-0.1.4.tgz",
-            "integrity": "sha512-mUWlSxAmYLfwnRBmgYV86tgYmMIICX4kza8YnE/eIlywGe2XoOxlpVnXWwir92xRLjwyarqwpu2EJKD2pk0IUA=="
+            "integrity": "sha512-mUWlSxAmYLfwnRBmgYV86tgYmMIICX4kza8YnE/eIlywGe2XoOxlpVnXWwir92xRLjwyarqwpu2EJKD2pk0IUA==",
+            "peer": true
         },
         "node_modules/@types/mapbox__vector-tile": {
             "version": "1.3.4",
             "resolved": "https://registry.npmjs.org/@types/mapbox__vector-tile/-/mapbox__vector-tile-1.3.4.tgz",
             "integrity": "sha512-bpd8dRn9pr6xKvuEBQup8pwQfD4VUyqO/2deGjfpe6AwC8YRlyEipvefyRJUSiCJTZuCb8Pl1ciVV5ekqJ96Bg==",
+            "peer": true,
             "dependencies": {
                 "@types/geojson": "*",
                 "@types/mapbox__point-geometry": "*",
@@ -7174,12 +7197,14 @@
         },
         "node_modules/@types/parse-json": {
             "version": "4.0.0",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@types/pbf": {
             "version": "3.0.5",
             "resolved": "https://registry.npmjs.org/@types/pbf/-/pbf-3.0.5.tgz",
-            "integrity": "sha512-j3pOPiEcWZ34R6a6mN07mUkM4o4Lwf6hPNt8eilOeZhTFbxFXmKhvXl9Y28jotFPaI1bpPDJsbCprUoNke6OrA=="
+            "integrity": "sha512-j3pOPiEcWZ34R6a6mN07mUkM4o4Lwf6hPNt8eilOeZhTFbxFXmKhvXl9Y28jotFPaI1bpPDJsbCprUoNke6OrA==",
+            "peer": true
         },
         "node_modules/@types/plotly.js": {
             "version": "2.12.25",
@@ -7202,7 +7227,6 @@
             "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
             "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/prop-types": "*",
                 "csstype": "^3.2.2"
@@ -7239,6 +7263,7 @@
         "node_modules/@types/react-transition-group": {
             "version": "4.4.6",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/react": "*"
             }
@@ -7251,12 +7276,14 @@
         },
         "node_modules/@types/stylis": {
             "version": "4.2.5",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@types/supercluster": {
             "version": "7.1.3",
             "resolved": "https://registry.npmjs.org/@types/supercluster/-/supercluster-7.1.3.tgz",
             "integrity": "sha512-Z0pOY34GDFl3Q6hUFYf3HkTwKEE02e7QgtJppBt+beEAxnyOpJua+voGFvxINBHa06GwLFFym7gRPY2SiKIfIA==",
+            "peer": true,
             "dependencies": {
                 "@types/geojson": "*"
             }
@@ -7313,7 +7340,6 @@
             "integrity": "sha512-4z2nCSBfVIMnbuu8uinj+f0o4qOeggYJLbjpPHka3KH1om7e+H9yLKTYgksTaHcGco+NClhhY2vyO3HsMH1RGw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.55.0",
                 "@typescript-eslint/types": "8.55.0",
@@ -8206,13 +8232,15 @@
             "resolved": "https://registry.npmjs.org/a5-js/-/a5-js-0.1.4.tgz",
             "integrity": "sha512-lpuXcoBHL4Sa5sKu+dbBaH/8L3TYIHpVBSWqBdwDVMKYNipaVpW6sZBv0x9Yu9y38iS72jWyoKLFiKynUpwvBw==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "gl-matrix": "^3.4.3"
             }
         },
         "node_modules/abs-svg-path": {
             "version": "0.1.1",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/acorn": {
             "version": "8.15.0",
@@ -8220,7 +8248,6 @@
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -8285,7 +8312,8 @@
         },
         "node_modules/almost-equal": {
             "version": "1.1.0",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/animate.css": {
             "version": "4.1.1",
@@ -8324,7 +8352,8 @@
         },
         "node_modules/array-bounds": {
             "version": "1.0.1",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/array-buffer-byte-length": {
             "version": "1.0.2",
@@ -8346,6 +8375,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
             "integrity": "sha512-M1HQyIXcBGtVywBt8WVdim+lrNaK7VHp99Qt5pSNziXznKHViIBbXWtfRTpEFpF/c4FdfxNAsCCwPp5phBYJtw==",
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -8376,17 +8406,20 @@
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/array-normalize/-/array-normalize-1.1.4.tgz",
             "integrity": "sha512-fCp0wKFLjvSPmCn4F5Tiw4M3lpMZoHlCjfcs7nNzuj3vqQQ1/a8cgB9DXcpDSn18c+coLnaW7rqfcYCvKbyJXg==",
+            "peer": true,
             "dependencies": {
                 "array-bounds": "^1.0.0"
             }
         },
         "node_modules/array-range": {
             "version": "1.0.1",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/array-rearrange": {
             "version": "2.2.2",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/array.prototype.findlast": {
             "version": "1.2.5",
@@ -8566,6 +8599,7 @@
         "node_modules/babel-plugin-macros": {
             "version": "3.1.0",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.12.5",
                 "cosmiconfig": "^7.0.0",
@@ -8585,6 +8619,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
             "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+            "peer": true,
             "engines": {
                 "node": ">= 0.6.0"
             }
@@ -8620,7 +8655,8 @@
         },
         "node_modules/binary-search-bounds": {
             "version": "2.0.5",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/bit-twiddle": {
             "version": "1.0.2",
@@ -8629,11 +8665,13 @@
         },
         "node_modules/bitmap-sdf": {
             "version": "1.0.4",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/bl": {
             "version": "2.2.1",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "readable-stream": "^2.3.5",
                 "safe-buffer": "^5.1.1"
@@ -8692,7 +8730,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.9.0",
                 "caniuse-lite": "^1.0.30001759",
@@ -8742,7 +8779,8 @@
         },
         "node_modules/buffer-from": {
             "version": "1.1.2",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/bundle-name": {
             "version": "4.1.0",
@@ -8874,6 +8912,7 @@
         "node_modules/camelize": {
             "version": "1.0.1",
             "license": "MIT",
+            "peer": true,
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
@@ -8902,6 +8941,7 @@
         "node_modules/canvas-fit": {
             "version": "1.5.0",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "element-size": "^1.1.1"
             }
@@ -8992,7 +9032,8 @@
         },
         "node_modules/clamp": {
             "version": "1.0.1",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/classnames": {
             "version": "2.5.1",
@@ -9009,6 +9050,7 @@
         "node_modules/color-alpha": {
             "version": "1.0.4",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "color-parse": "^1.3.8"
             }
@@ -9029,6 +9071,7 @@
         "node_modules/color-id": {
             "version": "1.1.0",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "clamp": "^1.0.1"
             }
@@ -9042,6 +9085,7 @@
         "node_modules/color-normalize": {
             "version": "1.5.0",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "clamp": "^1.0.1",
                 "color-rgba": "^2.1.1",
@@ -9051,6 +9095,7 @@
         "node_modules/color-parse": {
             "version": "1.3.8",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "color-name": "^1.0.0",
                 "defined": "^1.0.0",
@@ -9060,6 +9105,7 @@
         "node_modules/color-rgba": {
             "version": "2.1.1",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "clamp": "^1.0.1",
                 "color-parse": "^1.3.8",
@@ -9069,6 +9115,7 @@
         "node_modules/color-space": {
             "version": "1.16.0",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "hsluv": "^0.0.3",
                 "mumath": "^3.3.4"
@@ -9140,6 +9187,7 @@
                 "node >= 0.8"
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "buffer-from": "^1.0.0",
                 "inherits": "^2.0.3",
@@ -9166,7 +9214,8 @@
         },
         "node_modules/convert-source-map": {
             "version": "1.9.0",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/convert-units": {
             "version": "2.3.4",
@@ -9196,6 +9245,7 @@
         "node_modules/cosmiconfig": {
             "version": "7.1.0",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/parse-json": "^4.0.0",
                 "import-fresh": "^3.2.1",
@@ -9212,13 +9262,15 @@
             "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
             "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
             "license": "ISC",
+            "peer": true,
             "engines": {
                 "node": ">= 6"
             }
         },
         "node_modules/country-regex": {
             "version": "1.1.0",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/cross-spawn": {
             "version": "7.0.6",
@@ -9247,6 +9299,7 @@
         "node_modules/css-color-keywords": {
             "version": "1.0.0",
             "license": "ISC",
+            "peer": true,
             "engines": {
                 "node": ">=4"
             }
@@ -9255,6 +9308,7 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/css-font/-/css-font-1.2.0.tgz",
             "integrity": "sha512-V4U4Wps4dPDACJ4WpgofJ2RT5Yqwe1lEH6wlOOaIxMi0gTjdIijsc5FmxQlZ7ZZyKQkkutqqvULOp07l9c7ssA==",
+            "peer": true,
             "dependencies": {
                 "css-font-size-keywords": "^1.0.0",
                 "css-font-stretch-keywords": "^1.0.1",
@@ -9270,36 +9324,43 @@
         "node_modules/css-font-size-keywords": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/css-font-size-keywords/-/css-font-size-keywords-1.0.0.tgz",
-            "integrity": "sha512-Q+svMDbMlelgCfH/RVDKtTDaf5021O486ZThQPIpahnIjUkMUslC+WuOQSWTgGSrNCH08Y7tYNEmmy0hkfMI8Q=="
+            "integrity": "sha512-Q+svMDbMlelgCfH/RVDKtTDaf5021O486ZThQPIpahnIjUkMUslC+WuOQSWTgGSrNCH08Y7tYNEmmy0hkfMI8Q==",
+            "peer": true
         },
         "node_modules/css-font-stretch-keywords": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/css-font-stretch-keywords/-/css-font-stretch-keywords-1.0.1.tgz",
-            "integrity": "sha512-KmugPO2BNqoyp9zmBIUGwt58UQSfyk1X5DbOlkb2pckDXFSAfjsD5wenb88fNrD6fvS+vu90a/tsPpb9vb0SLg=="
+            "integrity": "sha512-KmugPO2BNqoyp9zmBIUGwt58UQSfyk1X5DbOlkb2pckDXFSAfjsD5wenb88fNrD6fvS+vu90a/tsPpb9vb0SLg==",
+            "peer": true
         },
         "node_modules/css-font-style-keywords": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/css-font-style-keywords/-/css-font-style-keywords-1.0.1.tgz",
-            "integrity": "sha512-0Fn0aTpcDktnR1RzaBYorIxQily85M2KXRpzmxQPgh8pxUN9Fcn00I8u9I3grNr1QXVgCl9T5Imx0ZwKU973Vg=="
+            "integrity": "sha512-0Fn0aTpcDktnR1RzaBYorIxQily85M2KXRpzmxQPgh8pxUN9Fcn00I8u9I3grNr1QXVgCl9T5Imx0ZwKU973Vg==",
+            "peer": true
         },
         "node_modules/css-font-weight-keywords": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/css-font-weight-keywords/-/css-font-weight-keywords-1.0.0.tgz",
-            "integrity": "sha512-5So8/NH+oDD+EzsnF4iaG4ZFHQ3vaViePkL1ZbZ5iC/KrsCY+WHq/lvOgrtmuOQ9pBBZ1ADGpaf+A4lj1Z9eYA=="
+            "integrity": "sha512-5So8/NH+oDD+EzsnF4iaG4ZFHQ3vaViePkL1ZbZ5iC/KrsCY+WHq/lvOgrtmuOQ9pBBZ1ADGpaf+A4lj1Z9eYA==",
+            "peer": true
         },
         "node_modules/css-global-keywords": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/css-global-keywords/-/css-global-keywords-1.0.1.tgz",
-            "integrity": "sha512-X1xgQhkZ9n94WDwntqst5D/FKkmiU0GlJSFZSV3kLvyJ1WC5VeyoXDOuleUD+SIuH9C7W05is++0Woh0CGfKjQ=="
+            "integrity": "sha512-X1xgQhkZ9n94WDwntqst5D/FKkmiU0GlJSFZSV3kLvyJ1WC5VeyoXDOuleUD+SIuH9C7W05is++0Woh0CGfKjQ==",
+            "peer": true
         },
         "node_modules/css-system-font-keywords": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/css-system-font-keywords/-/css-system-font-keywords-1.0.0.tgz",
-            "integrity": "sha512-1umTtVd/fXS25ftfjB71eASCrYhilmEsvDEI6wG/QplnmlfmVM5HkZ/ZX46DT5K3eblFPgLUHt5BRCb0YXkSFA=="
+            "integrity": "sha512-1umTtVd/fXS25ftfjB71eASCrYhilmEsvDEI6wG/QplnmlfmVM5HkZ/ZX46DT5K3eblFPgLUHt5BRCb0YXkSFA==",
+            "peer": true
         },
         "node_modules/css-to-react-native": {
             "version": "3.2.0",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "camelize": "^1.0.0",
                 "css-color-keywords": "^1.0.0",
@@ -9309,11 +9370,13 @@
         "node_modules/csscolorparser": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/csscolorparser/-/csscolorparser-1.0.3.tgz",
-            "integrity": "sha512-umPSgYwZkdFoUrH5hIq5kf0wPSXiro51nPw0j2K/c83KflkPSTBGMz6NJvMB+07VlL0y7VPo6QJcDjcgKTTm3w=="
+            "integrity": "sha512-umPSgYwZkdFoUrH5hIq5kf0wPSXiro51nPw0j2K/c83KflkPSTBGMz6NJvMB+07VlL0y7VPo6QJcDjcgKTTm3w==",
+            "peer": true
         },
         "node_modules/csstype": {
             "version": "3.1.3",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/cubic-hermite-spline": {
             "version": "1.0.1",
@@ -9348,6 +9411,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/d/-/d-1.0.2.tgz",
             "integrity": "sha512-MOqHvMWF9/9MX6nza0KgvFH4HpMU0EF5uUDXqX/BtxtU8NfB0QzRtJ8Oe/6SuS4kbhyzVJwjd97EA4PKrzJ8bw==",
+            "peer": true,
             "dependencies": {
                 "es5-ext": "^0.10.64",
                 "type": "^2.7.2"
@@ -9438,7 +9502,8 @@
         },
         "node_modules/d3-collection": {
             "version": "1.0.7",
-            "license": "BSD-3-Clause"
+            "license": "BSD-3-Clause",
+            "peer": true
         },
         "node_modules/d3-color": {
             "version": "3.1.0",
@@ -9550,6 +9615,7 @@
         "node_modules/d3-geo-projection": {
             "version": "2.9.0",
             "license": "BSD-3-Clause",
+            "peer": true,
             "dependencies": {
                 "commander": "2",
                 "d3-array": "1",
@@ -9566,11 +9632,13 @@
         },
         "node_modules/d3-geo-projection/node_modules/d3-array": {
             "version": "1.2.4",
-            "license": "BSD-3-Clause"
+            "license": "BSD-3-Clause",
+            "peer": true
         },
         "node_modules/d3-geo-projection/node_modules/d3-geo": {
             "version": "1.12.1",
             "license": "BSD-3-Clause",
+            "peer": true,
             "dependencies": {
                 "d3-array": "1"
             }
@@ -9660,7 +9728,6 @@
         "node_modules/d3-selection": {
             "version": "3.0.0",
             "license": "ISC",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -9958,6 +10025,7 @@
         "node_modules/defined": {
             "version": "1.0.1",
             "license": "MIT",
+            "peer": true,
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
@@ -10083,7 +10151,8 @@
         "node_modules/detect-kerning": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/detect-kerning/-/detect-kerning-2.1.2.tgz",
-            "integrity": "sha512-I3JIbrnKPAntNLl1I6TpSQQdQ4AutYzv/sKMFKbepawV/hlH0GmYKhUoOEMd4xqaUHT+Bm0f4127lh5qs1m1tw=="
+            "integrity": "sha512-I3JIbrnKPAntNLl1I6TpSQQdQ4AutYzv/sKMFKbepawV/hlH0GmYKhUoOEMd4xqaUHT+Bm0f4127lh5qs1m1tw==",
+            "peer": true
         },
         "node_modules/detect-libc": {
             "version": "2.1.2",
@@ -10098,6 +10167,7 @@
         "node_modules/dom-helpers": {
             "version": "5.2.1",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.8.7",
                 "csstype": "^3.0.2"
@@ -10140,6 +10210,7 @@
         "node_modules/draw-svg-path": {
             "version": "1.0.0",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "abs-svg-path": "~0.1.1",
                 "normalize-svg-path": "~0.1.0"
@@ -10148,6 +10219,7 @@
         "node_modules/dtype": {
             "version": "2.0.0",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">= 0.8.0"
             }
@@ -10173,6 +10245,7 @@
         "node_modules/duplexify": {
             "version": "3.7.1",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "end-of-stream": "^1.0.0",
                 "inherits": "^2.0.1",
@@ -10193,11 +10266,13 @@
         },
         "node_modules/element-size": {
             "version": "1.1.1",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/elementary-circuits-directed-graph": {
             "version": "1.3.1",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "strongly-connected-components": "^1.0.1"
             }
@@ -10205,6 +10280,7 @@
         "node_modules/end-of-stream": {
             "version": "1.4.4",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "once": "^1.4.0"
             }
@@ -10226,6 +10302,7 @@
         "node_modules/error-ex": {
             "version": "1.3.2",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "is-arrayish": "^0.2.1"
             }
@@ -10416,6 +10493,7 @@
             "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.64.tgz",
             "integrity": "sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg==",
             "hasInstallScript": true,
+            "peer": true,
             "dependencies": {
                 "es6-iterator": "^2.0.3",
                 "es6-symbol": "^3.1.3",
@@ -10430,6 +10508,7 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
             "integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
+            "peer": true,
             "dependencies": {
                 "d": "1",
                 "es5-ext": "^0.10.35",
@@ -10440,6 +10519,7 @@
             "version": "3.1.4",
             "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.4.tgz",
             "integrity": "sha512-U9bFFjX8tFiATgtkJ1zg25+KviIXpgRvRHS8sau3GfhVzThRQrOeksPeT0BWW2MNZs1OEWJ1DPXOQMn0KKRkvg==",
+            "peer": true,
             "dependencies": {
                 "d": "^1.0.2",
                 "ext": "^1.7.0"
@@ -10452,6 +10532,7 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
             "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
+            "peer": true,
             "dependencies": {
                 "d": "1",
                 "es5-ext": "^0.10.46",
@@ -10487,6 +10568,7 @@
         "node_modules/escodegen": {
             "version": "1.14.3",
             "license": "BSD-2-Clause",
+            "peer": true,
             "dependencies": {
                 "esprima": "^4.0.1",
                 "estraverse": "^4.2.0",
@@ -10507,6 +10589,7 @@
         "node_modules/escodegen/node_modules/estraverse": {
             "version": "4.3.0",
             "license": "BSD-2-Clause",
+            "peer": true,
             "engines": {
                 "node": ">=4.0"
             }
@@ -10514,6 +10597,7 @@
         "node_modules/escodegen/node_modules/levn": {
             "version": "0.3.0",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "prelude-ls": "~1.1.2",
                 "type-check": "~0.3.2"
@@ -10525,6 +10609,7 @@
         "node_modules/escodegen/node_modules/optionator": {
             "version": "0.8.3",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "deep-is": "~0.1.3",
                 "fast-levenshtein": "~2.0.6",
@@ -10539,6 +10624,7 @@
         },
         "node_modules/escodegen/node_modules/prelude-ls": {
             "version": "1.1.2",
+            "peer": true,
             "engines": {
                 "node": ">= 0.8.0"
             }
@@ -10547,6 +10633,7 @@
             "version": "0.6.1",
             "license": "BSD-3-Clause",
             "optional": true,
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -10554,6 +10641,7 @@
         "node_modules/escodegen/node_modules/type-check": {
             "version": "0.3.2",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "prelude-ls": "~1.1.2"
             },
@@ -10567,7 +10655,6 @@
             "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.1",
@@ -10749,7 +10836,6 @@
             "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
             "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@rtsao/scc": "^1.1.0",
                 "array-includes": "^3.1.9",
@@ -10938,6 +11024,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/esniff/-/esniff-2.0.1.tgz",
             "integrity": "sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==",
+            "peer": true,
             "dependencies": {
                 "d": "^1.0.1",
                 "es5-ext": "^0.10.62",
@@ -10982,6 +11069,7 @@
         "node_modules/esprima": {
             "version": "4.0.1",
             "license": "BSD-2-Clause",
+            "peer": true,
             "bin": {
                 "esparse": "bin/esparse.js",
                 "esvalidate": "bin/esvalidate.js"
@@ -11043,6 +11131,7 @@
             "version": "0.3.5",
             "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
             "integrity": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
+            "peer": true,
             "dependencies": {
                 "d": "1",
                 "es5-ext": "~0.10.14"
@@ -11057,6 +11146,7 @@
         "node_modules/events": {
             "version": "3.3.0",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=0.8.x"
             }
@@ -11082,6 +11172,7 @@
             "version": "1.7.0",
             "resolved": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz",
             "integrity": "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==",
+            "peer": true,
             "dependencies": {
                 "type": "^2.7.2"
             }
@@ -11099,6 +11190,7 @@
         "node_modules/falafel": {
             "version": "2.2.5",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "acorn": "^7.1.1",
                 "isarray": "^2.0.1"
@@ -11110,6 +11202,7 @@
         "node_modules/falafel/node_modules/acorn": {
             "version": "7.4.1",
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -11154,6 +11247,7 @@
         "node_modules/fast-isnumeric": {
             "version": "1.1.4",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "is-string-blank": "^1.0.1"
             }
@@ -11233,7 +11327,8 @@
         },
         "node_modules/find-root": {
             "version": "1.1.0",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/find-up": {
             "version": "5.0.0",
@@ -11274,6 +11369,7 @@
         "node_modules/flatten-vertex-data": {
             "version": "1.0.2",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "dtype": "^2.0.0"
             }
@@ -11302,6 +11398,7 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/font-atlas/-/font-atlas-2.1.0.tgz",
             "integrity": "sha512-kP3AmvX+HJpW4w3d+PiPR2X6E1yvsBXt2yhuCw+yReO9F1WYhvZwx3c95DGZGwg9xYzDGrgJYa885xmVA+28Cg==",
+            "peer": true,
             "dependencies": {
                 "css-font": "^1.0.0"
             }
@@ -11310,6 +11407,7 @@
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/font-measure/-/font-measure-1.2.2.tgz",
             "integrity": "sha512-mRLEpdrWzKe9hbfaF3Qpr06TAjquuBVP5cHy4b3hyeNdjc9i0PO6HniGsX5vjL5OWv7+Bd++NiooNpT/s8BvIA==",
+            "peer": true,
             "dependencies": {
                 "css-font": "^1.2.0"
             }
@@ -11386,6 +11484,7 @@
         "node_modules/from2": {
             "version": "2.3.0",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "inherits": "^2.0.1",
                 "readable-stream": "^2.0.0"
@@ -11490,11 +11589,13 @@
         "node_modules/geojson-vt": {
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-3.2.1.tgz",
-            "integrity": "sha512-EvGQQi/zPrDA6zr6BnJD/YhwAkBP8nnJ9emh3EnHQKVMfg/MRVtPbMYdgVy/IaEmn4UfagD2a6fafPDL5hbtwg=="
+            "integrity": "sha512-EvGQQi/zPrDA6zr6BnJD/YhwAkBP8nnJ9emh3EnHQKVMfg/MRVtPbMYdgVy/IaEmn4UfagD2a6fafPDL5hbtwg==",
+            "peer": true
         },
         "node_modules/get-canvas-context": {
             "version": "1.0.2",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/get-intrinsic": {
             "version": "1.3.0",
@@ -11535,6 +11636,7 @@
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
             "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -11592,7 +11694,8 @@
         },
         "node_modules/gl-mat4": {
             "version": "1.2.0",
-            "license": "Zlib"
+            "license": "Zlib",
+            "peer": true
         },
         "node_modules/gl-matrix": {
             "version": "3.4.3",
@@ -11602,6 +11705,7 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/gl-text/-/gl-text-1.4.0.tgz",
             "integrity": "sha512-o47+XBqLCj1efmuNyCHt7/UEJmB9l66ql7pnobD6p+sgmBUdzfMZXIF0zD2+KRfpd99DJN+QXdvTFAGCKCVSmQ==",
+            "peer": true,
             "dependencies": {
                 "bit-twiddle": "^1.0.2",
                 "color-normalize": "^1.5.0",
@@ -11626,6 +11730,7 @@
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/gl-util/-/gl-util-3.1.3.tgz",
             "integrity": "sha512-dvRTggw5MSkJnCbh74jZzSoTOGnVYK+Bt+Ckqm39CVcl6+zSsxqWk4lr5NKhkqXHL6qvZAU9h17ZF8mIskY9mA==",
+            "peer": true,
             "dependencies": {
                 "is-browser": "^2.0.1",
                 "is-firefox": "^1.0.3",
@@ -11727,6 +11832,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-4.0.0.tgz",
             "integrity": "sha512-w0Uf9Y9/nyHinEk5vMJKRie+wa4kR5hmDbEhGGds/kG1PwGLLHKRoNMeJOyCQjjBkANlnScqgzcFwGHgmgLkVA==",
+            "peer": true,
             "dependencies": {
                 "ini": "^4.1.3",
                 "kind-of": "^6.0.3",
@@ -11740,6 +11846,7 @@
             "version": "4.1.3",
             "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.3.tgz",
             "integrity": "sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg==",
+            "peer": true,
             "engines": {
                 "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
@@ -11748,6 +11855,7 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
             "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
+            "peer": true,
             "engines": {
                 "node": ">=16"
             }
@@ -11756,6 +11864,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
             "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
+            "peer": true,
             "dependencies": {
                 "isexe": "^3.1.1"
             },
@@ -11798,6 +11907,7 @@
         "node_modules/glsl-inject-defines": {
             "version": "1.0.3",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "glsl-token-inject-block": "^1.0.0",
                 "glsl-token-string": "^1.0.1",
@@ -11807,6 +11917,7 @@
         "node_modules/glsl-resolve": {
             "version": "0.0.1",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "resolve": "^0.6.1",
                 "xtend": "^2.1.2"
@@ -11814,32 +11925,38 @@
         },
         "node_modules/glsl-resolve/node_modules/resolve": {
             "version": "0.6.3",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/glsl-resolve/node_modules/xtend": {
             "version": "2.2.0",
+            "peer": true,
             "engines": {
                 "node": ">=0.4"
             }
         },
         "node_modules/glsl-token-assignments": {
             "version": "2.0.2",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/glsl-token-defines": {
             "version": "1.0.0",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "glsl-tokenizer": "^2.0.0"
             }
         },
         "node_modules/glsl-token-depth": {
             "version": "1.1.2",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/glsl-token-descope": {
             "version": "1.0.2",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "glsl-token-assignments": "^2.0.0",
                 "glsl-token-depth": "^1.1.0",
@@ -11849,38 +11966,46 @@
         },
         "node_modules/glsl-token-inject-block": {
             "version": "1.1.0",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/glsl-token-properties": {
             "version": "1.0.1",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/glsl-token-scope": {
             "version": "1.1.2",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/glsl-token-string": {
             "version": "1.0.1",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/glsl-token-whitespace-trim": {
             "version": "1.0.0",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/glsl-tokenizer": {
             "version": "2.1.5",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "through2": "^0.6.3"
             }
         },
         "node_modules/glsl-tokenizer/node_modules/isarray": {
             "version": "0.0.1",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/glsl-tokenizer/node_modules/readable-stream": {
             "version": "1.0.34",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.1",
@@ -11890,11 +12015,13 @@
         },
         "node_modules/glsl-tokenizer/node_modules/string_decoder": {
             "version": "0.10.31",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/glsl-tokenizer/node_modules/through2": {
             "version": "0.6.5",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "readable-stream": ">=1.0.33-1 <1.1.0-0",
                 "xtend": ">=4.0.0 <4.1.0-0"
@@ -11903,6 +12030,7 @@
         "node_modules/glslify": {
             "version": "7.1.1",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "bl": "^2.2.1",
                 "concat-stream": "^1.5.2",
@@ -11927,6 +12055,7 @@
         "node_modules/glslify-bundle": {
             "version": "5.1.1",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "glsl-inject-defines": "^1.0.1",
                 "glsl-token-defines": "^1.0.0",
@@ -11943,6 +12072,7 @@
         "node_modules/glslify-deps": {
             "version": "1.3.2",
             "license": "ISC",
+            "peer": true,
             "dependencies": {
                 "@choojs/findup": "^0.2.0",
                 "events": "^3.2.0",
@@ -11972,7 +12102,8 @@
         "node_modules/grid-index": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/grid-index/-/grid-index-1.1.0.tgz",
-            "integrity": "sha512-HZRwumpOGUrHyxO5bqKZL0B0GlUpwtCAzZ42sgxUPniu33R1LSFH5yrIcBCHjkctCAh3mtWKcKd9J4vDDdeVHA=="
+            "integrity": "sha512-HZRwumpOGUrHyxO5bqKZL0B0GlUpwtCAzZ42sgxUPniu33R1LSFH5yrIcBCHjkctCAh3mtWKcKd9J4vDDdeVHA==",
+            "peer": true
         },
         "node_modules/h3-js": {
             "version": "4.3.0",
@@ -12010,6 +12141,7 @@
         "node_modules/has-hover": {
             "version": "1.0.1",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "is-browser": "^2.0.1"
             }
@@ -12017,6 +12149,7 @@
         "node_modules/has-passive-events": {
             "version": "1.0.0",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "is-browser": "^2.0.1"
             }
@@ -12086,17 +12219,20 @@
         "node_modules/hoist-non-react-statics": {
             "version": "3.3.2",
             "license": "BSD-3-Clause",
+            "peer": true,
             "dependencies": {
                 "react-is": "^16.7.0"
             }
         },
         "node_modules/hoist-non-react-statics/node_modules/react-is": {
             "version": "16.13.1",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/hsluv": {
             "version": "0.0.3",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/html-escaper": {
             "version": "2.0.2",
@@ -12281,7 +12417,8 @@
         },
         "node_modules/is-arrayish": {
             "version": "0.2.1",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/is-async-function": {
             "version": "2.1.1",
@@ -12335,7 +12472,8 @@
         },
         "node_modules/is-browser": {
             "version": "2.1.0",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/is-buffer": {
             "version": "1.1.6",
@@ -12473,6 +12611,7 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
             "integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w==",
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             },
@@ -12484,6 +12623,7 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/is-firefox/-/is-firefox-1.0.3.tgz",
             "integrity": "sha512-6Q9ITjvWIm0Xdqv+5U12wgOKEM2KoBw4Y926m0OFkvlCxnbG94HKAsVz8w3fWcfAS5YA2fJORXX1dLrkprCCxA==",
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -12520,6 +12660,7 @@
         "node_modules/is-iexplorer": {
             "version": "1.0.0",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -12587,7 +12728,8 @@
         },
         "node_modules/is-mobile": {
             "version": "4.0.0",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/is-negative-zero": {
             "version": "2.0.3",
@@ -12630,6 +12772,7 @@
         "node_modules/is-obj": {
             "version": "1.0.1",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -12650,6 +12793,7 @@
         "node_modules/is-plain-obj": {
             "version": "1.1.0",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -12717,11 +12861,13 @@
         },
         "node_modules/is-string-blank": {
             "version": "1.0.1",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/is-svg-path": {
             "version": "1.0.2",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/is-symbol": {
             "version": "1.1.1",
@@ -12951,7 +13097,6 @@
             "resolved": "https://registry.npmjs.org/jotai/-/jotai-2.17.1.tgz",
             "integrity": "sha512-TFNZZDa/0ewCLQyRC/Sq9crtixNj/Xdf/wmj9631xxMuKToVJZDbqcHIYN0OboH+7kh6P6tpIK7uKWClj86PKw==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12.20.0"
             },
@@ -13054,7 +13199,8 @@
         },
         "node_modules/json-parse-even-better-errors": {
             "version": "2.3.1",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/json-schema-traverse": {
             "version": "1.0.0",
@@ -13068,7 +13214,8 @@
         "node_modules/json-stringify-pretty-compact": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-4.0.0.tgz",
-            "integrity": "sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q=="
+            "integrity": "sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==",
+            "peer": true
         },
         "node_modules/json5": {
             "version": "2.2.3",
@@ -13110,7 +13257,8 @@
         "node_modules/kdbush": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.0.2.tgz",
-            "integrity": "sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA=="
+            "integrity": "sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA==",
+            "peer": true
         },
         "node_modules/keyv": {
             "version": "4.5.4",
@@ -13126,6 +13274,7 @@
             "version": "6.0.3",
             "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
             "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -13428,7 +13577,8 @@
         },
         "node_modules/lines-and-columns": {
             "version": "1.2.4",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/locate-path": {
             "version": "6.0.0",
@@ -13692,6 +13842,7 @@
         "node_modules/map-limit": {
             "version": "0.0.1",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "once": "~1.3.0"
             }
@@ -13699,6 +13850,7 @@
         "node_modules/map-limit/node_modules/once": {
             "version": "1.3.3",
             "license": "ISC",
+            "peer": true,
             "dependencies": {
                 "wrappy": "1"
             }
@@ -13707,6 +13859,7 @@
             "version": "1.13.3",
             "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-1.13.3.tgz",
             "integrity": "sha512-p8lJFEiqmEQlyv+DQxFAOG/XPWN0Wp7j/Psq93Zywz7qt9CcUKFYDBOoOEKzqe6gudHVJY8/Bhqw6VDpX2lSBg==",
+            "peer": true,
             "dependencies": {
                 "@mapbox/geojson-rewind": "^0.5.2",
                 "@mapbox/geojson-types": "^1.0.2",
@@ -13738,12 +13891,14 @@
         "node_modules/mapbox-gl/node_modules/@mapbox/tiny-sdf": {
             "version": "1.2.5",
             "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-1.2.5.tgz",
-            "integrity": "sha512-cD8A/zJlm6fdJOk6DqPUV8mcpyJkRz2x2R+/fYcWDYG3oWbG7/L7Yl/WqQ1VZCjnL9OTIMAn6c+BC5Eru4sQEw=="
+            "integrity": "sha512-cD8A/zJlm6fdJOk6DqPUV8mcpyJkRz2x2R+/fYcWDYG3oWbG7/L7Yl/WqQ1VZCjnL9OTIMAn6c+BC5Eru4sQEw==",
+            "peer": true
         },
         "node_modules/maplibre-gl": {
             "version": "4.7.1",
             "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-4.7.1.tgz",
             "integrity": "sha512-lgL7XpIwsgICiL82ITplfS7IGwrB1OJIw/pCvprDp2dhmSSEBgmPzYRvwYYYvJGJD7fxUv1Tvpih4nZ6VrLuaA==",
+            "peer": true,
             "dependencies": {
                 "@mapbox/geojson-rewind": "^0.5.2",
                 "@mapbox/jsonlint-lines-primitives": "^2.0.2",
@@ -13783,32 +13938,38 @@
         "node_modules/maplibre-gl/node_modules/@mapbox/unitbezier": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.1.tgz",
-            "integrity": "sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw=="
+            "integrity": "sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==",
+            "peer": true
         },
         "node_modules/maplibre-gl/node_modules/earcut": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.0.1.tgz",
-            "integrity": "sha512-0l1/0gOjESMeQyYaK5IDiPNvFeu93Z/cO0TjZh9eZ1vyCtZnA7KMZ8rQggpsJHIbGSdrqYq9OhuveadOVHCshw=="
+            "integrity": "sha512-0l1/0gOjESMeQyYaK5IDiPNvFeu93Z/cO0TjZh9eZ1vyCtZnA7KMZ8rQggpsJHIbGSdrqYq9OhuveadOVHCshw==",
+            "peer": true
         },
         "node_modules/maplibre-gl/node_modules/geojson-vt": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-4.0.2.tgz",
-            "integrity": "sha512-AV9ROqlNqoZEIJGfm1ncNjEXfkz2hdFlZf0qkVfmkwdKa8vj7H16YUOT81rJw1rdFhyEDlN2Tds91p/glzbl5A=="
+            "integrity": "sha512-AV9ROqlNqoZEIJGfm1ncNjEXfkz2hdFlZf0qkVfmkwdKa8vj7H16YUOT81rJw1rdFhyEDlN2Tds91p/glzbl5A==",
+            "peer": true
         },
         "node_modules/maplibre-gl/node_modules/potpack": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/potpack/-/potpack-2.0.0.tgz",
-            "integrity": "sha512-Q+/tYsFU9r7xoOJ+y/ZTtdVQwTWfzjbiXBDMM/JKUux3+QPP02iUuIoeBQ+Ot6oEDlC+/PGjB/5A3K7KKb7hcw=="
+            "integrity": "sha512-Q+/tYsFU9r7xoOJ+y/ZTtdVQwTWfzjbiXBDMM/JKUux3+QPP02iUuIoeBQ+Ot6oEDlC+/PGjB/5A3K7KKb7hcw==",
+            "peer": true
         },
         "node_modules/maplibre-gl/node_modules/quickselect": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-3.0.0.tgz",
-            "integrity": "sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g=="
+            "integrity": "sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==",
+            "peer": true
         },
         "node_modules/maplibre-gl/node_modules/supercluster": {
             "version": "8.0.1",
             "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-8.0.1.tgz",
             "integrity": "sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ==",
+            "peer": true,
             "dependencies": {
                 "kdbush": "^4.0.2"
             }
@@ -13816,7 +13977,8 @@
         "node_modules/maplibre-gl/node_modules/tinyqueue": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-3.0.0.tgz",
-            "integrity": "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g=="
+            "integrity": "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==",
+            "peer": true
         },
         "node_modules/material-colors": {
             "version": "1.2.6",
@@ -13834,6 +13996,7 @@
         "node_modules/math-log2": {
             "version": "1.0.1",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -14041,21 +14204,25 @@
         "node_modules/mouse-change": {
             "version": "1.4.0",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "mouse-event": "^1.0.0"
             }
         },
         "node_modules/mouse-event": {
             "version": "1.0.5",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/mouse-event-offset": {
             "version": "3.0.2",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/mouse-wheel": {
             "version": "1.2.0",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "right-now": "^1.0.0",
                 "signum": "^1.0.0",
@@ -14071,13 +14238,15 @@
         "node_modules/mumath": {
             "version": "3.3.4",
             "license": "Unlicense",
+            "peer": true,
             "dependencies": {
                 "almost-equal": "^1.1.0"
             }
         },
         "node_modules/murmurhash-js": {
             "version": "1.0.0",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/nanoid": {
             "version": "3.3.11",
@@ -14115,7 +14284,8 @@
         },
         "node_modules/native-promise-only": {
             "version": "0.8.1",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/natural-compare": {
             "version": "1.4.0",
@@ -14166,6 +14336,7 @@
         "node_modules/needle": {
             "version": "2.9.1",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "debug": "^3.2.6",
                 "iconv-lite": "^0.4.4",
@@ -14181,6 +14352,7 @@
         "node_modules/needle/node_modules/debug": {
             "version": "3.2.7",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "ms": "^2.1.1"
             }
@@ -14188,7 +14360,8 @@
         "node_modules/next-tick": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
-            "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
+            "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
+            "peer": true
         },
         "node_modules/node-addon-api": {
             "version": "7.1.1",
@@ -14214,7 +14387,8 @@
         },
         "node_modules/normalize-svg-path": {
             "version": "0.1.0",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/npm-run-path": {
             "version": "6.0.0",
@@ -14248,6 +14422,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/number-is-integer/-/number-is-integer-1.0.1.tgz",
             "integrity": "sha512-Dq3iuiFBkrbmuQjGFFF3zckXNCQoSD37/SdSbgcBailUx6knDvDwb5CympBgcoWHy36sfS12u74MHYkXyHq6bg==",
+            "peer": true,
             "dependencies": {
                 "is-finite": "^1.0.1"
             },
@@ -14413,6 +14588,7 @@
         "node_modules/once": {
             "version": "1.4.0",
             "license": "ISC",
+            "peer": true,
             "dependencies": {
                 "wrappy": "1"
             }
@@ -14519,11 +14695,13 @@
         "node_modules/parenthesis": {
             "version": "3.1.8",
             "resolved": "https://registry.npmjs.org/parenthesis/-/parenthesis-3.1.8.tgz",
-            "integrity": "sha512-KF/U8tk54BgQewkJPvB4s/US3VQY68BRDpH638+7O/n58TpnwiwnOtGIOsT2/i+M78s61BBpeC83STB88d8sqw=="
+            "integrity": "sha512-KF/U8tk54BgQewkJPvB4s/US3VQY68BRDpH638+7O/n58TpnwiwnOtGIOsT2/i+M78s61BBpeC83STB88d8sqw==",
+            "peer": true
         },
         "node_modules/parse-json": {
             "version": "5.2.0",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.0.0",
                 "error-ex": "^1.3.1",
@@ -14540,17 +14718,20 @@
         "node_modules/parse-rect": {
             "version": "1.2.0",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "pick-by-alias": "^1.2.0"
             }
         },
         "node_modules/parse-svg-path": {
             "version": "0.1.2",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/parse-unit": {
             "version": "1.0.1",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/path-exists": {
             "version": "4.0.0",
@@ -14602,6 +14783,7 @@
         "node_modules/path-type": {
             "version": "4.0.0",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -14634,11 +14816,13 @@
         },
         "node_modules/performance-now": {
             "version": "2.1.0",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/pick-by-alias": {
             "version": "1.2.0",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/picocolors": {
             "version": "1.1.1",
@@ -14662,7 +14846,6 @@
             "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-7.4.3.tgz",
             "integrity": "sha512-uIWdH0EI2dVgNoqN9aFaHCmR0V65OEhMkXs2sek3c/QP2ItV6UoM+ouX9esSv3ibo20F+J5D1XwnQhUZI6wqeQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@pixi/accessibility": "7.4.3",
                 "@pixi/app": "7.4.3",
@@ -14764,6 +14947,7 @@
             "resolved": "https://registry.npmjs.org/plotly.js/-/plotly.js-3.3.1.tgz",
             "integrity": "sha512-SrGSZ02HvCWQIYsbQX4sgjgGo7k4T+Oz8a+RQwE5Caz+yu1vputBM1UThmiOPY51B5HzO9ajym8Rl4pmLj+i9Q==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@plotly/d3": "3.8.2",
                 "@plotly/d3-sankey": "0.7.2",
@@ -14824,6 +15008,7 @@
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/@turf/area/-/area-7.2.0.tgz",
             "integrity": "sha512-zuTTdQ4eoTI9nSSjerIy4QwgvxqwJVciQJ8tOPuMHbXJ9N/dNjI7bU8tasjhxas/Cx3NE9NxVHtNpYHL0FSzoA==",
+            "peer": true,
             "dependencies": {
                 "@turf/helpers": "^7.2.0",
                 "@turf/meta": "^7.2.0",
@@ -14838,6 +15023,7 @@
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-7.2.0.tgz",
             "integrity": "sha512-wzHEjCXlYZiDludDbXkpBSmv8Zu6tPGLmJ1sXQ6qDwpLE1Ew3mcWqt8AaxfTP5QwDNQa3sf2vvgTEzNbPQkCiA==",
+            "peer": true,
             "dependencies": {
                 "@turf/helpers": "^7.2.0",
                 "@turf/meta": "^7.2.0",
@@ -14852,6 +15038,7 @@
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/@turf/centroid/-/centroid-7.2.0.tgz",
             "integrity": "sha512-yJqDSw25T7P48au5KjvYqbDVZ7qVnipziVfZ9aSo7P2/jTE7d4BP21w0/XLi3T/9bry/t9PR1GDDDQljN4KfDw==",
+            "peer": true,
             "dependencies": {
                 "@turf/helpers": "^7.2.0",
                 "@turf/meta": "^7.2.0",
@@ -14866,6 +15053,7 @@
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.2.0.tgz",
             "integrity": "sha512-cXo7bKNZoa7aC7ydLmUR02oB3IgDe7MxiPuRz3cCtYQHn+BJ6h1tihmamYDWWUlPHgSNF0i3ATc4WmDECZafKw==",
+            "peer": true,
             "dependencies": {
                 "@types/geojson": "^7946.0.10",
                 "tslib": "^2.8.1"
@@ -14878,6 +15066,7 @@
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.2.0.tgz",
             "integrity": "sha512-igzTdHsQc8TV1RhPuOLVo74Px/hyPrVgVOTgjWQZzt3J9BVseCdpfY/0cJBdlSRI4S/yTmmHl7gAqjhpYH5Yaw==",
+            "peer": true,
             "dependencies": {
                 "@turf/helpers": "^7.2.0",
                 "@types/geojson": "^7946.0.10"
@@ -14890,6 +15079,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-2.0.0.tgz",
             "integrity": "sha512-g2Z+QnWsdHLppAbrpcFWo629kLOnOPtpxYV69GCqm92gqSgyXbzlfyN3MXs0412fPBkFmiuS+rXposgBgBa6Kg==",
+            "peer": true,
             "dependencies": {
                 "color-name": "^1.0.0"
             }
@@ -14898,6 +15088,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/color-rgba/-/color-rgba-3.0.0.tgz",
             "integrity": "sha512-PPwZYkEY3M2THEHHV6Y95sGUie77S7X8v+h1r6LSAPF3/LL2xJ8duUXSrkic31Nzc4odPwHgUbiX/XuTYzQHQg==",
+            "peer": true,
             "dependencies": {
                 "color-parse": "^2.0.0",
                 "color-space": "^2.0.0"
@@ -14906,19 +15097,23 @@
         "node_modules/plotly.js/node_modules/color-space": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/color-space/-/color-space-2.3.1.tgz",
-            "integrity": "sha512-5DJdKYwoDji3ik/i0xSn+SiwXsfwr+1FEcCMUz2GS5speGCfGSbBMOLd84SDUBOuX8y4CvdFJmOBBJuC4wp7sQ=="
+            "integrity": "sha512-5DJdKYwoDji3ik/i0xSn+SiwXsfwr+1FEcCMUz2GS5speGCfGSbBMOLd84SDUBOuX8y4CvdFJmOBBJuC4wp7sQ==",
+            "peer": true
         },
         "node_modules/plotly.js/node_modules/d3-array": {
             "version": "1.2.4",
-            "license": "BSD-3-Clause"
+            "license": "BSD-3-Clause",
+            "peer": true
         },
         "node_modules/plotly.js/node_modules/d3-dispatch": {
             "version": "1.0.6",
-            "license": "BSD-3-Clause"
+            "license": "BSD-3-Clause",
+            "peer": true
         },
         "node_modules/plotly.js/node_modules/d3-force": {
             "version": "1.2.1",
             "license": "BSD-3-Clause",
+            "peer": true,
             "dependencies": {
                 "d3-collection": "1",
                 "d3-dispatch": "1",
@@ -14929,41 +15124,49 @@
         "node_modules/plotly.js/node_modules/d3-geo": {
             "version": "1.12.1",
             "license": "BSD-3-Clause",
+            "peer": true,
             "dependencies": {
                 "d3-array": "1"
             }
         },
         "node_modules/plotly.js/node_modules/d3-hierarchy": {
             "version": "1.1.9",
-            "license": "BSD-3-Clause"
+            "license": "BSD-3-Clause",
+            "peer": true
         },
         "node_modules/plotly.js/node_modules/d3-quadtree": {
             "version": "1.0.7",
-            "license": "BSD-3-Clause"
+            "license": "BSD-3-Clause",
+            "peer": true
         },
         "node_modules/plotly.js/node_modules/d3-time": {
             "version": "1.1.0",
-            "license": "BSD-3-Clause"
+            "license": "BSD-3-Clause",
+            "peer": true
         },
         "node_modules/plotly.js/node_modules/d3-time-format": {
             "version": "2.3.0",
             "license": "BSD-3-Clause",
+            "peer": true,
             "dependencies": {
                 "d3-time": "1"
             }
         },
         "node_modules/plotly.js/node_modules/d3-timer": {
             "version": "1.0.10",
-            "license": "BSD-3-Clause"
+            "license": "BSD-3-Clause",
+            "peer": true
         },
         "node_modules/point-in-polygon": {
             "version": "1.1.0",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/polybooljs": {
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/polybooljs/-/polybooljs-1.2.2.tgz",
-            "integrity": "sha512-ziHW/02J0XuNuUtmidBc6GXE8YohYydp3DWPWXYsd7O721TjcmN+k6ezjdwkDqep+gnWnFY+yqZHvzElra2oCg=="
+            "integrity": "sha512-ziHW/02J0XuNuUtmidBc6GXE8YohYydp3DWPWXYsd7O721TjcmN+k6ezjdwkDqep+gnWnFY+yqZHvzElra2oCg==",
+            "peer": true
         },
         "node_modules/polygon-clipping": {
             "version": "0.15.7",
@@ -15015,12 +15218,14 @@
         },
         "node_modules/postcss-value-parser": {
             "version": "4.2.0",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/potpack": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/potpack/-/potpack-1.0.2.tgz",
-            "integrity": "sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ=="
+            "integrity": "sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ==",
+            "peer": true
         },
         "node_modules/powershell-utils": {
             "version": "0.1.0",
@@ -15040,6 +15245,7 @@
             "resolved": "https://registry.npmjs.org/preact/-/preact-10.28.3.tgz",
             "integrity": "sha512-tCmoRkPQLpBeWzpmbhryairGnhW9tKV6c6gr/w+RhoRoKEJwsjzipwp//1oCpGPOchvSLaAPlpcJi9MwMmoPyA==",
             "license": "MIT",
+            "peer": true,
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/preact"
@@ -15059,7 +15265,6 @@
             "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "prettier": "bin/prettier.cjs"
             },
@@ -15088,6 +15293,7 @@
         "node_modules/probe-image-size": {
             "version": "7.2.3",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "lodash.merge": "^4.6.2",
                 "needle": "^2.5.2",
@@ -15182,6 +15388,7 @@
         "node_modules/raf": {
             "version": "3.4.1",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "performance-now": "^2.1.0"
             }
@@ -15217,7 +15424,6 @@
             "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
             "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0"
             },
@@ -15300,7 +15506,6 @@
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
             "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0",
                 "scheduler": "^0.23.2"
@@ -15373,6 +15578,7 @@
         "node_modules/react-transition-group": {
             "version": "4.4.5",
             "license": "BSD-3-Clause",
+            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.5.5",
                 "dom-helpers": "^5.0.1",
@@ -15499,11 +15705,13 @@
             "name": "@plotly/regl",
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/@plotly/regl/-/regl-2.1.2.tgz",
-            "integrity": "sha512-Mdk+vUACbQvjd0m/1JJjOOafmkp/EpmHjISsopEz5Av44CBq7rPC05HHNbYGKVyNUF2zmEoBS/TT0pd0SPFFyw=="
+            "integrity": "sha512-Mdk+vUACbQvjd0m/1JJjOOafmkp/EpmHjISsopEz5Av44CBq7rPC05HHNbYGKVyNUF2zmEoBS/TT0pd0SPFFyw==",
+            "peer": true
         },
         "node_modules/regl-error2d": {
             "version": "2.0.12",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "array-bounds": "^1.0.1",
                 "color-normalize": "^1.5.0",
@@ -15518,6 +15726,7 @@
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/regl-line2d/-/regl-line2d-3.1.3.tgz",
             "integrity": "sha512-fkgzW+tTn4QUQLpFKsUIE0sgWdCmXAM3ctXcCgoGBZTSX5FE2A0M7aynz7nrZT5baaftLrk9te54B+MEq4QcSA==",
+            "peer": true,
             "dependencies": {
                 "array-bounds": "^1.0.1",
                 "array-find-index": "^1.0.2",
@@ -15536,6 +15745,7 @@
             "version": "3.3.1",
             "resolved": "https://registry.npmjs.org/regl-scatter2d/-/regl-scatter2d-3.3.1.tgz",
             "integrity": "sha512-seOmMIVwaCwemSYz/y4WE0dbSO9svNFSqtTh5RE57I7PjGo3tcUYKtH0MTSoshcAsreoqN8HoCtnn8wfHXXfKQ==",
+            "peer": true,
             "dependencies": {
                 "@plotly/point-cluster": "^3.1.9",
                 "array-range": "^1.0.1",
@@ -15557,6 +15767,7 @@
         "node_modules/regl-splom": {
             "version": "1.0.14",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "array-bounds": "^1.0.1",
                 "array-range": "^1.0.1",
@@ -15627,7 +15838,8 @@
         },
         "node_modules/right-now": {
             "version": "1.0.0",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/robust-predicates": {
             "version": "3.0.2",
@@ -15764,7 +15976,8 @@
                     "url": "https://feross.org/support"
                 }
             ],
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/safe-push-apply": {
             "version": "1.0.0",
@@ -16199,7 +16412,8 @@
         },
         "node_modules/sax": {
             "version": "1.2.4",
-            "license": "ISC"
+            "license": "ISC",
+            "peer": true
         },
         "node_modules/scheduler": {
             "version": "0.23.2",
@@ -16276,11 +16490,13 @@
         },
         "node_modules/shallow-copy": {
             "version": "0.0.1",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/shallowequal": {
             "version": "1.1.0",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/shebang-command": {
             "version": "2.0.0",
@@ -16378,7 +16594,8 @@
         },
         "node_modules/signum": {
             "version": "1.0.0",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/simplify-js": {
             "version": "1.2.4",
@@ -16398,6 +16615,7 @@
         "node_modules/source-map": {
             "version": "0.5.7",
             "license": "BSD-3-Clause",
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -16435,6 +16653,7 @@
         },
         "node_modules/stack-trace": {
             "version": "0.0.9",
+            "peer": true,
             "engines": {
                 "node": "*"
             }
@@ -16455,6 +16674,7 @@
         "node_modules/static-eval": {
             "version": "2.1.0",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "escodegen": "^1.11.1"
             }
@@ -16497,6 +16717,7 @@
         "node_modules/stream-parser": {
             "version": "0.3.1",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "debug": "2"
             }
@@ -16504,17 +16725,20 @@
         "node_modules/stream-parser/node_modules/debug": {
             "version": "2.6.9",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "ms": "2.0.0"
             }
         },
         "node_modules/stream-parser/node_modules/ms": {
             "version": "2.0.0",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/stream-shift": {
             "version": "1.0.1",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/string_decoder": {
             "version": "1.1.1",
@@ -16531,6 +16755,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/string-split-by/-/string-split-by-1.0.0.tgz",
             "integrity": "sha512-KaJKY+hfpzNyet/emP81PJA9hTVSfxNLS9SFTWxdCnnW1/zOOwiV248+EfoX7IQFcBaOp4G5YE6xTJMF+pLg6A==",
+            "peer": true,
             "dependencies": {
                 "parenthesis": "^3.1.5"
             }
@@ -16664,7 +16889,8 @@
         },
         "node_modules/strongly-connected-components": {
             "version": "1.0.1",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/styled-components": {
             "version": "6.1.13",
@@ -16710,6 +16936,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "nanoid": "^3.3.7",
                 "picocolors": "^1.0.0",
@@ -16721,20 +16948,24 @@
         },
         "node_modules/styled-components/node_modules/stylis": {
             "version": "4.3.2",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/styled-components/node_modules/tslib": {
             "version": "2.6.2",
-            "license": "0BSD"
+            "license": "0BSD",
+            "peer": true
         },
         "node_modules/stylis": {
             "version": "4.2.0",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/supercluster": {
             "version": "7.1.5",
             "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-7.1.5.tgz",
             "integrity": "sha512-EulshI3pGUM66o6ZdH3ReiFcvHpM3vAigyK+vcxdjpJyEbIIrtbmBdY23mGgnI24uXiGFvrGq9Gkum/8U7vJWg==",
+            "peer": true,
             "dependencies": {
                 "kdbush": "^3.0.0"
             }
@@ -16742,11 +16973,13 @@
         "node_modules/supercluster/node_modules/kdbush": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-3.0.0.tgz",
-            "integrity": "sha512-hRkd6/XW4HTsA9vjVpY9tuXJYLSlelnkTmVFu4M9/7MIYQtFcHpbugAU7UbOfjOiVSVYl2fqgBuJ32JUmRo5Ew=="
+            "integrity": "sha512-hRkd6/XW4HTsA9vjVpY9tuXJYLSlelnkTmVFu4M9/7MIYQtFcHpbugAU7UbOfjOiVSVYl2fqgBuJ32JUmRo5Ew==",
+            "peer": true
         },
         "node_modules/superscript-text": {
             "version": "1.0.0",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/supports-color": {
             "version": "7.2.0",
@@ -16773,11 +17006,13 @@
         },
         "node_modules/svg-arc-to-cubic-bezier": {
             "version": "3.2.0",
-            "license": "ISC"
+            "license": "ISC",
+            "peer": true
         },
         "node_modules/svg-path-bounds": {
             "version": "1.0.2",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "abs-svg-path": "^0.1.1",
                 "is-svg-path": "^1.0.1",
@@ -16788,6 +17023,7 @@
         "node_modules/svg-path-bounds/node_modules/normalize-svg-path": {
             "version": "1.1.0",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "svg-arc-to-cubic-bezier": "^3.0.0"
             }
@@ -16795,6 +17031,7 @@
         "node_modules/svg-path-sdf": {
             "version": "1.1.3",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "bitmap-sdf": "^1.0.0",
                 "draw-svg-path": "^1.0.0",
@@ -16881,6 +17118,7 @@
         "node_modules/through2": {
             "version": "2.0.5",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "readable-stream": "~2.3.6",
                 "xtend": "~4.0.1"
@@ -16959,7 +17197,6 @@
             "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -16970,7 +17207,8 @@
         "node_modules/tinyqueue": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-2.0.3.tgz",
-            "integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA=="
+            "integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA==",
+            "peer": true
         },
         "node_modules/tinyrainbow": {
             "version": "3.0.3",
@@ -16984,11 +17222,13 @@
         },
         "node_modules/to-float32": {
             "version": "1.1.0",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/to-px": {
             "version": "1.0.1",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "parse-unit": "^1.0.1"
             }
@@ -17009,6 +17249,7 @@
         "node_modules/topojson-client": {
             "version": "3.1.0",
             "license": "ISC",
+            "peer": true,
             "dependencies": {
                 "commander": "2"
             },
@@ -17106,7 +17347,8 @@
         "node_modules/type": {
             "version": "2.7.3",
             "resolved": "https://registry.npmjs.org/type/-/type-2.7.3.tgz",
-            "integrity": "sha512-8j+1QmAbPvLZow5Qpi6NCaN8FB60p/6x8/vfNqOk/hC+HuvFZhL4+WfekuhQLiqFZXOgQdrs3B+XxEmCc6b3FQ=="
+            "integrity": "sha512-8j+1QmAbPvLZow5Qpi6NCaN8FB60p/6x8/vfNqOk/hC+HuvFZhL4+WfekuhQLiqFZXOgQdrs3B+XxEmCc6b3FQ==",
+            "peer": true
         },
         "node_modules/type-check": {
             "version": "0.4.0",
@@ -17203,7 +17445,8 @@
         },
         "node_modules/typedarray": {
             "version": "0.0.6",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/typedarray-pool": {
             "version": "1.2.0",
@@ -17220,7 +17463,6 @@
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -17297,7 +17539,8 @@
         "node_modules/unquote": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/unquote/-/unquote-1.1.1.tgz",
-            "integrity": "sha512-vRCqFv6UhXpWxZPyGDh/F3ZpNv8/qo7w6iufLpQg9aKnQ71qM4B5KiI7Mia9COcjEhrO9LueHpMYjYzsWH3OIg=="
+            "integrity": "sha512-vRCqFv6UhXpWxZPyGDh/F3ZpNv8/qo7w6iufLpQg9aKnQ71qM4B5KiI7Mia9COcjEhrO9LueHpMYjYzsWH3OIg==",
+            "peer": true
         },
         "node_modules/unrs-resolver": {
             "version": "1.11.1",
@@ -17306,7 +17549,6 @@
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "napi-postinstall": "^0.3.0"
             },
@@ -17368,7 +17610,8 @@
         },
         "node_modules/update-diff": {
             "version": "1.1.0",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/uri-js": {
             "version": "4.4.1",
@@ -17455,7 +17698,6 @@
             "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "esbuild": "^0.27.0",
                 "fdir": "^6.5.0",
@@ -18118,7 +18360,6 @@
             "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -18132,7 +18373,6 @@
             "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@vitest/expect": "4.0.18",
                 "@vitest/mocker": "4.0.18",
@@ -18228,6 +18468,7 @@
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/vt-pbf/-/vt-pbf-3.1.3.tgz",
             "integrity": "sha512-2LzDFzt0mZKZ9IpVF2r69G9bXaP2Q2sArJCmcCgvfTdCCZzSyz4aCLoQyUilu37Ll56tCblIZrXFIjNUpGIlmA==",
+            "peer": true,
             "dependencies": {
                 "@mapbox/point-geometry": "0.1.0",
                 "@mapbox/vector-tile": "^1.3.1",
@@ -18250,11 +18491,13 @@
         "node_modules/weak-map": {
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/weak-map/-/weak-map-1.0.8.tgz",
-            "integrity": "sha512-lNR9aAefbGPpHO7AEnY0hCFjz1eTkWCXYvkTRrTHs9qv8zJp+SkVYpzfLIFXQQiG3tVvbNFQgVg2bQS8YGgxyw=="
+            "integrity": "sha512-lNR9aAefbGPpHO7AEnY0hCFjz1eTkWCXYvkTRrTHs9qv8zJp+SkVYpzfLIFXQQiG3tVvbNFQgVg2bQS8YGgxyw==",
+            "peer": true
         },
         "node_modules/webgl-context": {
             "version": "2.2.0",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "get-canvas-context": "^1.0.1"
             }
@@ -18403,13 +18646,15 @@
             "resolved": "https://registry.npmjs.org/world-calendars/-/world-calendars-1.0.4.tgz",
             "integrity": "sha512-VGRnLJS+xJmGDPodgJRnGIDwGu0s+Cr9V2HB3EzlDZ5n0qb8h5SJtGUEkjrphZYAglEiXZ6kiXdmk0H/h/uu/w==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "object-assign": "^4.1.0"
             }
         },
         "node_modules/wrappy": {
             "version": "1.0.2",
-            "license": "ISC"
+            "license": "ISC",
+            "peer": true
         },
         "node_modules/wsl-utils": {
             "version": "0.3.1",
@@ -18431,6 +18676,7 @@
         "node_modules/xtend": {
             "version": "4.0.2",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=0.4"
             }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,8 +4,8 @@
     "version": "0.0.0",
     "type": "module",
     "engines": {
-        "node": "^24.13.0",
-        "npm": "^11.6.2"
+        "node": "^24.14.0",
+        "npm": "^11.9.0"
     },
     "scripts": {
         "dev": "npm run generate:module-states-map && vite --host",


### PR DESCRIPTION
Seems like dependabot might be running updates on a lower version of npm, which caused a package lock change when running `npm install`. Might be caused due to npm running it's install on npm `<11.6.3` (see [here](https://github.com/npm/cli/issues/8690#issuecomment-3463552492))

Updated `engines` to specify npm `11.9`. Regenerated package-lock
