### PR TITLE
Fix tooltip positioning

### DIFF
--- a/frontend/src/lib/components/DenseIconButton/denseIconButton.tsx
+++ b/frontend/src/lib/components/DenseIconButton/denseIconButton.tsx
@@ -29,6 +29,38 @@ export type DenseIconButtonProps = {
     className?: string;
 };
 
+// NOTE: The wrapped EDS `Tooltip` clones its child and replaces the child's `ref`, reading the
+// original ref from `children.props.ref` (React 19 convention). In React 18, refs are not present
+// in `props`, so a ref passed through this component would be silently dropped. To work around
+// this, we read our forwarded ref via a regular prop on an inner forwardRef component and merge
+// it with whatever ref the Tooltip assigns via cloneElement.
+type InnerButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
+    outerButtonRef: React.ForwardedRef<HTMLButtonElement>;
+};
+
+const InnerButton = React.forwardRef<HTMLButtonElement, InnerButtonProps>(function InnerButton(
+    { outerButtonRef, ...rest },
+    tooltipRef,
+) {
+    const combinedRef = React.useCallback(
+        (el: HTMLButtonElement | null) => {
+            if (typeof tooltipRef === "function") {
+                tooltipRef(el);
+            } else if (tooltipRef) {
+                tooltipRef.current = el;
+            }
+            if (typeof outerButtonRef === "function") {
+                outerButtonRef(el);
+            } else if (outerButtonRef) {
+                outerButtonRef.current = el;
+            }
+        },
+        [tooltipRef, outerButtonRef],
+    );
+
+    return <button ref={combinedRef} {...rest} />;
+});
+
 export const DenseIconButton = React.forwardRef(function DenseIconButton(
     props: DenseIconButtonProps,
     ref: React.ForwardedRef<HTMLButtonElement>,
@@ -43,20 +75,20 @@ export const DenseIconButton = React.forwardRef(function DenseIconButton(
 
     return (
         <Tooltip title={props.title}>
-            <button
-                ref={ref}
+            <InnerButton
+                outerButtonRef={ref}
                 id={props.id}
                 className={resolveClassNames(props.className, "p-1 text-sm rounded-sm flex gap-1 items-center", {
                     [colorScheme + "text-gray-600 focus-visible:outline-1 hover:text-gray-900"]: !props.disabled,
                     "text-gray-300": props.disabled,
                 })}
                 disabled={props.disabled}
-                onClick={handleClick}
+                onClick={handleClick as unknown as React.MouseEventHandler<HTMLButtonElement>}
                 onPointerDown={props.onPointerDown}
                 onPointerUp={props.onPointerUp}
             >
                 {props.children}
-            </button>
+            </InnerButton>
         </Tooltip>
     );
 });


### PR DESCRIPTION
The deps update (#1586) bumped @equinor/eds-core-react from 0.48 to 2.4. The v2 Tooltip reads the anchor child's ref via children.props.ref (React 19 convention) and unconditionally overrides the child's ref through cloneElement. Since webviz is still on React 18 — where refs are not part of props — any ref forwarded into a Tooltip-wrapped child is silently dropped.

This broke DenseIconButton's forwarded ref, which caused ContextHelp's anchorRef.current to stay null and the popup to fall back to { top: 100, left: 100 } (upper-left of the viewport) instead of anchoring to the help button.

Fix: Wrap the internal button in DenseIconButton with a small inner forwardRef component that receives the outer ref via a plain prop (outerButtonRef) and merges it with the ref assigned by Tooltip.cloneElement. This bypasses the ref-replacement by routing the outer ref through props rather than the React ref channel.