### PR TITLE
Fix: Allow well visualization when surfaces are unavailable

### DIFF
--- a/frontend/src/modules/_shared/DataProviderFramework/dataProviders/implementations/DrilledWellboreTrajectoriesProvider.ts
+++ b/frontend/src/modules/_shared/DataProviderFramework/dataProviders/implementations/DrilledWellboreTrajectoriesProvider.ts
@@ -96,18 +96,6 @@ export class DrilledWellboreTrajectoriesProvider
             return false;
         }
 
-        if (getSetting(Setting.WELLBORE_DEPTH_FILTER_TYPE) === "surface_based") {
-            if (!getSetting(Setting.WELLBORE_DEPTH_FILTER_ATTRIBUTE)) {
-                return false;
-            }
-            if (!getSetting(Setting.WELLBORE_DEPTH_FORMATION_FILTER)?.topSurfaceName) {
-                return false;
-            }
-            if (getSetting(Setting.WELLBORE_DEPTH_FORMATION_FILTER)?.realizationNum === undefined) {
-                return false;
-            }
-        }
-
         return true;
     }
 
@@ -414,9 +402,13 @@ export class DrilledWellboreTrajectoriesProvider
             return [globalMin, globalMax, 1];
         });
 
-        settingAttributesUpdater(Setting.WELLBORE_DEPTH_FILTER_ATTRIBUTE, ({ getLocalSetting }) => {
+        settingAttributesUpdater(Setting.WELLBORE_DEPTH_FILTER_ATTRIBUTE, ({ getHelperDependency, getLocalSetting }) => {
             const filterType = getLocalSetting(Setting.WELLBORE_DEPTH_FILTER_TYPE);
+            const data = getHelperDependency(realizationSurfaceMetadataDep);
             return {
+                enabled: data?.surfaces.length
+                    ? true
+                    : { enabled: false, reason: "No surfaces available" },
                 visible: filterType === "surface_based",
             };
         });
@@ -441,9 +433,14 @@ export class DrilledWellboreTrajectoriesProvider
             return availableAttributes;
         });
 
-        settingAttributesUpdater(Setting.WELLBORE_DEPTH_FORMATION_FILTER, ({ getLocalSetting }) => {
+        settingAttributesUpdater(Setting.WELLBORE_DEPTH_FORMATION_FILTER, ({ getHelperDependency, getLocalSetting }) => {
             const filterType = getLocalSetting(Setting.WELLBORE_DEPTH_FILTER_TYPE);
+
+            const data = getHelperDependency(realizationSurfaceMetadataDep);
             return {
+                enabled: data?.surfaces.length
+                    ? true
+                    : { enabled: false, reason: "No surfaces available" },
                 visible: filterType === "surface_based",
             };
         });

--- a/frontend/src/modules/_shared/DataProviderFramework/settings/SettingRegistry/_registerAllSettings.ts
+++ b/frontend/src/modules/_shared/DataProviderFramework/settings/SettingRegistry/_registerAllSettings.ts
@@ -32,6 +32,7 @@ import { SliderRangeSetting } from "../implementations/SliderRangeSetting";
 import { StaticRotationSetting } from "../implementations/StaticRotationSetting";
 import { StatisticFunctionSetting } from "../implementations/StatisticFunctionSetting";
 import { TimeOrIntervalSetting } from "../implementations/TimeOrIntervalSetting";
+import { WellboreDepthFilterAttributeSetting } from "../implementations/WellboreDepthFilterAttributeSetting";
 import { WellboreDepthFilterSetting } from "../implementations/WellboreDepthFilterSetting";
 import { Setting } from "../settingsDefinitions";
 
@@ -145,7 +146,11 @@ SettingRegistry.registerSetting(Setting.WELLBORE_DEPTH_FILTER_TYPE, "Depth Filte
 });
 SettingRegistry.registerSetting(Setting.MD_RANGE, "MD Range", SliderRangeSetting);
 SettingRegistry.registerSetting(Setting.TVD_RANGE, "TVD Range", SliderRangeSetting);
-SettingRegistry.registerSetting(Setting.WELLBORE_DEPTH_FILTER_ATTRIBUTE, "Surface Attribute", DropdownStringSetting);
+SettingRegistry.registerSetting(
+    Setting.WELLBORE_DEPTH_FILTER_ATTRIBUTE,
+    "Surface Attribute",
+    WellboreDepthFilterAttributeSetting,
+);
 SettingRegistry.registerSetting(
     Setting.WELLBORE_DEPTH_FORMATION_FILTER,
     "Formation Filter",

--- a/frontend/src/modules/_shared/DataProviderFramework/settings/implementations/WellboreDepthFilterAttributeSetting.tsx
+++ b/frontend/src/modules/_shared/DataProviderFramework/settings/implementations/WellboreDepthFilterAttributeSetting.tsx
@@ -1,0 +1,22 @@
+import { DropdownStringSetting } from "./DropdownStringSetting";
+
+type ValueType = string | null;
+type ValueConstraintsType = string[];
+
+export class WellboreDepthFilterAttributeSetting extends DropdownStringSetting {
+    isValueValid(value: ValueType, valueConstraints: ValueConstraintsType): boolean {
+        if (valueConstraints.length === 0) {
+            return value === null;
+        }
+
+        return super.isValueValid(value, valueConstraints);
+    }
+
+    fixupValue(value: ValueType, valueConstraints: ValueConstraintsType): ValueType {
+        if (valueConstraints.length === 0) {
+            return null;
+        }
+
+        return super.fixupValue(value, valueConstraints);
+    }
+}

--- a/frontend/src/modules/_shared/DataProviderFramework/settings/implementations/WellboreDepthFilterSetting.tsx
+++ b/frontend/src/modules/_shared/DataProviderFramework/settings/implementations/WellboreDepthFilterSetting.tsx
@@ -13,9 +13,11 @@ type InternalValueType = SettingTypeDefinitions[Setting.WELLBORE_DEPTH_FORMATION
 type ExternalValueType = SettingTypeDefinitions[Setting.WELLBORE_DEPTH_FORMATION_FILTER]["externalValue"] | null;
 type ValueRangeType = SettingTypeDefinitions[Setting.WELLBORE_DEPTH_FORMATION_FILTER]["valueConstraints"] | null;
 
-export class WellboreDepthFilterSetting
-    implements CustomSettingImplementation<InternalValueType, ExternalValueType, ValueRangeType>
-{
+export class WellboreDepthFilterSetting implements CustomSettingImplementation<
+    InternalValueType,
+    ExternalValueType,
+    ValueRangeType
+> {
     valueConstraintsIntersectionReducerDefinition = {
         reducer: (accumulator: ValueRangeType, valueConstraints: ValueRangeType, index: number) => {
             if (index === 0) {
@@ -82,6 +84,10 @@ export class WellboreDepthFilterSetting
             return null;
         }
 
+        if (valueConstraints.surfaceNamesInStratOrder.length === 0) {
+            return null;
+        }
+
         if (currentValue === null) {
             return {
                 topSurfaceName: valueConstraints.surfaceNamesInStratOrder[0],
@@ -113,7 +119,15 @@ export class WellboreDepthFilterSetting
     }
 
     isValueValid(value: InternalValueType, valueConstraints: ValueRangeType): boolean {
-        if (value === null || valueConstraints === null) {
+        if (valueConstraints === null) {
+            return false;
+        }
+
+        if (valueConstraints.surfaceNamesInStratOrder.length === 0) {
+            return value === null;
+        }
+
+        if (value === null) {
             return false;
         }
 


### PR DESCRIPTION
Allow drilled wellbore trajectory layers to remain valid when realization surfaces are unavailable.

The surface-based depth filter now treats empty surface metadata as a valid disabled state, so the layer can still load trajectories without formation segments. The surface attribute and formation filter controls are disabled with a “No surfaces available” reason instead of making the whole layer invalid.
