### PR TITLE
[Bug]: Replace usage of `onChange` with `onValueChange` for numerical `Input`-component 

### DIFF
--- a/frontend/src/framework/components/ColorScaleSelector/colorScaleSelector.tsx
+++ b/frontend/src/framework/components/ColorScaleSelector/colorScaleSelector.tsx
@@ -203,18 +203,6 @@ function ColorScaleSelectorDialog(props: ColorScaleSelectorProps): React.ReactNo
         );
     }
 
-    function setNumSteps(numSteps: number) {
-        makeAndPropagateColorScale(
-            colorScaleSpecification.colorScale.getColorPalette(),
-            colorScaleSpecification.colorScale.getType(),
-            colorScaleSpecification.colorScale.getGradientType(),
-            colorScaleSpecification.colorScale.getMin(),
-            colorScaleSpecification.colorScale.getMax(),
-            numSteps,
-            colorScaleSpecification.colorScale.getDivMidPoint(),
-            colorScaleSpecification.areBoundariesUserDefined,
-        );
-    }
 
     const makeAndPropagateColorScale = React.useCallback(
         function makeAndPropagateColorScale(
@@ -246,6 +234,25 @@ function ColorScaleSelectorDialog(props: ColorScaleSelectorProps): React.ReactNo
         },
         [onChange],
     );
+
+    const handleNumStepsChange = React.useCallback(
+        function handleNumStepsChange(value: string) {
+            const numSteps = parseInt(value);
+
+            makeAndPropagateColorScale(
+            colorScaleSpecification.colorScale.getColorPalette(),
+            colorScaleSpecification.colorScale.getType(),
+            colorScaleSpecification.colorScale.getGradientType(),
+            colorScaleSpecification.colorScale.getMin(),
+            colorScaleSpecification.colorScale.getMax(),
+            numSteps,
+            colorScaleSpecification.colorScale.getDivMidPoint(),
+            colorScaleSpecification.areBoundariesUserDefined,
+        );
+        },
+        [colorScaleSpecification, makeAndPropagateColorScale],
+    );
+
 
     const handleMinMaxDivMidPointChange = React.useCallback(
         function handleMinMaxDivMidPointChange(min: number, max: number, divMidPoint?: number) {
@@ -307,7 +314,7 @@ function ColorScaleSelectorDialog(props: ColorScaleSelectorProps): React.ReactNo
                     <Input
                         type="number"
                         value={colorScaleSpecification.colorScale.getNumSteps()}
-                        onChange={(e) => setNumSteps(parseInt(e.target.value, 10))}
+                        onValueChange={handleNumStepsChange}
                         disabled={colorScaleSpecification.colorScale.getType() !== ColorScaleType.Discrete}
                         min={2}
                     />

--- a/frontend/src/framework/internal/components/RightSettingsPanel/private-components/colorPaletteSettings.tsx
+++ b/frontend/src/framework/internal/components/RightSettingsPanel/private-components/colorPaletteSettings.tsx
@@ -92,12 +92,7 @@ export const ColorPaletteSettings: React.FC<ColorPaletteSettingsProps> = (props)
                                 min={2}
                                 max={100}
                                 defaultValue={steps[ColorScaleDiscreteSteps.Sequential]}
-                                onChange={(e) =>
-                                    handleColorPaletteStepsChanged(
-                                        parseInt(e.target.value),
-                                        ColorScaleDiscreteSteps.Sequential,
-                                    )
-                                }
+                                onValueChange={(value:string)=> handleColorPaletteStepsChanged(parseInt(value), ColorScaleDiscreteSteps.Sequential)}
                             />
                         </Label>
                     </div>
@@ -127,12 +122,7 @@ export const ColorPaletteSettings: React.FC<ColorPaletteSettingsProps> = (props)
                                 min={2}
                                 max={100}
                                 defaultValue={steps[ColorScaleDiscreteSteps.Diverging]}
-                                onChange={(e) =>
-                                    handleColorPaletteStepsChanged(
-                                        parseInt(e.target.value),
-                                        ColorScaleDiscreteSteps.Diverging,
-                                    )
-                                }
+                                onValueChange={(value:string) => handleColorPaletteStepsChanged(parseInt(value), ColorScaleDiscreteSteps.Diverging)}
                             />
                         </Label>
                     </div>

--- a/frontend/src/lib/components/Input/input.tsx
+++ b/frontend/src/lib/components/Input/input.tsx
@@ -71,15 +71,15 @@ function InputComponent(props: InputProps, ref: React.ForwardedRef<HTMLDivElemen
 
     const clampNumberValue = React.useCallback(
         function clampNumberValue(val: unknown): number {
-            let newValue = 0;
-            if (!isNaN(parseFloat(val as string))) {
-                newValue = parseFloat((val as string) || "0");
-                if (props.min !== undefined) {
-                    newValue = Math.max(props.min, newValue);
-                }
-                if (props.max !== undefined) {
-                    newValue = Math.min(props.max, newValue);
-                }
+            const parsedValue = parseFloat(val as string);
+            let newValue = isNaN(parsedValue) ? 0 : parsedValue;
+
+            // Clamp to min/max if specified
+            if (props.min !== undefined) {
+                newValue = Math.max(props.min, newValue);
+            }
+            if (props.max !== undefined) {
+                newValue = Math.min(props.max, newValue);
             }
             return newValue;
         },

--- a/frontend/src/modules/Map/settings/settings.tsx
+++ b/frontend/src/modules/Map/settings/settings.tsx
@@ -182,9 +182,9 @@ export function MapSettings(props: ModuleSettingsProps<Interfaces>) {
         setAggregation(aggregation);
     }
 
-    function handleRealizationTextChanged(event: React.ChangeEvent<HTMLInputElement>) {
-        console.debug("handleRealizationTextChanged() " + event.target.value);
-        const realNum = parseInt(event.target.value, 10);
+    function handleRealizationTextChanged(value: string) {
+        console.debug("handleRealizationTextChanged() " + value);
+        const realNum = parseInt(value, 10);
         if (realNum >= 0) {
             setRealizationNum(realNum);
         }
@@ -221,7 +221,7 @@ export function MapSettings(props: ModuleSettingsProps<Interfaces>) {
     if (aggregation === null) {
         chooseRealizationElement = (
             <Label text="Realization:">
-                <Input type={"number"} value={realizationNum} onChange={handleRealizationTextChanged} />
+                <Input type={"number"} value={realizationNum} onValueChange={handleRealizationTextChanged} />
             </Label>
         );
     }

--- a/frontend/src/modules/MyModule/settings/settings.tsx
+++ b/frontend/src/modules/MyModule/settings/settings.tsx
@@ -96,14 +96,14 @@ export function Settings(props: ModuleSettingsProps<Interfaces>): React.ReactNod
                 />
             </Label>
             <Label text="Max">
-                <Input type="number" value={max} onChange={(e) => setMax(parseFloat(e.target.value))} />
+                <Input type="number" value={max} onValueChange={(value: string) => setMax(parseFloat(value))} />
             </Label>
             {gradientType === ColorScaleGradientType.Diverging && (
                 <Label text="Midpoint">
                     <Input
                         type="number"
                         value={divMidPoint}
-                        onChange={(e) => setDivMidPoint(parseFloat(e.target.value))}
+                        onValueChange={(value: string) => setDivMidPoint(parseFloat(value))}
                         min={0}
                         max={max}
                     />

--- a/frontend/src/modules/SimulationTimeSeries/settings/settings.tsx
+++ b/frontend/src/modules/SimulationTimeSeries/settings/settings.tsx
@@ -120,8 +120,8 @@ export function Settings(props: ModuleSettingsProps<Interfaces>) {
         setSubplotLimitDirection(newLimitDirection);
     }
 
-    function handleSubplotMaxDirectionElementsChange(event: React.ChangeEvent<HTMLInputElement>) {
-        setSubplotMaxDirectionElements(parseInt(event.target.value));
+    function handleSubplotMaxDirectionElementsChange(value: string) {
+        setSubplotMaxDirectionElements(parseInt(value, 10));
     }
 
     function handleGroupByChange(newValue: GroupBy) {
@@ -280,7 +280,7 @@ export function Settings(props: ModuleSettingsProps<Interfaces>) {
                             min={1}
                             max={12}
                             debounceTimeMs={150}
-                            onChange={handleSubplotMaxDirectionElementsChange}
+                            onValueChange={handleSubplotMaxDirectionElementsChange}
                         />
                     </div>
                 </Label>

--- a/frontend/src/modules/SubsurfaceMap/settings/settings.tsx
+++ b/frontend/src/modules/SubsurfaceMap/settings/settings.tsx
@@ -455,20 +455,20 @@ export function Settings({ settingsContext, workbenchSession, workbenchServices 
         setAggregation(aggregation);
     }
 
-    function handleRealizationTextChanged(event: React.ChangeEvent<HTMLInputElement>) {
-        const realNum = parseInt(event.target.value, 10);
+    function handleRealizationTextChanged(value: string) {
+        const realNum = parseInt(value, 10);
         if (realNum >= 0) {
             setRealizationNum(realNum);
         }
     }
-    function handleContourStartChange(event: React.ChangeEvent<HTMLInputElement>) {
-        const contourStart = parseInt(event.target.value, 10);
+    function handleContourStartChange(value: string) {
+        const contourStart = parseInt(value, 10);
         if (contourStart >= 0) {
             setContourStartValue(contourStart);
         }
     }
-    function handleContourIncChange(event: React.ChangeEvent<HTMLInputElement>) {
-        const contourInc = parseInt(event.target.value, 10);
+    function handleContourIncChange(value: string) {
+        const contourInc = parseInt(value, 10);
         if (contourInc > 0) {
             setContourIncValue(contourInc);
         }
@@ -503,7 +503,7 @@ export function Settings({ settingsContext, workbenchSession, workbenchServices 
                 />
                 {aggregation === null && (
                     <Label text="Realization:">
-                        <Input type={"number"} value={realizationNum} onChange={handleRealizationTextChanged} />
+                        <Input type={"number"} value={realizationNum} onValueChange={handleRealizationTextChanged} />
                     </Label>
                 )}
             </CollapsibleGroup>
@@ -717,7 +717,7 @@ export function Settings({ settingsContext, workbenchSession, workbenchServices 
                                                 className="text-xs"
                                                 type={"number"}
                                                 value={contourStartValue}
-                                                onChange={handleContourStartChange}
+                                                onValueChange={handleContourStartChange}
                                             />
                                         </div>
                                         <div className=" float-right">
@@ -725,7 +725,7 @@ export function Settings({ settingsContext, workbenchSession, workbenchServices 
                                                 className="text-xs"
                                                 type={"number"}
                                                 value={contourIncValue}
-                                                onChange={handleContourIncChange}
+                                                onValueChange={handleContourIncChange}
                                             />
                                         </div>
                                     </>

--- a/frontend/src/modules/_shared/DataProviderFramework/settings/implementations/FlowFilterSetting.tsx
+++ b/frontend/src/modules/_shared/DataProviderFramework/settings/implementations/FlowFilterSetting.tsx
@@ -384,15 +384,15 @@ function SliderNumberSettingComponent(props: SliderNumberSettingProps) {
     );
 
     const handleInputChange = React.useCallback(
-        function handleInputChange(event: React.ChangeEvent<HTMLInputElement>) {
-            let value = Number(event.target.value) * 1000;
+        function handleInputChange(value: string) {
+            let numericValue = Number(value) * 1000;
             const allowedValues = Array.from({ length: Math.floor((max - min) / step) + 1 }, (_, i) => min + i * step);
-            value = allowedValues.reduce((prev, curr) =>
-                Math.abs(curr - value) < Math.abs(prev - value) ? curr : prev,
+            numericValue = allowedValues.reduce((prev, curr) =>
+                Math.abs(curr - numericValue) < Math.abs(prev - numericValue) ? curr : prev,
             );
 
-            setLocalValue(value);
-            debouncedOnValueChange(value);
+            setLocalValue(numericValue);
+            debouncedOnValueChange(numericValue);
         },
         [debouncedOnValueChange, min, max, step],
     );
@@ -418,7 +418,7 @@ function SliderNumberSettingComponent(props: SliderNumberSettingProps) {
                     value={localValue / 1000}
                     min={min / 1000}
                     max={max / 1000}
-                    onChange={handleInputChange}
+                    onValueChange={handleInputChange}
                     endAdornment="K"
                     className="min-w-20"
                 />


### PR DESCRIPTION
Numerical input components should not trigger too eagerly, `onChange` emits on every input change, which can create invalid intermediate states when editing numerical values, especially Nan values when clearing the input.

`onValueChange` fires when loosing focus, and ensures value within min/max.

---

Closes: #1579
Closes: #1643