### PR TITLE
Prepare for using passwords stored in Azure KeyVault with Redis

### DIFF
--- a/backend_py/primary/primary/config.py
+++ b/backend_py/primary/primary/config.py
@@ -26,7 +26,7 @@ RESOURCE_SCOPES_DICT = {
     "ssdl": ["8b6e5eb9-edc8-4086-83cb-afa5cc185b23/user_impersonation"],
     "pdm": ["f2e415dc-d400-4cd4-a801-fa707138a49c/user_impersonation"],
 }
-REDIS_USER_SESSION_URL = "redis://redis-user-session:6379"
+REDIS_USER_SESSION_URL = "redis://redis-auth-store:6379"
 REDIS_CACHE_URL = "redis://redis-cache:6379"
 
 _is_on_radix_platform = is_running_on_radix_platform()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,7 +78,7 @@ services:
       - ./backend_py/user_grid3d_ri/user_grid3d_ri:/home/appuser/backend_py/user_grid3d_ri/user_grid3d_ri
       - ./backend_py/libs:/home/appuser/backend_py/libs
 
-  redis-user-session:
+  redis-auth-store:
     image: redis:7.2
     expose:
       - 6379

--- a/radixconfig.yml
+++ b/radixconfig.yml
@@ -163,13 +163,6 @@ spec:
       identity:
         azure:
           clientId: 900ed417-a860-4970-bd37-73b059ca6f0d
-      secretRefs:
-        azureKeyVaults:
-          - name: webviz
-            useAzureIdentity: true
-            items:
-              - name: WEBVIZ-REDIS-AUTH-STORE-PASSWORD
-                envVar: NOT_YET_IN_USE
       runAsUser: 999
       command: ["redis-server",  "--loglevel", "notice"]
       ports:
@@ -181,13 +174,6 @@ spec:
       identity:
         azure:
           clientId: 900ed417-a860-4970-bd37-73b059ca6f0d
-      secretRefs:
-        azureKeyVaults:
-          - name: webviz
-            useAzureIdentity: true
-            items:
-              - name: WEBVIZ-REDIS-CACHE-PASSWORD
-                envVar: NOT_YET_IN_USE
       runAsUser: 999
       # https://redis.io/docs/latest/operate/oss_and_stack/management/config/#configuring-redis-as-a-cache
       # maxmemory for redis must be aligned with component's requested memory, here 3gb vs 4gb

--- a/radixconfig.yml
+++ b/radixconfig.yml
@@ -158,8 +158,18 @@ spec:
           memory:
             value: 20
 
-    - name: redis-user-session
+    - name: redis-auth-store
       image: redis:7.2
+      identity:
+        azure:
+          clientId: 900ed417-a860-4970-bd37-73b059ca6f0d
+      secretRefs:
+        azureKeyVaults:
+          - name: webviz
+            useAzureIdentity: true
+            items:
+              - name: WEBVIZ-REDIS-AUTH-STORE-PASSWORD
+                envVar: NOT_YET_IN_USE
       runAsUser: 999
       command: ["redis-server",  "--loglevel", "notice"]
       ports:
@@ -168,6 +178,16 @@ spec:
 
     - name: redis-cache
       image: redis:7.2
+      identity:
+        azure:
+          clientId: 900ed417-a860-4970-bd37-73b059ca6f0d
+      secretRefs:
+        azureKeyVaults:
+          - name: webviz
+            useAzureIdentity: true
+            items:
+              - name: WEBVIZ-REDIS-CACHE-PASSWORD
+                envVar: NOT_YET_IN_USE
       runAsUser: 999
       # https://redis.io/docs/latest/operate/oss_and_stack/management/config/#configuring-redis-as-a-cache
       # maxmemory for redis must be aligned with component's requested memory, here 3gb vs 4gb


### PR DESCRIPTION
Configures `radixconfig.yml` so that secrets can be consumed by `redis-auth-store` and `redis-cache` components
Also renames the `redis-user-session` to `redis-auth-store`

Done so that we can configure workload identity in Radix/Azure before activating code that relies on the passwords.