### PR TITLE
Fix: Replace fixed sleep with curl retry to reliably wait for backend in API generation CI check

### DIFF
--- a/.github/workflows/webviz.yml
+++ b/.github/workflows/webviz.yml
@@ -79,6 +79,7 @@ jobs:
           CONTAINER_ID=$(docker run --detach -p 5000:5000 --env UVICORN_PORT=5000 --env WEBVIZ_SKIP_LIFESPAN_GENERATE_API_ONLY=true --env WEBVIZ_CLIENT_SECRET=0 --env WEBVIZ_SMDA_SUBSCRIPTION_KEY=0 --env WEBVIZ_VDS_HOST_ADDRESS=0 --env WEBVIZ_ENTERPRISE_SUBSCRIPTION_KEY=0 backend:latest)
           sleep 10  # Ensure the backend server is up and running exposing /openapi.json
           npm run generate:api --prefix ./frontend
+          docker logs $CONTAINER_ID
           docker stop $CONTAINER_ID
           git diff --exit-code ./frontend/src/api || exit 1
 

--- a/.github/workflows/webviz.yml
+++ b/.github/workflows/webviz.yml
@@ -77,7 +77,7 @@ jobs:
         run: |
           docker build -f ./backend_py/primary/Dockerfile -t backend:latest .
           CONTAINER_ID=$(docker run --detach -p 5000:5000 --env UVICORN_PORT=5000 --env WEBVIZ_SKIP_LIFESPAN_GENERATE_API_ONLY=true --env WEBVIZ_CLIENT_SECRET=0 --env WEBVIZ_SMDA_SUBSCRIPTION_KEY=0 --env WEBVIZ_VDS_HOST_ADDRESS=0 --env WEBVIZ_ENTERPRISE_SUBSCRIPTION_KEY=0 backend:latest)
-          # sleep 10  # Ensure the backend server is up and running exposing /openapi.json
+          sleep 10  # Ensure the backend server is up and running exposing /openapi.json
           curl --retry 10 --retry-delay 2 --retry-connrefused --retry-all-errors -f http://localhost:5000/alive
           npm run generate:api --prefix ./frontend
           docker logs $CONTAINER_ID

--- a/.github/workflows/webviz.yml
+++ b/.github/workflows/webviz.yml
@@ -77,7 +77,8 @@ jobs:
         run: |
           docker build -f ./backend_py/primary/Dockerfile -t backend:latest .
           CONTAINER_ID=$(docker run --detach -p 5000:5000 --env UVICORN_PORT=5000 --env WEBVIZ_SKIP_LIFESPAN_GENERATE_API_ONLY=true --env WEBVIZ_CLIENT_SECRET=0 --env WEBVIZ_SMDA_SUBSCRIPTION_KEY=0 --env WEBVIZ_VDS_HOST_ADDRESS=0 --env WEBVIZ_ENTERPRISE_SUBSCRIPTION_KEY=0 backend:latest)
-          sleep 10  # Ensure the backend server is up and running exposing /openapi.json
+          # sleep 10  # Ensure the backend server is up and running exposing /openapi.json
+          curl --retry 10 --retry-delay 2 --retry-connrefused --retry-all-errors -f http://localhost:5000/alive
           npm run generate:api --prefix ./frontend
           docker logs $CONTAINER_ID
           docker stop $CONTAINER_ID

--- a/backend_py/primary/primary/main.py
+++ b/backend_py/primary/primary/main.py
@@ -124,6 +124,9 @@ async def lifespan_handler_async(_fastapi_app: FastAPI) -> AsyncIterator[None]:
 # This allows us to import this module and access the app object without running the lifespan handler,
 # which may be desirable in certain contexts such as API code generation.
 if os.getenv("WEBVIZ_SKIP_LIFESPAN_GENERATE_API_ONLY") is not None:
+    LOGGER.warning(
+        "WEBVIZ_SKIP_LIFESPAN_GENERATE_API_ONLY is set to true, skipping lifespan handler and using None instead. This may lead to issues if the app is run without a proper lifespan handler, so ensure this env variable is only set in contexts where the app will not be run (e.g. API code generation)."
+    )
     lifespan_handler_async = None  # type: ignore[assignment]
 
 app = FastAPI(

--- a/backend_py/primary/primary/main.py
+++ b/backend_py/primary/primary/main.py
@@ -124,9 +124,6 @@ async def lifespan_handler_async(_fastapi_app: FastAPI) -> AsyncIterator[None]:
 # This allows us to import this module and access the app object without running the lifespan handler,
 # which may be desirable in certain contexts such as API code generation.
 if os.getenv("WEBVIZ_SKIP_LIFESPAN_GENERATE_API_ONLY") is not None:
-    LOGGER.warning(
-        "WEBVIZ_SKIP_LIFESPAN_GENERATE_API_ONLY is set to true, skipping lifespan handler and using None instead. This may lead to issues if the app is run without a proper lifespan handler, so ensure this env variable is only set in contexts where the app will not be run (e.g. API code generation)."
-    )
     lifespan_handler_async = None  # type: ignore[assignment]
 
 app = FastAPI(


### PR DESCRIPTION
The "Check auto-generated frontend code is in sync with backend" CI step was intermittently failing with an HTTP error from `npm run generate:api`. A possible cause might have been a race condition: the backend startup includes a synchronous outbound HTTP call at import time (`config.py`) whose latency varies in CI and based on SUMO load, meaning the fixed `sleep 10` was sometimes not enough.

- Replace the fixed `sleep 10` with `curl --retry` to poll `/alive` until the server is actually ready, rather than assuming it's up after an arbitrary delay
- Keep the initial `sleep 10` as a baseline to avoid hammering the port before the container process has started at all
- Add `docker logs` after the generate step so backend errors are visible in CI output when the step fails