### PR TITLE
Use a trap to output docker logs on exit

### DIFF
--- a/.github/workflows/webviz.yml
+++ b/.github/workflows/webviz.yml
@@ -77,11 +77,10 @@ jobs:
         run: |
           docker build -f ./backend_py/primary/Dockerfile -t backend:latest .
           CONTAINER_ID=$(docker run --detach -p 5000:5000 --env UVICORN_PORT=5000 --env WEBVIZ_SKIP_LIFESPAN_GENERATE_API_ONLY=true --env WEBVIZ_CLIENT_SECRET=0 --env WEBVIZ_SMDA_SUBSCRIPTION_KEY=0 --env WEBVIZ_VDS_HOST_ADDRESS=0 --env WEBVIZ_ENTERPRISE_SUBSCRIPTION_KEY=0 --env WEBVIZ_REDIS_AUTH_STORE_PASSWORD=0 --env WEBVIZ_REDIS_CACHE_PASSWORD=0  backend:latest)
+          trap "echo '--- Trap showing Docker container logs ---'; docker logs $CONTAINER_ID; docker stop $CONTAINER_ID" EXIT
           sleep 10  # Ensure the backend server is up and running exposing /openapi.json
           curl --retry 10 --retry-delay 2 --retry-connrefused --retry-all-errors -f http://localhost:5000/alive
           npm run generate:api --prefix ./frontend
-          docker logs $CONTAINER_ID
-          docker stop $CONTAINER_ID
           git diff --exit-code ./frontend/src/api || exit 1
 
       - name: 🕵️ Check ModuleSerializedStateMap is up to date


### PR DESCRIPTION
This PR adds a `trap` on `EXIT` that prints the container logs and stops the container whenever the CI step exits, regardless of success or failure. 

When checking that auto-generated frontend code is in sync with the backend, the CI step starts a Docker container and waits for it to become healthy via curl. If the container failed to start (e.g. due to a crash at startup), the curl health check would fail and the step would exit immediately before docker logs was reached, leaving no trace of why the container failed.

