### PR TITLE
[EDS] Slider component fixes

### DIFF
--- a/frontend/.storybook/preview.tsx
+++ b/frontend/.storybook/preview.tsx
@@ -11,7 +11,9 @@ import type { Preview } from "@storybook/react";
 import { DarkModeButton } from "../src/framework/internal/components/DarkModeButton";
 import { DensityModeToggle } from "../src/framework/internal/components/DensityModeToggle";
 
+// @ts-expect-error -- CSS imports are not typed
 import "../src/styles/index.css";
+// @ts-expect-error -- CSS imports are not typed
 import "./preview.css";
 
 const theme = createTheme({
@@ -33,7 +35,7 @@ const preview: Preview = {
                 {/* TODO: Dark-mode buttons overlap content too much in doc-view. Hide it for now*/}
                 {ctx.viewMode !== "docs" && (
                     <div
-                        className="bg-canvas gap-horizontal-sm px-horizontal-2xs py-horizontal-3xs fixed top-1 right-1 flex rounded"
+                        className="bg-canvas gap-horizontal-sm px-2xs py-3xs fixed top-1 right-1 flex rounded"
                         style={{
                             position: "fixed",
                             top: "1rem",
@@ -44,7 +46,7 @@ const preview: Preview = {
                         <DensityModeToggle />
                     </div>
                 )}
-                <div className="bg-surface border-neutral-subtle py-horizontal-2xl px-horizontal-xl h-full w-full rounded border">
+                <div className="bg-surface border-neutral-subtle py-2xl px-xl h-full w-full rounded border">
                     <Story />
                 </div>
             </>

--- a/frontend/src/lib/hooks/useOptInControlledValue.ts
+++ b/frontend/src/lib/hooks/useOptInControlledValue.ts
@@ -21,7 +21,7 @@ export function useOptInControlledValue<TValue>(
 
     const setValue = React.useCallback(
         function setValue(newValue: TValue) {
-            if (isControlled) setLocalValue(newValue);
+            if (!isControlled) setLocalValue(newValue);
             onValueChange?.(newValue);
         },
         [isControlled, onValueChange],

--- a/frontend/src/lib/newComponents/Button/_components/button.tsx
+++ b/frontend/src/lib/newComponents/Button/_components/button.tsx
@@ -95,6 +95,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(function 
             {...getDataAttributesForSelectableSize(size, true)}
             style={{
                 minHeight: "calc(var(--eds-selectable-space-vertical) * 2 + round(1cap , 4px))",
+                ...baseProps.style,
             }}
             className={resolveClassNames(
                 props.layoutClassName,

--- a/frontend/src/lib/newComponents/Menu/_components/group.tsx
+++ b/frontend/src/lib/newComponents/Menu/_components/group.tsx
@@ -15,7 +15,7 @@ function GroupComponent(props: MenuGroupProps, ref: React.ForwardedRef<HTMLDivEl
     const groupDepth = React.useContext(GroupDepthContext);
 
     return (
-        <MenuBase.Group {...baseProps} ref={ref} style={{ paddingLeft: `${groupDepth}rem` }}>
+        <MenuBase.Group {...baseProps} ref={ref} style={{ paddingLeft: `${groupDepth}rem`, ...baseProps.style }}>
             <GroupDepthContext.Provider value={groupDepth + 1}>{props.children}</GroupDepthContext.Provider>
         </MenuBase.Group>
     );

--- a/frontend/src/lib/newComponents/Slider/Slider.stories.tsx
+++ b/frontend/src/lib/newComponents/Slider/Slider.stories.tsx
@@ -99,26 +99,27 @@ export const Marks: Story = {
     argTypes: {
         markerLabels: {
             control: "radio",
-            options: [false, true, "(v) => `${v}%`", "(_, i) => (i % 2 === 0 ? v : null)"],
+            options: [false, true, "(v) => `${v}%`", "(v, i) => (i % 2 === 0 ? v : null)"],
         },
     },
     render: (args) => {
         let markerLabels = args.markerLabels as
             | SliderProps["markerLabels"]
             | "(v) => `${v}%`"
-            | "(_, i) => (i % 2 === 0 ? v : null)";
+            | "(v, i) => (i % 2 === 0 ? v : null)";
 
         if (markerLabels === "(v) => `${v}%`") {
             markerLabels = (v: number) => `${v}%`;
         }
 
-        if (markerLabels === "(_, i) => (i % 2 === 0 ? v : null)") {
+        if (markerLabels === "(v, i) => (i % 2 === 0 ? v : null)") {
             markerLabels = (v: number, i: number) => (i % 2 === 0 ? v : null);
         }
 
         return (
             <div className="gap-y-lg flex flex-col">
                 <Slider defaultValue={20} {...args} markerLabels={markerLabels} />
+                <Slider defaultValue={[20, 80]} {...args} markerLabels={markerLabels} />
             </div>
         );
     },

--- a/frontend/src/lib/newComponents/Slider/Slider.stories.tsx
+++ b/frontend/src/lib/newComponents/Slider/Slider.stories.tsx
@@ -14,6 +14,13 @@ const meta: Meta<typeof Slider> = {
     component: Slider,
     parameters: {
         layout: "centered",
+        docs: {
+            description: {
+                component: `
+The \`Slider\` component allows users to select a value or range of values along a track by dragging a thumb. It supports both single-value and range selection, as well as various customization options for appearance and behavior. When explicitly using a singular value, the emitted change events will match the value type (and vice versa for dual sliders)
+                `,
+            },
+        },
     },
     decorators: [
         (Story) => (
@@ -56,6 +63,49 @@ export const Default: Story = {
     ),
 };
 
+export const Marks: Story = {
+    args: { markers: [10, 20, 40, 60, 80], snapToMarkers: true, markerLabels: true },
+    argTypes: {
+        markerLabels: {
+            control: "radio",
+            options: [false, true, "(v) => `${v}%`", "(v, i) => (i % 2 === 0 ? v : null)"],
+        },
+    },
+    parameters: {
+        docs: {
+            description: {
+                story: `
+Marks (or ticks) consist of three properties: \`markers\`, \`snapToMarkers\`, and \`markerLabels\`.
+- The \`markers\` prop can be used to define an assorted list of slider points that should show a marker. The slider will *always* have marks at the \`min\` and \`max\` values.
+- The \`snapToMarkers\` prop makes the slider thumb snap to the closest marker when dragged, or to the next/previous value when changing the value with keyboard inputs
+- The \`markerLabels\` prop can be used to show text labels underneath each marker. Labels can be clicked to quickly snap the slider to the marked value. Set it to \`true\` to just show the marker values directly, or provide a custom formatting function to render custom labels.	                
+`,
+            },
+        },
+    },
+    render: (args) => {
+        let markerLabels = args.markerLabels as
+            | SliderProps["markerLabels"]
+            | "(v) => `${v}%`"
+            | "(v, i) => (i % 2 === 0 ? v : null)";
+
+        if (markerLabels === "(v) => `${v}%`") {
+            markerLabels = (v: number) => `${v}%`;
+        }
+
+        if (markerLabels === "(v, i) => (i % 2 === 0 ? v : null)") {
+            markerLabels = (v: number, i: number) => (i % 2 === 0 ? v : null);
+        }
+
+        return (
+            <div className="gap-y-lg flex flex-col">
+                <Slider {...args} defaultValue={20} markerLabels={markerLabels} />
+                <Slider {...args} defaultValue={[20, 80]} markerLabels={markerLabels} />
+            </div>
+        );
+    },
+};
+
 export const Disabled: Story = {
     args: { disabled: true },
     render: (args) => (
@@ -92,37 +142,6 @@ export const Size: Story = {
             <Slider defaultValue={75} valueLabelDisplay="always" {...args} size="large" />
         </div>
     ),
-};
-
-export const Marks: Story = {
-    args: { markers: [10, 20, 40, 60, 80], snapToMarkers: true, markerLabels: true },
-    argTypes: {
-        markerLabels: {
-            control: "radio",
-            options: [false, true, "(v) => `${v}%`", "(v, i) => (i % 2 === 0 ? v : null)"],
-        },
-    },
-    render: (args) => {
-        let markerLabels = args.markerLabels as
-            | SliderProps["markerLabels"]
-            | "(v) => `${v}%`"
-            | "(v, i) => (i % 2 === 0 ? v : null)";
-
-        if (markerLabels === "(v) => `${v}%`") {
-            markerLabels = (v: number) => `${v}%`;
-        }
-
-        if (markerLabels === "(v, i) => (i % 2 === 0 ? v : null)") {
-            markerLabels = (v: number, i: number) => (i % 2 === 0 ? v : null);
-        }
-
-        return (
-            <div className="gap-y-lg flex flex-col">
-                <Slider defaultValue={20} {...args} markerLabels={markerLabels} />
-                <Slider defaultValue={[20, 80]} {...args} markerLabels={markerLabels} />
-            </div>
-        );
-    },
 };
 
 export const Controlled: Story = {

--- a/frontend/src/lib/newComponents/Slider/Slider.stories.tsx
+++ b/frontend/src/lib/newComponents/Slider/Slider.stories.tsx
@@ -78,7 +78,7 @@ export const Marks: Story = {
 Marks (or ticks) consist of three properties: \`markers\`, \`snapToMarkers\`, and \`markerLabels\`.
 - The \`markers\` prop can be used to define an assorted list of slider points that should show a marker. The slider will *always* have marks at the \`min\` and \`max\` values.
 - The \`snapToMarkers\` prop makes the slider thumb snap to the closest marker when dragged, or to the next/previous value when changing the value with keyboard inputs
-- The \`markerLabels\` prop can be used to show text labels underneath each marker. Labels can be clicked to quickly snap the slider to the marked value. Set it to \`true\` to just show the marker values directly, or provide a custom formatting function to render custom labels.	                
+- The \`markerLabels\` prop can be used to show text labels underneath each marker. Labels can be clicked to quickly snap the slider to the marked value. Set it to \`true\` to just show the marker values directly, or provide a custom formatting function to render custom labels.
 `,
             },
         },

--- a/frontend/src/lib/newComponents/Slider/Slider.stories.tsx
+++ b/frontend/src/lib/newComponents/Slider/Slider.stories.tsx
@@ -23,12 +23,22 @@ const meta: Meta<typeof Slider> = {
         ),
     ],
     tags: ["autodocs"],
+    args: {
+        markers: [],
+    },
     argTypes: {
+        thumbCollisionBehavior: {
+            control: "inline-radio",
+            options: ["push", "swap", "none"],
+        },
         disabled: {
             control: "boolean",
         },
         step: {
             control: "number",
+        },
+        markerLabels: {
+            control: "boolean",
         },
     },
 };
@@ -84,12 +94,40 @@ export const Size: Story = {
     ),
 };
 
+export const Marks: Story = {
+    args: { markers: [10, 20, 40, 60, 80], snapToMarkers: true, markerLabels: true },
+    argTypes: {
+        markerLabels: {
+            control: "radio",
+            options: [false, true, "(v) => `${v}%`", "(_, i) => (i % 2 === 0 ? v : null)"],
+        },
+    },
+    render: (args) => {
+        let markerLabels = args.markerLabels as
+            | SliderProps["markerLabels"]
+            | "(v) => `${v}%`"
+            | "(_, i) => (i % 2 === 0 ? v : null)";
+
+        if (markerLabels === "(v) => `${v}%`") {
+            markerLabels = (v: number) => `${v}%`;
+        }
+
+        if (markerLabels === "(_, i) => (i % 2 === 0 ? v : null)") {
+            markerLabels = (v: number, i: number) => (i % 2 === 0 ? v : null);
+        }
+
+        return (
+            <div className="gap-y-lg flex flex-col">
+                <Slider defaultValue={20} {...args} markerLabels={markerLabels} />
+            </div>
+        );
+    },
+};
+
 export const Controlled: Story = {
     argTypes: { min: { control: "number" }, max: { control: "number" } },
     args: { min: 0, max: 100 },
     render: function ControlledStoryComp(args) {
-        // const [, ] = React.useState<>()
-
         const [lockMin, setLockMin] = React.useState(false);
         const [lockMax, setLockMax] = React.useState(true);
 

--- a/frontend/src/lib/newComponents/Slider/slider.tsx
+++ b/frontend/src/lib/newComponents/Slider/slider.tsx
@@ -9,6 +9,7 @@ import { clamp, clone, isEqual } from "lodash";
 import { Key } from "ts-key-enum";
 
 import { useElementSize } from "@lib/hooks/useElementSize";
+import { useOptInControlledValue } from "@lib/hooks/useOptInControlledValue";
 import { resolveClassNames } from "@lib/utils/resolveClassNames";
 
 import { useComponentSize } from "../_shared/contexts/componentSizeContext";
@@ -151,6 +152,7 @@ function isDualSliderValue(value: number | readonly number[]): value is readonly
 }
 
 function useLockState(props: {
+    isDualSlider: boolean;
     showMinLock: boolean;
     showMaxLock: boolean;
     minLocked?: boolean;
@@ -160,39 +162,44 @@ function useLockState(props: {
     onMinLockedChange?: (locked: boolean) => void;
     onMaxLockedChange?: (locked: boolean) => void;
 }) {
-    const [minLockedState, setMinLockedState] = React.useState(props.defaultMinLocked ?? false);
-    const [maxLockedState, setMaxLockedState] = React.useState(props.defaultMaxLocked ?? false);
-
-    const minLocked = props.minLocked ?? minLockedState;
-    const maxLocked = props.maxLocked ?? maxLockedState;
+    const [internalMinLocked, internalSetMinLocked] = useOptInControlledValue(
+        props.defaultMinLocked ?? false,
+        props.minLocked,
+        props.onMinLockedChange,
+    );
+    const [internalMaxLocked, internalSetMaxLocked] = useOptInControlledValue(
+        props.defaultMaxLocked ?? false,
+        props.maxLocked,
+        props.onMaxLockedChange,
+    );
 
     const setMinLocked = React.useCallback(
         (locked: boolean) => {
             if (!props.showMinLock) return;
 
-            if (props.minLocked === undefined) {
-                setMinLockedState(locked);
+            internalSetMinLocked(locked);
+            if (locked && props.isDualSlider) {
+                internalSetMaxLocked(false);
             }
-            props.onMinLockedChange?.(locked);
         },
-        [props],
+        [internalSetMaxLocked, internalSetMinLocked, props.isDualSlider, props.showMinLock],
     );
 
     const setMaxLocked = React.useCallback(
         (locked: boolean) => {
             if (!props.showMaxLock) return;
 
-            if (props.maxLocked === undefined) {
-                setMaxLockedState(locked);
+            internalSetMaxLocked(locked);
+            if (locked && props.isDualSlider) {
+                internalSetMinLocked(false);
             }
-            props.onMaxLockedChange?.(locked);
         },
-        [props],
+        [internalSetMaxLocked, internalSetMinLocked, props.isDualSlider, props.showMaxLock],
     );
 
     return {
-        minLocked,
-        maxLocked,
+        minLocked: internalMinLocked,
+        maxLocked: internalMaxLocked,
         setMinLocked,
         setMaxLocked,
     };
@@ -326,13 +333,23 @@ function SliderComponent(props: SliderProps, ref: React.ForwardedRef<HTMLDivElem
     const minGutterDotRef = React.useRef<HTMLDivElement | null>(null);
     const maxGutterDotRef = React.useRef<HTMLDivElement | null>(null);
 
+    const [internalValue, setInternalValue] = React.useState(defaultedProps.value ?? defaultedProps.defaultValue ?? 0);
     const [prevMin, setPrevMin] = React.useState(defaultedProps.min);
     const [prevMax, setPrevMax] = React.useState(defaultedProps.max);
+
+    const [isHovered, setIsHovered] = React.useState(false);
+    const [isFocused, setIsFocused] = React.useState(false);
+    const [isDragging, setIsDragging] = React.useState(false);
 
     const showMinLock = [true, "both", "min"].includes(defaultedProps.showRangeLocks);
     const showMaxLock = [true, "both", "max"].includes(defaultedProps.showRangeLocks);
 
+    const allMarkers = [defaultedProps.min, ...defaultedProps.markers, defaultedProps.max];
+    const isDualSlider = Array.isArray(internalValue);
+    const getThumbAriaLabel = defaultedProps.thumbAriaLabel ? getThumbAriaLabelFunc : undefined;
+
     const { minLocked, maxLocked, setMinLocked, setMaxLocked } = useLockState({
+        isDualSlider,
         showMinLock,
         showMaxLock,
         minLocked: props.minLocked,
@@ -343,17 +360,7 @@ function SliderComponent(props: SliderProps, ref: React.ForwardedRef<HTMLDivElem
         onMaxLockedChange: props.onMaxLockedChange,
     });
 
-    const [isHovered, setIsHovered] = React.useState(false);
-    const [isFocused, setIsFocused] = React.useState(false);
-    const [isDragging, setIsDragging] = React.useState(false);
-
-    const [internalValue, setInternalValue] = React.useState(defaultedProps.value ?? defaultedProps.defaultValue ?? 0);
-
     const wrapperSize = useElementSize(wrapperRef);
-
-    const allMarkers = [defaultedProps.min, ...defaultedProps.markers, defaultedProps.max];
-    const isDualSlider = Array.isArray(internalValue);
-    const getThumbAriaLabel = defaultedProps.thumbAriaLabel ? getThumbAriaLabelFunc : undefined;
 
     if (props.value !== undefined && props.value !== internalValue) {
         setInternalValue(props.value);

--- a/frontend/src/lib/newComponents/Slider/slider.tsx
+++ b/frontend/src/lib/newComponents/Slider/slider.tsx
@@ -18,8 +18,16 @@ import { resolveWrapperProps, type ComponentWrapperProps } from "../_shared/util
 import { Button } from "../Button";
 import { Typography } from "../Typography";
 
+type SnapTarget = "nearest" | "next" | "prev";
+
 const TRACK_CLASS_NAME = "not-data-disabled:group-hover:bg-neutral-hover data-dragging:bg-neutral-hover bg-canvas";
 const INDICATOR_CLASS_NAME = "bg-accent-strong data-disabled:bg-disabled";
+const TRACK_HEIGHT_CLASS_NAMES = {
+    // Same size for small and default, as h-0.5 seems way to small
+    small: "h-1",
+    default: "h-1",
+    large: "h-1.5",
+} as const;
 
 export type SliderChangeEventDetails =
     | SliderBase.Root.ChangeEventDetails
@@ -112,7 +120,7 @@ export type SliderProps<TValue extends number | readonly number[] = number | rea
 
     /**
      * Display the value of each marker below them.
-     * A function can be provided for further customization. Returning an empty node (null, false, etc) will fully remove the label */
+     * A function can be provided for further customization. Returning an empty node (null, false, etc) or an empty string will fully remove the label */
     markerLabels?: boolean | ((markerValue: number, index: number) => React.ReactNode);
 
     /**
@@ -217,7 +225,6 @@ function SliderComponent(
     }, [defaultedProps.markers, defaultedProps.max, defaultedProps.min]);
 
     const isDualSlider = Array.isArray(internalValue);
-    const getThumbAriaLabel = defaultedProps.thumbAriaLabel ? getThumbAriaLabelFunc : undefined;
 
     const { minLocked, maxLocked, setMinLocked, setMaxLocked } = useLockState({
         isDualSlider,
@@ -237,11 +244,17 @@ function SliderComponent(
         setInternalValue(props.value);
     }
 
-    function getThumbAriaLabelFunc(index: number) {
-        if (!defaultedProps.thumbAriaLabel) return "";
-        if (!Array.isArray(defaultedProps.thumbAriaLabel)) return defaultedProps.thumbAriaLabel;
-        return defaultedProps.thumbAriaLabel[index];
-    }
+    const getThumbAriaLabelFunc = React.useCallback(
+        function getThumbAriaLabelFunc(index: number) {
+            if (!defaultedProps.thumbAriaLabel) return "";
+            if (!Array.isArray(defaultedProps.thumbAriaLabel)) return defaultedProps.thumbAriaLabel;
+            return defaultedProps.thumbAriaLabel[index];
+        },
+        [defaultedProps.thumbAriaLabel],
+    );
+
+    // To preserve built-in base-ui defaults, we only pass a function to the thumbs if any thumb-labels were configured
+    const getThumbAriaLabel = defaultedProps.thumbAriaLabel ? getThumbAriaLabelFunc : undefined;
 
     const updateValue = React.useCallback(
         function updateValue(newValue: number | number[], eventDetails: SliderChangeEventDetails, commit?: boolean) {
@@ -424,14 +437,10 @@ function SliderComponent(
                         )}
 
                         <SliderBase.Track
-                            className={resolveClassNames(
-                                "w-full rounded-lg",
-                                resolveTrackHeightClassName(componentSize),
-                                {
-                                    [INDICATOR_CLASS_NAME]: props.inverted,
-                                    [TRACK_CLASS_NAME]: !props.inverted,
-                                },
-                            )}
+                            className={resolveClassNames("w-full rounded-lg", TRACK_HEIGHT_CLASS_NAMES[componentSize], {
+                                [INDICATOR_CLASS_NAME]: props.inverted,
+                                [TRACK_CLASS_NAME]: !props.inverted,
+                            })}
                         >
                             {!props.noIndicator && (
                                 <SliderBase.Indicator
@@ -703,7 +712,7 @@ const SliderLockGutter = React.forwardRef<HTMLDivElement, SliderLockGutterProps>
             />
 
             <div
-                className={resolveClassNames("w-full", resolveTrackHeightClassName(props.size))}
+                className={resolveClassNames("w-full", TRACK_HEIGHT_CLASS_NAMES[props.size])}
                 style={{
                     // @ts-expect-error -- css typing doesn't accept variables
                     "--gutter-color": getGutterColorVariable(isDisabled, isFilled, isDragging),
@@ -850,38 +859,41 @@ function useLockedValueUpdate(props: {
 
     const { onValueChange } = props;
 
-    React.useEffect(() => {
-        const value = props.value as number | number[];
-        const isDualValue = isDualSliderValue(value);
-        let newValue: number | number[] | null = null;
+    React.useEffect(
+        function clampToToggledLocksEffec() {
+            const value = props.value as number | number[];
+            const isDualValue = isDualSliderValue(value);
+            let newValue: number | number[] | null = null;
 
-        // Min lock was just enabled
-        if (props.minLocked && !prevMinLocked.current) {
-            if (isDualValue) {
-                newValue = [props.min, value[1]];
-            } else {
-                newValue = props.min;
+            // Min lock was just enabled
+            if (props.minLocked && !prevMinLocked.current) {
+                if (isDualValue) {
+                    newValue = [props.min, value[1]];
+                } else {
+                    newValue = props.min;
+                }
             }
-        }
 
-        // Max lock was just enabled
-        if (props.maxLocked && !prevMaxLocked.current) {
-            if (isDualValue && newValue !== null) {
-                newValue = [(newValue as number[])[0], props.max];
-            } else if (isDualValue) {
-                newValue = [value[0], props.max];
-            } else {
-                newValue = props.max;
+            // Max lock was just enabled
+            if (props.maxLocked && !prevMaxLocked.current) {
+                if (isDualValue && newValue !== null) {
+                    newValue = [(newValue as number[])[0], props.max];
+                } else if (isDualValue) {
+                    newValue = [value[0], props.max];
+                } else {
+                    newValue = props.max;
+                }
             }
-        }
 
-        prevMinLocked.current = props.minLocked;
-        prevMaxLocked.current = props.maxLocked;
+            prevMinLocked.current = props.minLocked;
+            prevMaxLocked.current = props.maxLocked;
 
-        if (newValue !== null) {
-            onValueChange?.(newValue, { reason: "range-locked" }, true);
-        }
-    }, [props.minLocked, props.maxLocked, props.min, props.max, props.value, onValueChange]);
+            if (newValue !== null) {
+                onValueChange?.(newValue, { reason: "range-locked" }, true);
+            }
+        },
+        [props.minLocked, props.maxLocked, props.min, props.max, props.value, onValueChange],
+    );
 }
 
 function useUnlockOnValueChange(props: {
@@ -897,35 +909,27 @@ function useUnlockOnValueChange(props: {
     const { setMinLocked, setMaxLocked } = props;
     const prevValue = React.useRef(props.value);
 
-    React.useEffect(() => {
-        // Only check if value actually changed
-        if (isEqual(prevValue.current, props.value)) return;
+    React.useEffect(
+        function unlockSliderLocksEffect() {
+            // Only check if value actually changed
+            if (isEqual(prevValue.current, props.value)) return;
 
-        const lowerValue = isDualSliderValue(props.value) ? props.value[0] : props.value;
-        const upperValue = isDualSliderValue(props.value) ? props.value[1] : props.value;
+            const lowerValue = isDualSliderValue(props.value) ? props.value[0] : props.value;
+            const upperValue = isDualSliderValue(props.value) ? props.value[1] : props.value;
 
-        if (props.minLocked && lowerValue > props.min) {
-            setMinLocked(false);
-        }
+            if (props.minLocked && lowerValue > props.min) {
+                setMinLocked(false);
+            }
 
-        if (props.maxLocked && upperValue < props.max) {
-            setMaxLocked(false);
-        }
+            if (props.maxLocked && upperValue < props.max) {
+                setMaxLocked(false);
+            }
 
-        prevValue.current = props.value;
-    }, [props.max, props.maxLocked, props.min, props.minLocked, props.value, setMaxLocked, setMinLocked]);
+            prevValue.current = props.value;
+        },
+        [props.max, props.maxLocked, props.min, props.minLocked, props.value, setMaxLocked, setMinLocked],
+    );
 }
-
-function resolveTrackHeightClassName(size: SelectableSize) {
-    return {
-        // Same size for small and default, as h-0.5 seems way to small
-        small: "h-1",
-        default: "h-1",
-        large: "h-1.5",
-    }[size];
-}
-
-type SnapTarget = "nearest" | "next" | "prev";
 
 function getSnappedValue(sortedMarkers: number[], value: number | number[], target: SnapTarget): number | number[] {
     if (Array.isArray(value)) {

--- a/frontend/src/lib/newComponents/Slider/slider.tsx
+++ b/frontend/src/lib/newComponents/Slider/slider.tsx
@@ -5,7 +5,7 @@ import { Tooltip } from "@base-ui/react";
 import type { SliderRootProps as SliderRootBaseProps, SliderRootState } from "@base-ui/react/slider";
 import { Slider as SliderBase } from "@base-ui/react/slider";
 import { Lock, LockOpen } from "@mui/icons-material";
-import { clamp, clone, isEqual } from "lodash";
+import { chain, clamp, clone, isEqual, minBy } from "lodash";
 import { Key } from "ts-key-enum";
 
 import { useElementSize } from "@lib/hooks/useElementSize";
@@ -24,6 +24,7 @@ const INDICATOR_CLASS_NAME = "bg-accent-strong data-disabled:bg-disabled";
 export type SliderChangeEventDetails =
     | SliderBase.Root.ChangeEventDetails
     | { reason: "clamp-value" }
+    | { reason: "marker-clicked" }
     | { reason: "range-locked" };
 // If we want to follow base-ui even more directly, use these
 // | BaseUIChangeEventDetails<"clamp-min", SliderRootChangeEventCustomProperties>
@@ -194,7 +195,13 @@ function SliderComponent(props: SliderProps, ref: React.ForwardedRef<HTMLDivElem
     const showMinLock = [true, "both", "min"].includes(defaultedProps.showRangeLocks);
     const showMaxLock = [true, "both", "max"].includes(defaultedProps.showRangeLocks);
 
-    const allMarkers = [defaultedProps.min, ...defaultedProps.markers, defaultedProps.max];
+    const allMarkers = React.useMemo(() => {
+        return chain([defaultedProps.min, ...defaultedProps.markers, defaultedProps.max])
+            .sortBy()
+            .sortedUniq()
+            .value();
+    }, [defaultedProps.markers, defaultedProps.max, defaultedProps.min]);
+
     const isDualSlider = Array.isArray(internalValue);
     const getThumbAriaLabel = defaultedProps.thumbAriaLabel ? getThumbAriaLabelFunc : undefined;
 
@@ -437,14 +444,22 @@ function SliderComponent(props: SliderProps, ref: React.ForwardedRef<HTMLDivElem
                                             leftPosPercent={percentage}
                                             value={v}
                                             index={i}
+                                            disabled={props.disabled}
                                             markerLabels={defaultedProps.markerLabels}
                                             onClick={(v) => {
                                                 if (!isDualSliderValue(internalValue)) {
-                                                    setInternalValue(v);
-                                                } else if (v <= internalValue[0]) {
-                                                    setInternalValue([v, internalValue[1]]);
-                                                } else if (v >= internalValue[1]) {
-                                                    setInternalValue([internalValue[1], v]);
+                                                    updateValue(v, { reason: "marker-clicked" }, true);
+                                                    inputRefs[0].current?.focus();
+                                                } else {
+                                                    const nearestThumbIndex = minBy([0, 1], (idx) =>
+                                                        Math.abs(internalValue[idx] - v),
+                                                    )!;
+
+                                                    const newValue = [...internalValue];
+                                                    newValue[nearestThumbIndex] = v;
+
+                                                    updateValue(newValue, { reason: "marker-clicked" }, true);
+                                                    inputRefs[nearestThumbIndex].current?.focus();
                                                 }
                                             }}
                                         />
@@ -590,7 +605,7 @@ function Thumb(props: {
                         disabled={thumbHidden}
                         className="border-accent-strong data-disabled:border-disabled bg-surface not-data-disabled:hover:outline-focus focus-within:outline-focus z-2 box-content size-(--thumb-size) rounded-full border-2 outline-2 outline-offset-2 outline-transparent"
                         index={props.index}
-                        inputRef={props.inputRefs[1]}
+                        inputRef={props.inputRefs[props.index]}
                         getAriaLabel={props.getAriaLabel}
                         style={positionStyle}
                         onKeyDownCapture={onThumbInputKeyDown}
@@ -714,6 +729,7 @@ function DotLabel(props: {
     value: number;
     index: number;
     markerLabels?: SliderProps["markerLabels"];
+    disabled?: boolean;
     onClick: (value: number) => void;
 }): React.ReactNode {
     if (!props.markerLabels) return null;
@@ -732,24 +748,23 @@ function DotLabel(props: {
 
     return (
         <Typography
-            data-pos={props.leftPosPercent}
             as="span"
+            aria-label={`Set slider to ${props.value}`}
+            data-disabled={props.disabled ? "" : undefined}
             family="body"
             variant="subtle"
             size="sm"
             tone="neutral"
-            layoutClassName="font-bolder px-2xs py-4xs block rounded-sm absolute -translate-x-1/2 top-sm hover:bg-input "
-            layoutStyles={{ left: `${props.leftPosPercent}%` }}
-            onPointerDownCapture={(evt) => {
-                evt.stopPropagation();
-                props.onClick(props.value);
-            }}
+            layoutClassName="font-bolder px-2xs py-4xs block rounded-sm absolute -translate-x-1/2 top-sm not-data-disabled:hover:bg-input "
+            layoutStyle={{ left: `${props.leftPosPercent}%` }}
+            // ! Slider will move the thumb during pointer-down event, so we stop it here to avoid jumpiness
+            onPointerDown={(evt) => !props.disabled && evt.stopPropagation()}
+            onClick={() => !props.disabled && props.onClick(props.value)}
         >
             {formattedValue}
         </Typography>
     );
 }
-
 
 function isDualSliderValue(value: number | readonly number[]): value is readonly number[] {
     return Array.isArray(value);
@@ -778,7 +793,7 @@ function useLockState(props: {
     );
 
     const setMinLocked = React.useCallback(
-        (locked: boolean) => {
+        function setMinLockedFunc(locked: boolean) {
             if (!props.showMinLock) return;
 
             internalSetMinLocked(locked);
@@ -790,7 +805,7 @@ function useLockState(props: {
     );
 
     const setMaxLocked = React.useCallback(
-        (locked: boolean) => {
+        function setMaxLockedFunc(locked: boolean) {
             if (!props.showMaxLock) return;
 
             internalSetMaxLocked(locked);

--- a/frontend/src/lib/newComponents/Slider/slider.tsx
+++ b/frontend/src/lib/newComponents/Slider/slider.tsx
@@ -147,156 +147,6 @@ const DEFAULT_PROPS = {
 
 type DefaultedSliderProps = typeof DEFAULT_PROPS & SliderProps;
 
-function isDualSliderValue(value: number | readonly number[]): value is readonly number[] {
-    return Array.isArray(value);
-}
-
-function useLockState(props: {
-    isDualSlider: boolean;
-    showMinLock: boolean;
-    showMaxLock: boolean;
-    minLocked?: boolean;
-    maxLocked?: boolean;
-    defaultMinLocked?: boolean;
-    defaultMaxLocked?: boolean;
-    onMinLockedChange?: (locked: boolean) => void;
-    onMaxLockedChange?: (locked: boolean) => void;
-}) {
-    const [internalMinLocked, internalSetMinLocked] = useOptInControlledValue(
-        props.defaultMinLocked ?? false,
-        props.minLocked,
-        props.onMinLockedChange,
-    );
-    const [internalMaxLocked, internalSetMaxLocked] = useOptInControlledValue(
-        props.defaultMaxLocked ?? false,
-        props.maxLocked,
-        props.onMaxLockedChange,
-    );
-
-    const setMinLocked = React.useCallback(
-        (locked: boolean) => {
-            if (!props.showMinLock) return;
-
-            internalSetMinLocked(locked);
-            if (locked && props.isDualSlider) {
-                internalSetMaxLocked(false);
-            }
-        },
-        [internalSetMaxLocked, internalSetMinLocked, props.isDualSlider, props.showMinLock],
-    );
-
-    const setMaxLocked = React.useCallback(
-        (locked: boolean) => {
-            if (!props.showMaxLock) return;
-
-            internalSetMaxLocked(locked);
-            if (locked && props.isDualSlider) {
-                internalSetMinLocked(false);
-            }
-        },
-        [internalSetMaxLocked, internalSetMinLocked, props.isDualSlider, props.showMaxLock],
-    );
-
-    return {
-        minLocked: internalMinLocked,
-        maxLocked: internalMaxLocked,
-        setMinLocked,
-        setMaxLocked,
-    };
-}
-
-function useLockedValueUpdate(props: {
-    value: number | readonly number[];
-    min: number;
-    max: number;
-    minLocked: boolean;
-    maxLocked: boolean;
-    onValueChange?: (
-        value: number | readonly number[],
-        eventDetails: SliderChangeEventDetails,
-        commit: boolean,
-    ) => void;
-}) {
-    const prevMinLocked = React.useRef(false);
-    const prevMaxLocked = React.useRef(false);
-
-    const { onValueChange } = props;
-
-    React.useEffect(() => {
-        const value = props.value;
-        const isDualValue = isDualSliderValue(value);
-        let newValue: typeof value | null = null;
-
-        // Min lock was just enabled
-        if (props.minLocked && !prevMinLocked.current) {
-            if (isDualValue) {
-                newValue = [props.min, value[1]];
-            } else {
-                newValue = props.min;
-            }
-        }
-
-        // Max lock was just enabled
-        if (props.maxLocked && !prevMaxLocked.current) {
-            if (isDualValue && newValue !== null) {
-                newValue = [(newValue as number[])[0], props.max];
-            } else if (isDualValue) {
-                newValue = [value[0], props.max];
-            } else {
-                newValue = props.max;
-            }
-        }
-
-        prevMinLocked.current = props.minLocked;
-        prevMaxLocked.current = props.maxLocked;
-
-        if (newValue !== null) {
-            onValueChange?.(newValue, { reason: "range-locked" }, true);
-        }
-    }, [props.minLocked, props.maxLocked, props.min, props.max, props.value, onValueChange]);
-}
-
-function useUnlockOnValueChange(props: {
-    value: number | readonly number[];
-    min: number;
-    max: number;
-    minLocked: boolean;
-    maxLocked: boolean;
-
-    setMinLocked: (locked: boolean) => void;
-    setMaxLocked: (locked: boolean) => void;
-}) {
-    const { setMinLocked, setMaxLocked } = props;
-    const prevValue = React.useRef(props.value);
-
-    React.useEffect(() => {
-        // Only check if value actually changed
-        if (isEqual(prevValue.current, props.value)) return;
-
-        const lowerValue = isDualSliderValue(props.value) ? props.value[0] : props.value;
-        const upperValue = isDualSliderValue(props.value) ? props.value[1] : props.value;
-
-        if (props.minLocked && lowerValue > props.min) {
-            setMinLocked(false);
-        }
-
-        if (props.maxLocked && upperValue < props.max) {
-            setMaxLocked(false);
-        }
-
-        prevValue.current = props.value;
-    }, [props.max, props.maxLocked, props.min, props.minLocked, props.value, setMaxLocked, setMinLocked]);
-}
-
-function resolveTrackHeightClassName(size: SelectableSize) {
-    return {
-        // Same size for small and default, as h-0.5 seems way to small
-        small: "h-1",
-        default: "h-1",
-        large: "h-1.5",
-    }[size];
-}
-
 function SliderComponent(props: SliderProps, ref: React.ForwardedRef<HTMLDivElement>): React.ReactNode {
     const defaultedProps: DefaultedSliderProps = { ...DEFAULT_PROPS, ...props };
 
@@ -898,6 +748,157 @@ function DotLabel(props: {
             {formattedValue}
         </Typography>
     );
+}
+
+
+function isDualSliderValue(value: number | readonly number[]): value is readonly number[] {
+    return Array.isArray(value);
+}
+
+function useLockState(props: {
+    isDualSlider: boolean;
+    showMinLock: boolean;
+    showMaxLock: boolean;
+    minLocked?: boolean;
+    maxLocked?: boolean;
+    defaultMinLocked?: boolean;
+    defaultMaxLocked?: boolean;
+    onMinLockedChange?: (locked: boolean) => void;
+    onMaxLockedChange?: (locked: boolean) => void;
+}) {
+    const [internalMinLocked, internalSetMinLocked] = useOptInControlledValue(
+        props.defaultMinLocked ?? false,
+        props.minLocked,
+        props.onMinLockedChange,
+    );
+    const [internalMaxLocked, internalSetMaxLocked] = useOptInControlledValue(
+        props.defaultMaxLocked ?? false,
+        props.maxLocked,
+        props.onMaxLockedChange,
+    );
+
+    const setMinLocked = React.useCallback(
+        (locked: boolean) => {
+            if (!props.showMinLock) return;
+
+            internalSetMinLocked(locked);
+            if (locked && props.isDualSlider) {
+                internalSetMaxLocked(false);
+            }
+        },
+        [internalSetMaxLocked, internalSetMinLocked, props.isDualSlider, props.showMinLock],
+    );
+
+    const setMaxLocked = React.useCallback(
+        (locked: boolean) => {
+            if (!props.showMaxLock) return;
+
+            internalSetMaxLocked(locked);
+            if (locked && props.isDualSlider) {
+                internalSetMinLocked(false);
+            }
+        },
+        [internalSetMaxLocked, internalSetMinLocked, props.isDualSlider, props.showMaxLock],
+    );
+
+    return {
+        minLocked: internalMinLocked,
+        maxLocked: internalMaxLocked,
+        setMinLocked,
+        setMaxLocked,
+    };
+}
+
+function useLockedValueUpdate(props: {
+    value: number | readonly number[];
+    min: number;
+    max: number;
+    minLocked: boolean;
+    maxLocked: boolean;
+    onValueChange?: (
+        value: number | readonly number[],
+        eventDetails: SliderChangeEventDetails,
+        commit: boolean,
+    ) => void;
+}) {
+    const prevMinLocked = React.useRef(false);
+    const prevMaxLocked = React.useRef(false);
+
+    const { onValueChange } = props;
+
+    React.useEffect(() => {
+        const value = props.value;
+        const isDualValue = isDualSliderValue(value);
+        let newValue: typeof value | null = null;
+
+        // Min lock was just enabled
+        if (props.minLocked && !prevMinLocked.current) {
+            if (isDualValue) {
+                newValue = [props.min, value[1]];
+            } else {
+                newValue = props.min;
+            }
+        }
+
+        // Max lock was just enabled
+        if (props.maxLocked && !prevMaxLocked.current) {
+            if (isDualValue && newValue !== null) {
+                newValue = [(newValue as number[])[0], props.max];
+            } else if (isDualValue) {
+                newValue = [value[0], props.max];
+            } else {
+                newValue = props.max;
+            }
+        }
+
+        prevMinLocked.current = props.minLocked;
+        prevMaxLocked.current = props.maxLocked;
+
+        if (newValue !== null) {
+            onValueChange?.(newValue, { reason: "range-locked" }, true);
+        }
+    }, [props.minLocked, props.maxLocked, props.min, props.max, props.value, onValueChange]);
+}
+
+function useUnlockOnValueChange(props: {
+    value: number | readonly number[];
+    min: number;
+    max: number;
+    minLocked: boolean;
+    maxLocked: boolean;
+
+    setMinLocked: (locked: boolean) => void;
+    setMaxLocked: (locked: boolean) => void;
+}) {
+    const { setMinLocked, setMaxLocked } = props;
+    const prevValue = React.useRef(props.value);
+
+    React.useEffect(() => {
+        // Only check if value actually changed
+        if (isEqual(prevValue.current, props.value)) return;
+
+        const lowerValue = isDualSliderValue(props.value) ? props.value[0] : props.value;
+        const upperValue = isDualSliderValue(props.value) ? props.value[1] : props.value;
+
+        if (props.minLocked && lowerValue > props.min) {
+            setMinLocked(false);
+        }
+
+        if (props.maxLocked && upperValue < props.max) {
+            setMaxLocked(false);
+        }
+
+        prevValue.current = props.value;
+    }, [props.max, props.maxLocked, props.min, props.minLocked, props.value, setMaxLocked, setMinLocked]);
+}
+
+function resolveTrackHeightClassName(size: SelectableSize) {
+    return {
+        // Same size for small and default, as h-0.5 seems way to small
+        small: "h-1",
+        default: "h-1",
+        large: "h-1.5",
+    }[size];
 }
 
 export const Slider = React.forwardRef<HTMLDivElement, SliderProps>(SliderComponent);

--- a/frontend/src/lib/newComponents/Slider/slider.tsx
+++ b/frontend/src/lib/newComponents/Slider/slider.tsx
@@ -443,7 +443,6 @@ function SliderComponent(props: SliderProps, ref: React.ForwardedRef<HTMLDivElem
             value={internalValue}
             onValueChange={onValueChangeInternal}
             style={{
-                // @ts-expect-error -- css typing doesn't accept variables
                 "--lock-gutter-size": `${clamp(wrapperSize.width * 0.1, 20, 40)}px`,
 
                 // Couldn't find any EDS variable for these sizes; these pixels sizes are used in the design doc
@@ -452,6 +451,7 @@ function SliderComponent(props: SliderProps, ref: React.ForwardedRef<HTMLDivElem
 
                 // Needed to avoid some jumpiness in some cases
                 "--mark-thumb-diff": "calc(var(--thumb-size) - var(--mark-size))",
+                ...baseProps.style,
             }}
             render={(rootProps, state) => (
                 <div {...rootProps}>

--- a/frontend/src/lib/newComponents/Slider/slider.tsx
+++ b/frontend/src/lib/newComponents/Slider/slider.tsx
@@ -348,10 +348,7 @@ function SliderComponent(
     return (
         <SliderBase.Root
             {...baseProps}
-            className={resolveClassNames(
-                "gap-x-2xs px-2xs flex items-center data-disabled:cursor-not-allowed",
-                props.layoutClassName,
-            )}
+            className={resolveClassNames("gap-x-2xs px-2xs flex items-center", props.layoutClassName)}
             ref={wrapperRef}
             value={internalValue}
             onValueChange={onValueChangeInternal}
@@ -379,10 +376,13 @@ function SliderComponent(
 
                     <SliderBase.Control
                         ref={ref}
-                        className={resolveClassNames("group py-xs flex w-full touch-none items-center select-none", {
-                            "pl-(--lock-gutter-size)": showMinLock,
-                            "pr-(--lock-gutter-size)": showMaxLock,
-                        })}
+                        className={resolveClassNames(
+                            "group py-xs flex w-full cursor-pointer touch-none items-center select-none data-disabled:cursor-not-allowed",
+                            {
+                                "pl-(--lock-gutter-size)": showMinLock,
+                                "pr-(--lock-gutter-size)": showMaxLock,
+                            },
+                        )}
                         onMouseEnter={() => setIsHovered(true)}
                         onMouseLeave={() => setIsHovered(false)}
                         onFocus={() => setIsFocused(true)}

--- a/frontend/src/lib/newComponents/Slider/slider.tsx
+++ b/frontend/src/lib/newComponents/Slider/slider.tsx
@@ -112,7 +112,7 @@ export type SliderProps<TValue extends number | readonly number[] = number | rea
 
     /**
      * Display the value of each marker below them.
-     * A function can be provided for further customization. Returning a empty node (null, false, etc) will fully remove the label */
+     * A function can be provided for further customization. Returning an empty node (null, false, etc) will fully remove the label */
     markerLabels?: boolean | ((markerValue: number, index: number) => React.ReactNode);
 
     /**
@@ -234,7 +234,7 @@ function SliderComponent(
     const wrapperSize = useElementSize(wrapperRef);
 
     if (props.value !== undefined && props.value !== internalValue) {
-        setInternalValue(props.value as number | number[]);
+        setInternalValue(props.value);
     }
 
     function getThumbAriaLabelFunc(index: number) {
@@ -247,8 +247,8 @@ function SliderComponent(
         function updateValue(newValue: number | number[], eventDetails: SliderChangeEventDetails, commit?: boolean) {
             setInternalValue(newValue);
 
-            onValueChange?.(newValue as any, eventDetails);
-            if (commit) onValueCommitted?.(newValue as any, eventDetails);
+            onValueChange?.(newValue, eventDetails);
+            if (commit) onValueCommitted?.(newValue, eventDetails);
         },
         [onValueChange, onValueCommitted],
     );
@@ -433,39 +433,6 @@ function SliderComponent(
                                 },
                             )}
                         >
-                            {allMarkers.map((v, i) => {
-                                const percentage =
-                                    ((v - defaultedProps.min) / (defaultedProps.max - defaultedProps.min)) * 100;
-                                return (
-                                    <React.Fragment key={i}>
-                                        <Dot leftPosPercent={percentage} />
-                                        <DotLabel
-                                            leftPosPercent={percentage}
-                                            value={v}
-                                            index={i}
-                                            disabled={props.disabled}
-                                            markerLabels={defaultedProps.markerLabels}
-                                            onClick={(v) => {
-                                                if (!isDualSliderValue(internalValue)) {
-                                                    updateValue(v, { reason: "marker-clicked" }, true);
-                                                    inputRefs[0].current?.focus();
-                                                } else {
-                                                    const nearestThumbIndex = minBy([0, 1], (idx) =>
-                                                        Math.abs(internalValue[idx] - v),
-                                                    )!;
-
-                                                    const newValue = [...internalValue];
-                                                    newValue[nearestThumbIndex] = v;
-
-                                                    updateValue(newValue, { reason: "marker-clicked" }, true);
-                                                    inputRefs[nearestThumbIndex].current?.focus();
-                                                }
-                                            }}
-                                        />
-                                    </React.Fragment>
-                                );
-                            })}
-
                             {!props.noIndicator && (
                                 <SliderBase.Indicator
                                     className={resolveClassNames("rounded-lg", {
@@ -508,6 +475,41 @@ function SliderComponent(
                                 onSetMinLocked={setMinLocked}
                                 onSetMaxLocked={setMaxLocked}
                             />
+
+                            {allMarkers.map((v, i) => {
+                                const range = defaultedProps.max - defaultedProps.min;
+                                const percentage = range === 0 ? 0 : ((v - defaultedProps.min) / range) * 100;
+
+                                return (
+                                    <React.Fragment key={i}>
+                                        <Dot leftPosPercent={percentage} />
+                                        <DotLabel
+                                            leftPosPercent={percentage}
+                                            value={v}
+                                            index={i}
+                                            size={componentSize}
+                                            disabled={props.disabled}
+                                            markerLabels={defaultedProps.markerLabels}
+                                            onClick={(v) => {
+                                                if (!isDualSliderValue(internalValue)) {
+                                                    updateValue(v, { reason: "marker-clicked" }, true);
+                                                    inputRefs[0].current?.focus();
+                                                } else {
+                                                    const nearestThumbIndex = minBy([0, 1], (idx) =>
+                                                        Math.abs(internalValue[idx] - v),
+                                                    )!;
+
+                                                    const newValue = [...internalValue];
+                                                    newValue[nearestThumbIndex] = v;
+
+                                                    updateValue(newValue, { reason: "marker-clicked" }, true);
+                                                    inputRefs[nearestThumbIndex].current?.focus();
+                                                }
+                                            }}
+                                        />
+                                    </React.Fragment>
+                                );
+                            })}
                         </SliderBase.Track>
 
                         {showMaxLock && (
@@ -602,7 +604,8 @@ function Thumb(props: {
                         // Hiding via style to keep refs stable
                         hidden={thumbHidden}
                         disabled={thumbHidden}
-                        className="border-accent-strong data-disabled:border-disabled bg-surface not-data-disabled:hover:outline-focus focus-within:outline-focus z-2 box-content size-(--thumb-size) rounded-full border-2 outline-2 outline-offset-2 outline-transparent"
+                        // Note that z-index is forced to 2. Internal slider logic will attempt to set it to 1, so we force it to avoid layering issues with Dots
+                        className="border-accent-strong data-disabled:border-disabled bg-surface not-data-disabled:hover:outline-focus focus-within:outline-focus z-2! box-content size-(--thumb-size) rounded-full border-2 outline-2 outline-offset-2 outline-transparent"
                         index={props.index}
                         inputRef={props.inputRefs[props.index]}
                         getAriaLabel={props.getAriaLabel}
@@ -718,7 +721,7 @@ const SliderLockGutter = React.forwardRef<HTMLDivElement, SliderLockGutterProps>
 
 function Dot(props: { leftPosPercent: number }) {
     const className =
-        "border border-neutral box-content size-(--mark-size) rounded-full absolute bg-surface z-1 top-0 -translate-y-1/4 -translate-x-[4px]";
+        "border border-neutral box-content size-(--mark-size) rounded-full absolute bg-surface z-1 top-0 -translate-y-1/4 -translate-x-1/2";
 
     return <div className={className} style={{ left: `${props.leftPosPercent}%` }} />;
 }
@@ -729,11 +732,13 @@ function DotLabel(props: {
     index: number;
     markerLabels?: SliderProps["markerLabels"];
     disabled?: boolean;
+    size: SelectableSize;
     onClick: (value: number) => void;
 }): React.ReactNode {
     if (!props.markerLabels) return null;
 
     let formattedValue;
+    const textSize = getTextSizeForSelectableSize(props.size);
 
     if (typeof props.markerLabels === "function") {
         formattedValue = props.markerLabels(props.value, props.index);
@@ -745,20 +750,29 @@ function DotLabel(props: {
         return null;
     }
 
+    function handleOnClick() {
+        if (props.disabled) return;
+        props.onClick(props.value);
+    }
+
     return (
         <Typography
             as="span"
+            role="button"
+            tabIndex={props.disabled ? -1 : 0}
+            aria-disabled={props.disabled ? true : undefined}
             aria-label={`Set slider to ${props.value}`}
             data-disabled={props.disabled ? "" : undefined}
             family="body"
             variant="subtle"
-            size="sm"
+            size={getNextTextSize(textSize, -1)}
             tone="neutral"
-            layoutClassName="font-bolder px-2xs py-4xs block rounded-sm absolute -translate-x-1/2 top-sm not-data-disabled:hover:bg-input "
+            layoutClassName="font-bolder px-2xs py-4xs block rounded-sm absolute -translate-x-1/2 top-sm not-data-disabled:hover:bg-input focus:outline-focus"
             layoutStyle={{ left: `${props.leftPosPercent}%` }}
             // ! Slider will move the thumb during pointer-down event, so we stop it here to avoid jumpiness
+            onClick={handleOnClick}
+            onKeyDown={(evt) => ["Enter", " "].includes(evt.key) && handleOnClick()}
             onPointerDown={(evt) => !props.disabled && evt.stopPropagation()}
-            onClick={() => !props.disabled && props.onClick(props.value)}
         >
             {formattedValue}
         </Typography>
@@ -928,8 +942,8 @@ function getSnappedValue(sortedMarkers: number[], value: number | number[], targ
             return nextMarker !== undefined ? nextMarker : sortedMarkers[sortedMarkers.length - 1];
         }
         case "prev": {
-            const prevMaker = sortedMarkers.findLast((marker) => marker <= value);
-            return prevMaker !== undefined ? prevMaker : sortedMarkers[0];
+            const prevMarker = sortedMarkers.findLast((marker) => marker <= value);
+            return prevMarker !== undefined ? prevMarker : sortedMarkers[0];
         }
     }
 }

--- a/frontend/src/lib/newComponents/Slider/slider.tsx
+++ b/frontend/src/lib/newComponents/Slider/slider.tsx
@@ -28,7 +28,11 @@ export type SliderChangeEventDetails =
 // | BaseUIChangeEventDetails<"clamp-min", SliderRootChangeEventCustomProperties>
 // | BaseUIChangeEventDetails<"clamp-max", SliderRootChangeEventCustomProperties>;
 
-export type SliderProps = ComponentWrapperProps<Omit<SliderRootBaseProps, "orientation">> & {
+export type SliderProps = ComponentWrapperProps<
+    // ! Orientation would require a lot of extra checks, and we currently
+    // ! are not using vertical sliders anywhere, so we disable it for now
+    Omit<SliderRootBaseProps, "orientation">
+> & {
     /**
      * Shows a button and gutter tracks for locking value to min and/or max values
      *
@@ -98,6 +102,17 @@ export type SliderProps = ComponentWrapperProps<Omit<SliderRootBaseProps, "orien
     /** Hides the slider indicator */
     noIndicator?: boolean;
 
+    /** Additional slider values to show a mark at. The slider will *always* show markers at the ends */
+    markers?: number[];
+
+    /** Snaps the allowed slider values to the values defined in markers (including min/max) */
+    snapToMarkers?: boolean;
+
+    /**
+     * Display the value of each marker below them.
+     * A function can be provided for further customization. Returning a empty node (null, false, etc) will fully remove the label */
+    markerLabels?: boolean | ((markerValue: number, index: number) => React.ReactNode);
+
     /**
      * Formats the value displayed by the thumbs value tooltip.
      * @param value The current value of the thumb.
@@ -124,6 +139,9 @@ const DEFAULT_PROPS = {
     max: 100,
     showRangeLocks: "none" as NonNullable<SliderProps["showRangeLocks"]>,
     valueLabelDisplay: "auto" as NonNullable<SliderProps["valueLabelDisplay"]>,
+    markers: [] as number[],
+    snapToMarkers: false as boolean,
+    thumbCollisionBehavior: "push" as NonNullable<SliderProps["thumbCollisionBehavior"]>,
 } satisfies Partial<SliderProps>;
 
 type DefaultedSliderProps = typeof DEFAULT_PROPS & SliderProps;
@@ -274,6 +292,7 @@ function resolveTrackHeightClassName(size: SelectableSize) {
 
 function SliderComponent(props: SliderProps, ref: React.ForwardedRef<HTMLDivElement>): React.ReactNode {
     const defaultedProps: DefaultedSliderProps = { ...DEFAULT_PROPS, ...props };
+
     const { onValueChange, onValueCommitted } = props;
 
     const baseProps = resolveWrapperProps(defaultedProps, [
@@ -284,6 +303,9 @@ function SliderComponent(props: SliderProps, ref: React.ForwardedRef<HTMLDivElem
         "inverted",
         "noIndicator",
         "size",
+        "markers",
+        "markerLabels",
+        "snapToMarkers",
         "minLocked",
         "maxLocked",
         "defaultMinLocked",
@@ -329,6 +351,7 @@ function SliderComponent(props: SliderProps, ref: React.ForwardedRef<HTMLDivElem
 
     const wrapperSize = useElementSize(wrapperRef);
 
+    const allMarkers = [defaultedProps.min, ...defaultedProps.markers, defaultedProps.max];
     const isDualSlider = Array.isArray(internalValue);
     const getThumbAriaLabel = defaultedProps.thumbAriaLabel ? getThumbAriaLabelFunc : undefined;
 
@@ -396,7 +419,34 @@ function SliderComponent(props: SliderProps, ref: React.ForwardedRef<HTMLDivElem
             }
         }
 
-        updateValue(newValue, eventDetails);
+        if (defaultedProps.snapToMarkers && !allMarkers.includes(activeValue)) {
+            const closestMarker = allMarkers.reduce((prev, curr) => {
+                return Math.abs(curr - activeValue) < Math.abs(prev - activeValue) ? curr : prev;
+            });
+
+            let snappedValue = closestMarker as number | number[];
+
+            if (isDualSliderValue(newValue)) {
+                // ! The "push" thumb behavior might cause the other value to change as
+                // ! well, so we need to make sure it also remains snapped to a marker
+                let otherValue = eventDetails.activeThumbIndex === 0 ? newValue[1] : newValue[0];
+                const otherGotPushed = !allMarkers.includes(otherValue);
+
+                if (otherGotPushed) otherValue = closestMarker;
+
+                const snappedDualValue = [otherValue, otherValue];
+                snappedDualValue[eventDetails.activeThumbIndex] = closestMarker;
+
+                snappedValue = snappedDualValue;
+            }
+
+            // Only apply the snapped value if necessary
+            if (!isEqual(snappedValue, internalValue)) {
+                updateValue(snappedValue, eventDetails);
+            }
+        } else {
+            updateValue(newValue, eventDetails);
+        }
     }
 
     const showThumbValueLabels =
@@ -466,13 +516,10 @@ function SliderComponent(props: SliderProps, ref: React.ForwardedRef<HTMLDivElem
 
                     <SliderBase.Control
                         ref={ref}
-                        className={resolveClassNames(
-                            "group py-xs flex w-full touch-none items-center select-none",
-                            {
-                                "pl-(--lock-gutter-size)": showMinLock,
-                                "pr-(--lock-gutter-size)": showMaxLock,
-                            },
-                        )}
+                        className={resolveClassNames("group py-xs flex w-full touch-none items-center select-none", {
+                            "pl-(--lock-gutter-size)": showMinLock,
+                            "pr-(--lock-gutter-size)": showMaxLock,
+                        })}
                         onMouseEnter={() => setIsHovered(true)}
                         onMouseLeave={() => setIsHovered(false)}
                         onFocus={() => setIsFocused(true)}
@@ -523,8 +570,30 @@ function SliderComponent(props: SliderProps, ref: React.ForwardedRef<HTMLDivElem
                                 },
                             )}
                         >
-                            {/* Only show start dot for dual sliders */}
-                            <Dot placement="start" />
+                            {allMarkers.map((v, i) => {
+                                const percentage =
+                                    ((v - defaultedProps.min) / (defaultedProps.max - defaultedProps.min)) * 100;
+                                return (
+                                    <React.Fragment key={i}>
+                                        <Dot leftPosPercent={percentage} />
+                                        <DotLabel
+                                            leftPosPercent={percentage}
+                                            value={v}
+                                            index={i}
+                                            markerLabels={defaultedProps.markerLabels}
+                                            onClick={(v) => {
+                                                if (!isDualSliderValue(internalValue)) {
+                                                    setInternalValue(v);
+                                                } else if (v <= internalValue[0]) {
+                                                    setInternalValue([v, internalValue[1]]);
+                                                } else if (v >= internalValue[1]) {
+                                                    setInternalValue([internalValue[1], v]);
+                                                }
+                                            }}
+                                        />
+                                    </React.Fragment>
+                                );
+                            })}
 
                             {!props.noIndicator && (
                                 <SliderBase.Indicator
@@ -568,8 +637,6 @@ function SliderComponent(props: SliderProps, ref: React.ForwardedRef<HTMLDivElem
                                 onSetMinLocked={setMinLocked}
                                 onSetMaxLocked={setMaxLocked}
                             />
-
-                            <Dot placement="end" />
                         </SliderBase.Track>
 
                         {showMaxLock && (
@@ -778,16 +845,52 @@ const SliderLockGutter = React.forwardRef<HTMLDivElement, SliderLockGutterProps>
     );
 });
 
-function Dot(props: { placement: "start" | "end" }) {
+function Dot(props: { leftPosPercent: number }) {
     const className =
-        "border border-neutral box-content size-(--mark-size) rounded-full absolute bg-surface z-1 top-0 -translate-y-1/4";
+        "border border-neutral box-content size-(--mark-size) rounded-full absolute bg-surface z-1 top-0 -translate-y-1/4 -translate-x-[4px]";
 
-    const style: React.HTMLAttributes<HTMLDivElement>["style"] = {};
+    return <div className={className} style={{ left: `${props.leftPosPercent}%` }} />;
+}
 
-    if (props.placement === "start") style.left = "-4px";
-    if (props.placement === "end") style.right = "-4px";
+function DotLabel(props: {
+    leftPosPercent: number;
+    value: number;
+    index: number;
+    markerLabels?: SliderProps["markerLabels"];
+    onClick: (value: number) => void;
+}): React.ReactNode {
+    if (!props.markerLabels) return null;
 
-    return <div className={className} style={style} />;
+    let formattedValue;
+
+    if (typeof props.markerLabels === "function") {
+        formattedValue = props.markerLabels(props.value, props.index);
+    } else {
+        formattedValue = String(props.value);
+    }
+
+    if (!formattedValue && formattedValue !== 0) {
+        return null;
+    }
+
+    return (
+        <Typography
+            data-pos={props.leftPosPercent}
+            as="span"
+            family="body"
+            variant="subtle"
+            size="sm"
+            tone="neutral"
+            layoutClassName="font-bolder px-2xs py-4xs block rounded-sm absolute -translate-x-1/2 top-sm hover:bg-input "
+            layoutStyles={{ left: `${props.leftPosPercent}%` }}
+            onPointerDownCapture={(evt) => {
+                evt.stopPropagation();
+                props.onClick(props.value);
+            }}
+        >
+            {formattedValue}
+        </Typography>
+    );
 }
 
 export const Slider = React.forwardRef<HTMLDivElement, SliderProps>(SliderComponent);

--- a/frontend/src/lib/newComponents/Slider/slider.tsx
+++ b/frontend/src/lib/newComponents/Slider/slider.tsx
@@ -10,6 +10,7 @@ import { Key } from "ts-key-enum";
 
 import { useElementSize } from "@lib/hooks/useElementSize";
 import { useOptInControlledValue } from "@lib/hooks/useOptInControlledValue";
+import { isArrayAsReadOnly } from "@lib/utils/arrays";
 import { resolveClassNames } from "@lib/utils/resolveClassNames";
 
 import { useComponentSize } from "../_shared/contexts/componentSizeContext";
@@ -267,6 +268,9 @@ function SliderComponent(props: SliderProps, ref: React.ForwardedRef<HTMLDivElem
         eventDetails: SliderBase.Root.ChangeEventDetails,
     ) {
         const activeValue = isDualSliderValue(newValue) ? newValue[eventDetails.activeThumbIndex] : newValue;
+        const prevActiveValue = isDualSliderValue(internalValue)
+            ? internalValue[eventDetails.activeThumbIndex]
+            : internalValue;
 
         if (isDualSliderValue(newValue)) {
             if (eventDetails.activeThumbIndex === 0 && activeValue > defaultedProps.min) {
@@ -284,25 +288,14 @@ function SliderComponent(props: SliderProps, ref: React.ForwardedRef<HTMLDivElem
         }
 
         if (defaultedProps.snapToMarkers && !allMarkers.includes(activeValue)) {
-            const closestMarker = allMarkers.reduce((prev, curr) => {
-                return Math.abs(curr - activeValue) < Math.abs(prev - activeValue) ? curr : prev;
-            });
+            let snapTarget: SnapTarget = "nearest";
 
-            let snappedValue = closestMarker as number | number[];
-
-            if (isDualSliderValue(newValue)) {
-                // ! The "push" thumb behavior might cause the other value to change as
-                // ! well, so we need to make sure it also remains snapped to a marker
-                let otherValue = eventDetails.activeThumbIndex === 0 ? newValue[1] : newValue[0];
-                const otherGotPushed = !allMarkers.includes(otherValue);
-
-                if (otherGotPushed) otherValue = closestMarker;
-
-                const snappedDualValue = [otherValue, otherValue];
-                snappedDualValue[eventDetails.activeThumbIndex] = closestMarker;
-
-                snappedValue = snappedDualValue;
+            // For keyboard movement, we should always go a new marker marker
+            if (eventDetails.reason === "keyboard") {
+                snapTarget = prevActiveValue - activeValue < 0 ? "next" : "prev";
             }
+
+            const snappedValue = getSnappedValue(allMarkers, newValue, snapTarget);
 
             // Only apply the snapped value if necessary
             if (!isEqual(snappedValue, internalValue)) {
@@ -914,6 +907,33 @@ function resolveTrackHeightClassName(size: SelectableSize) {
         default: "h-1",
         large: "h-1.5",
     }[size];
+}
+
+type SnapTarget = "nearest" | "next" | "prev";
+
+function getSnappedValue(
+    sortedMarkers: number[],
+    value: number | readonly number[],
+    target: SnapTarget,
+): number | readonly number[] {
+    if (isArrayAsReadOnly(value)) {
+        return value.map((v) => getSnappedValue(sortedMarkers, v, target)) as number[];
+    }
+
+    switch (target) {
+        case "nearest": {
+            const closestMarker = minBy(sortedMarkers, (marker) => Math.abs(marker - value))!;
+            return closestMarker;
+        }
+        case "next": {
+            const nextMarker = sortedMarkers.find((marker) => marker >= value);
+            return nextMarker !== undefined ? nextMarker : sortedMarkers[sortedMarkers.length - 1];
+        }
+        case "prev": {
+            const prevMaker = sortedMarkers.findLast((marker) => marker <= value);
+            return prevMaker !== undefined ? prevMaker : sortedMarkers[0];
+        }
+    }
 }
 
 export const Slider = React.forwardRef<HTMLDivElement, SliderProps>(SliderComponent);

--- a/frontend/src/lib/newComponents/Slider/slider.tsx
+++ b/frontend/src/lib/newComponents/Slider/slider.tsx
@@ -10,7 +10,6 @@ import { Key } from "ts-key-enum";
 
 import { useElementSize } from "@lib/hooks/useElementSize";
 import { useOptInControlledValue } from "@lib/hooks/useOptInControlledValue";
-import { isArrayAsReadOnly } from "@lib/utils/arrays";
 import { resolveClassNames } from "@lib/utils/resolveClassNames";
 
 import { useComponentSize } from "../_shared/contexts/componentSizeContext";
@@ -31,10 +30,10 @@ export type SliderChangeEventDetails =
 // | BaseUIChangeEventDetails<"clamp-min", SliderRootChangeEventCustomProperties>
 // | BaseUIChangeEventDetails<"clamp-max", SliderRootChangeEventCustomProperties>;
 
-export type SliderProps = ComponentWrapperProps<
+export type SliderProps<TValue extends number | readonly number[] = number | readonly number[]> = ComponentWrapperProps<
     // ! Orientation would require a lot of extra checks, and we currently
     // ! are not using vertical sliders anywhere, so we disable it for now
-    Omit<SliderRootBaseProps, "orientation">
+    Omit<SliderRootBaseProps<TValue>, "orientation">
 > & {
     /**
      * Shows a button and gutter tracks for locking value to min and/or max values
@@ -129,17 +128,25 @@ export type SliderProps = ComponentWrapperProps<
      *
      * Event is extended to include lock-toggles as an event-reason
      */
-    onValueChange?: (value: number | readonly number[], eventDetails: SliderChangeEventDetails) => void;
+    onValueChange?: (
+        value: TValue extends number ? number : readonly number[],
+        eventDetails: SliderChangeEventDetails,
+    ) => void;
+
     /**
      * See `Slider.Root.onValueCommit`
      *
      * Event is extended to include lock-toggles as an event-reason
      */
-    onValueCommitted?: (value: number | readonly number[], eventDetails: SliderChangeEventDetails) => void;
+    onValueCommitted?: (
+        value: TValue extends number ? number : readonly number[],
+        eventDetails: SliderChangeEventDetails,
+    ) => void;
 };
 const DEFAULT_PROPS = {
     min: 0,
     max: 100,
+    defaultValue: 0,
     showRangeLocks: "none" as NonNullable<SliderProps["showRangeLocks"]>,
     valueLabelDisplay: "auto" as NonNullable<SliderProps["valueLabelDisplay"]>,
     markers: [] as number[],
@@ -147,12 +154,18 @@ const DEFAULT_PROPS = {
     thumbCollisionBehavior: "push" as NonNullable<SliderProps["thumbCollisionBehavior"]>,
 } satisfies Partial<SliderProps>;
 
-type DefaultedSliderProps = typeof DEFAULT_PROPS & SliderProps;
+type InternalOnChangeCallback = (value: number | number[], eventDetails: SliderChangeEventDetails) => void;
 
-function SliderComponent(props: SliderProps, ref: React.ForwardedRef<HTMLDivElement>): React.ReactNode {
-    const defaultedProps: DefaultedSliderProps = { ...DEFAULT_PROPS, ...props };
+function SliderComponent(
+    // ! Note: To simplify internal logic, we always type the slider props as number | number[] using some direct
+    // ! casting. Externally, slider users will see the change event's with the same type as the provided values
+    props: SliderProps<number | number[]>,
+    ref: React.ForwardedRef<HTMLDivElement>,
+): React.ReactNode {
+    const defaultedProps = { ...DEFAULT_PROPS, ...props };
 
-    const { onValueChange, onValueCommitted } = props;
+    const onValueChange = props.onValueChange as InternalOnChangeCallback;
+    const onValueCommitted = props.onValueCommitted as InternalOnChangeCallback;
 
     const baseProps = resolveWrapperProps(defaultedProps, [
         "showRangeLocks",
@@ -185,7 +198,7 @@ function SliderComponent(props: SliderProps, ref: React.ForwardedRef<HTMLDivElem
     const minGutterDotRef = React.useRef<HTMLDivElement | null>(null);
     const maxGutterDotRef = React.useRef<HTMLDivElement | null>(null);
 
-    const [internalValue, setInternalValue] = React.useState(defaultedProps.value ?? defaultedProps.defaultValue ?? 0);
+    const [internalValue, setInternalValue] = React.useState(defaultedProps.value ?? defaultedProps.defaultValue);
     const [prevMin, setPrevMin] = React.useState(defaultedProps.min);
     const [prevMax, setPrevMax] = React.useState(defaultedProps.max);
 
@@ -221,7 +234,7 @@ function SliderComponent(props: SliderProps, ref: React.ForwardedRef<HTMLDivElem
     const wrapperSize = useElementSize(wrapperRef);
 
     if (props.value !== undefined && props.value !== internalValue) {
-        setInternalValue(props.value);
+        setInternalValue(props.value as number | number[]);
     }
 
     function getThumbAriaLabelFunc(index: number) {
@@ -231,15 +244,11 @@ function SliderComponent(props: SliderProps, ref: React.ForwardedRef<HTMLDivElem
     }
 
     const updateValue = React.useCallback(
-        function updateValue(
-            newValue: number | readonly number[],
-            eventDetails: SliderChangeEventDetails,
-            commit?: boolean,
-        ) {
+        function updateValue(newValue: number | number[], eventDetails: SliderChangeEventDetails, commit?: boolean) {
             setInternalValue(newValue);
-            onValueChange?.(newValue, eventDetails);
 
-            if (commit) onValueCommitted?.(newValue, eventDetails);
+            onValueChange?.(newValue as any, eventDetails);
+            if (commit) onValueCommitted?.(newValue as any, eventDetails);
         },
         [onValueChange, onValueCommitted],
     );
@@ -263,10 +272,7 @@ function SliderComponent(props: SliderProps, ref: React.ForwardedRef<HTMLDivElem
         setMaxLocked,
     });
 
-    function onValueChangeInternal(
-        newValue: number | readonly number[],
-        eventDetails: SliderBase.Root.ChangeEventDetails,
-    ) {
+    function onValueChangeInternal(newValue: number | number[], eventDetails: SliderBase.Root.ChangeEventDetails) {
         const activeValue = isDualSliderValue(newValue) ? newValue[eventDetails.activeThumbIndex] : newValue;
         const prevActiveValue = isDualSliderValue(internalValue)
             ? internalValue[eventDetails.activeThumbIndex]
@@ -818,16 +824,12 @@ function useLockState(props: {
 }
 
 function useLockedValueUpdate(props: {
-    value: number | readonly number[];
+    value: number | number[];
     min: number;
     max: number;
     minLocked: boolean;
     maxLocked: boolean;
-    onValueChange?: (
-        value: number | readonly number[],
-        eventDetails: SliderChangeEventDetails,
-        commit: boolean,
-    ) => void;
+    onValueChange?: (value: number | number[], eventDetails: SliderChangeEventDetails, commit: boolean) => void;
 }) {
     const prevMinLocked = React.useRef(false);
     const prevMaxLocked = React.useRef(false);
@@ -835,9 +837,9 @@ function useLockedValueUpdate(props: {
     const { onValueChange } = props;
 
     React.useEffect(() => {
-        const value = props.value;
+        const value = props.value as number | number[];
         const isDualValue = isDualSliderValue(value);
-        let newValue: typeof value | null = null;
+        let newValue: number | number[] | null = null;
 
         // Min lock was just enabled
         if (props.minLocked && !prevMinLocked.current) {
@@ -911,12 +913,8 @@ function resolveTrackHeightClassName(size: SelectableSize) {
 
 type SnapTarget = "nearest" | "next" | "prev";
 
-function getSnappedValue(
-    sortedMarkers: number[],
-    value: number | readonly number[],
-    target: SnapTarget,
-): number | readonly number[] {
-    if (isArrayAsReadOnly(value)) {
+function getSnappedValue(sortedMarkers: number[], value: number | number[], target: SnapTarget): number | number[] {
+    if (Array.isArray(value)) {
         return value.map((v) => getSnappedValue(sortedMarkers, v, target)) as number[];
     }
 
@@ -936,4 +934,8 @@ function getSnappedValue(
     }
 }
 
-export const Slider = React.forwardRef<HTMLDivElement, SliderProps>(SliderComponent);
+export const Slider = React.forwardRef(SliderComponent) as <
+    Value extends number | readonly number[] = number | readonly number[],
+>(
+    props: SliderProps<Value> & React.RefAttributes<HTMLDivElement>,
+) => React.ReactNode;

--- a/frontend/src/lib/newComponents/Table/_components/cell.tsx
+++ b/frontend/src/lib/newComponents/Table/_components/cell.tsx
@@ -57,7 +57,7 @@ function CellComponent(props: TableCellProps, ref: React.ForwardedRef<HTMLTableC
             width={props.width ?? percentWidth}
             tabIndex={isSortable ? 0 : undefined}
             role={isSortable ? "button" : undefined}
-            style={{ fontWeight: "inherit", height: `${cellHeightPx}px` }}
+            style={{ fontWeight: "inherit", height: `${cellHeightPx}px`, ...baseProps.style }}
             className={resolveClassNames(
                 props.layoutClassName,
                 "border-neutral-subtle group/cell relative text-left align-middle whitespace-nowrap",

--- a/frontend/src/lib/newComponents/_shared/utils/wrapperProps.ts
+++ b/frontend/src/lib/newComponents/_shared/utils/wrapperProps.ts
@@ -4,6 +4,9 @@ import { omit } from "lodash";
 export type LayoutClassProps = {
     /** Class names applied to the element. Should only be used for adjusting layout (margins, visibility, positioning) */
     layoutClassName?: string;
+
+    /** Styles applied to the element. Should only be used for adjusting layout (margins, visibility, positioning) */
+    layoutStyles?: React.CSSProperties;
 };
 
 /**
@@ -25,10 +28,17 @@ export function resolveWrapperProps<
     // wrapped components in other library components. By omitting them in the type definition of ComponentWrapperProps,
     // we prevent implementers from passing these props and bypassing the design system while still allowing us to use them
     // at runtime when necessary.
-    const baseProps = omit(props, "layoutClassName", "className" as keyof TWrappedProps, ...additionalOmitPaths);
+    const baseProps = omit(
+        props,
+        "layoutClassName",
+        "layoutStyles",
+        "className" as keyof TWrappedProps,
+        ...additionalOmitPaths,
+    );
 
     return {
         className: `${props.className ?? ""} ${props.layoutClassName ?? ""}`.trim(),
+        style: { ...props.styles, ...props.layoutStyles },
         ...baseProps,
     } as unknown as TBaseUIProps;
 }

--- a/frontend/src/lib/newComponents/_shared/utils/wrapperProps.ts
+++ b/frontend/src/lib/newComponents/_shared/utils/wrapperProps.ts
@@ -1,3 +1,5 @@
+import type React from "react"
+
 import type { Many } from "lodash";
 import { omit } from "lodash";
 
@@ -6,7 +8,7 @@ export type LayoutClassProps = {
     layoutClassName?: string;
 
     /** Styles applied to the element. Should only be used for adjusting layout (margins, visibility, positioning) */
-    layoutStyles?: React.CSSProperties;
+    layoutStyle?: React.CSSProperties;
 };
 
 /**
@@ -31,14 +33,15 @@ export function resolveWrapperProps<
     const baseProps = omit(
         props,
         "layoutClassName",
-        "layoutStyles",
+        "layoutStyle",
+        "style" as keyof TWrappedProps,
         "className" as keyof TWrappedProps,
         ...additionalOmitPaths,
     );
 
     return {
         className: `${props.className ?? ""} ${props.layoutClassName ?? ""}`.trim(),
-        style: { ...props.styles, ...props.layoutStyles },
+        style: { ...props.style, ...props.layoutStyle },
         ...baseProps,
     } as unknown as TBaseUIProps;
 }

--- a/frontend/src/lib/newComponents/_shared/utils/wrapperProps.ts
+++ b/frontend/src/lib/newComponents/_shared/utils/wrapperProps.ts
@@ -1,4 +1,4 @@
-import type React from "react"
+import type React from "react";
 
 import type { Many } from "lodash";
 import { omit } from "lodash";

--- a/frontend/src/lib/utils/arrays.ts
+++ b/frontend/src/lib/utils/arrays.ts
@@ -50,3 +50,11 @@ export function sortTimeOrIntervalArray(values: string[]): string[] {
         return a.localeCompare(b);
     });
 }
+
+/**
+ * Simple wrapper around Array.isArray() that narrows the type as a readonly array. Note that
+ * this can't *actually* check that an array is readonly, it merely narrows it as if it was.
+ */
+export function isArrayAsReadOnly(arg: any): arg is readonly any[] {
+    return Array.isArray(arg);
+}

--- a/frontend/src/lib/utils/arrays.ts
+++ b/frontend/src/lib/utils/arrays.ts
@@ -50,11 +50,3 @@ export function sortTimeOrIntervalArray(values: string[]): string[] {
         return a.localeCompare(b);
     });
 }
-
-/**
- * Simple wrapper around Array.isArray() that narrows the type as a readonly array. Note that
- * this can't *actually* check that an array is readonly, it merely narrows it as if it was.
- */
-export function isArrayAsReadOnly(arg: any): arg is readonly any[] {
-    return Array.isArray(arg);
-}


### PR DESCRIPTION
Updates the slider component to support markers, marker-labels and having the value snap to those markers

Additionally, has some small tweaks/fixes in some other code:
* Added `layoutStyle` to component wrapper props; should be used in the same manner as `layoutClassName`
  * Migrated a few components to apply this style to their own style rules
* Fixed `useOptInControlledValue` not setting it's internal value correctly
* Fixed outdated padding classes in main storybook wrapper