### PR TITLE
Made a shared Chip component for Combobox and realization-picker

### DIFF
--- a/frontend/src/framework/components/EnsemblePicker/ensemblePicker.tsx
+++ b/frontend/src/framework/components/EnsemblePicker/ensemblePicker.tsx
@@ -37,7 +37,8 @@ export function EnsemblePicker(props: EnsemblePickerProps): JSX.Element {
     const optionsArray = React.useMemo(() => {
         return ensembles.map((ens) => ({
             value: ens.getIdent().toString(),
-            label: ens.getDisplayName(),
+            // Some fields write case names in snake_case, so we make it so words can wrap on underscores as well
+            label: ens.getDisplayName().replaceAll("_", "_\u200b"),
         }));
     }, [ensembles]);
 
@@ -78,7 +79,7 @@ export function EnsemblePicker(props: EnsemblePickerProps): JSX.Element {
                         ensemble,
                         ensembleRealizationFilterFunction,
                     )}
-                    wrapperClassName="w-2 h-2 mr-xs"
+                    wrapperClassName="w-5 h-5"
                     size="small"
                 />
             );

--- a/frontend/src/framework/components/RealizationPicker/RealizationRangeTag.tsx
+++ b/frontend/src/framework/components/RealizationPicker/RealizationRangeTag.tsx
@@ -1,13 +1,11 @@
 import React from "react";
 
-import { Close, Error } from "@mui/icons-material";
+import { Error } from "@mui/icons-material";
 import { Key } from "ts-key-enum";
 
 import type { FocusableListItem } from "@lib/hooks/useListFocus";
 import { Direction } from "@lib/hooks/useListFocus";
-import { Button } from "@lib/newComponents/Button";
-import { Separator } from "@lib/newComponents/Separator";
-import { resolveClassNames } from "@lib/utils/resolveClassNames";
+import { Chip } from "@lib/newComponents/Chip";
 
 import type { RealizationNumberLimits, SelectionValidityInfo } from "./_utils";
 import { computeTagValidityInfo, sanitizeRangeInput, SelectionValidity } from "./_utils";
@@ -148,22 +146,16 @@ export function RealizationRangeTag(props: RealizationRangeTagProps): React.Reac
     }
 
     return (
-        <li
-            data-disabled={props.disabled ? "" : undefined}
-            className={resolveClassNames(
-                "relative rounded-sm",
-                "flex items-center overflow-hidden",
-                "pl-2xs",
-                "data-disabled:opacity-75",
-                "text-neutral-strong data-[tone=warning]:text-warning-subtle data-[tone=danger]:text-danger-subtle",
-                "bg-neutral data-[tone=warning]:bg-warning data-[tone=danger]:bg-danger",
-            )}
-            data-tone={colorTone}
+        <Chip
+            as="li"
+            tone={colorTone}
+            onRemove={props.onRemove}
+            disabled={props.disabled}
             title={tagTitle}
+            selected={props.selected}
+            startAdornment={makeMatchCounter()}
             onClick={props.onFocus}
         >
-            {makeMatchCounter()}
-
             <AutoFitInput
                 ref={inputRef}
                 value={activeValue}
@@ -177,32 +169,7 @@ export function RealizationRangeTag(props: RealizationRangeTagProps): React.Reac
                 onFocus={handleFocus}
                 onKeyDown={handleKeyDown}
             />
-
-            <Separator
-                orientation="vertical"
-                data-tone={colorTone}
-                layoutClassName="bg-neutral-active data-[tone=warning]:bg-warning-active data-[tone=danger]:bg-danger-active mr-0!"
-            />
-
-            <Button
-                tabIndex={-1}
-                iconOnly
-                size="small"
-                tone={colorTone}
-                disabled={props.selected || props.disabled}
-                variant="ghost"
-                onClick={(e) => {
-                    e.stopPropagation();
-                    props.onRemove();
-                }}
-            >
-                <Close />
-            </Button>
-
-            {props.selected && (
-                <div className="bg-accent-strong absolute top-0 left-0 z-10 block h-full w-full rounded-sm opacity-50" />
-            )}
-        </li>
+        </Chip>
     );
 }
 

--- a/frontend/src/framework/components/RealizationPicker/realizationPicker.tsx
+++ b/frontend/src/framework/components/RealizationPicker/realizationPicker.tsx
@@ -181,12 +181,12 @@ function RealizationPickerComponent(props: RealizationPickerProps, ref: React.Fo
 
     return (
         <div
-            className="gap-2xs form-element px-xs py-xs flex w-full items-center"
+            className="form-element gap-x-xs px-xs py-xs flex cursor-text items-center"
             data-disabled={props.disabled ? "" : undefined}
         >
             <ul
                 className={resolveClassNames(
-                    "gap-3xs flex w-full flex-wrap",
+                    "gap-3xs flex min-w-0 grow flex-wrap items-center",
                     // Equivalent to SELECTABLE_SIZES_CLASSNAMES["small"],
                     "h-selectable-sm text-body-sm",
                 )}
@@ -212,7 +212,7 @@ function RealizationPickerComponent(props: RealizationPickerProps, ref: React.Fo
                         value={currentInputValue}
                         wrapperClassName="h-full"
                         type="text"
-                        placeholder="Enter a realization number or range..."
+                        placeholder={!rangeValues.length ? "Enter a realization number or range..." : ""}
                         minCharacterWidth={5}
                         onFocus={() => listFocus.setFocusedIndex(-1)}
                         onValueChange={handleInputChange}

--- a/frontend/src/framework/components/RealizationPicker/realizationPicker.tsx
+++ b/frontend/src/framework/components/RealizationPicker/realizationPicker.tsx
@@ -181,12 +181,12 @@ function RealizationPickerComponent(props: RealizationPickerProps, ref: React.Fo
 
     return (
         <div
-            className="gap-x-2xs form-element px-xs py-xs flex w-full items-center"
+            className="gap-2xs form-element px-xs py-xs flex w-full items-center"
             data-disabled={props.disabled ? "" : undefined}
         >
             <ul
                 className={resolveClassNames(
-                    "gap-x-3xs flex w-full flex-wrap",
+                    "gap-3xs flex w-full flex-wrap",
                     // Equivalent to SELECTABLE_SIZES_CLASSNAMES["small"],
                     "h-selectable-sm text-body-sm",
                 )}

--- a/frontend/src/lib/newComponents/Chip/chip.tsx
+++ b/frontend/src/lib/newComponents/Chip/chip.tsx
@@ -49,7 +49,7 @@ function ChipComponent(props: ChipProps, ref: React.ForwardedRef<HTMLElement>): 
             tone={props.tone}
             disabled={props.disabled}
             variant="ghost"
-            layoutClassName={resolveClassNames("ml-3xs self-stretch border-l rounded-l-none", {
+            layoutClassName={resolveClassNames("ml-3xs shrink-0 self-stretch border-l rounded-l-none", {
                 "border-warning": props.tone === "warning",
                 "border-danger": props.tone === "danger",
                 "border-neutral": props.tone === "neutral",
@@ -82,7 +82,7 @@ function ChipComponent(props: ChipProps, ref: React.ForwardedRef<HTMLElement>): 
             )}
         >
             {props.startAdornment}
-            {props.children}
+            <div className="min-w-0 flex-1 overflow-hidden">{props.children}</div>
             {props.wrapRemoveButton?.(removeButton) ?? removeButton}
             {props.selected && (
                 <div className="bg-accent-strong absolute top-0 left-0 z-10 block h-full w-full rounded-sm opacity-50" />

--- a/frontend/src/lib/newComponents/Chip/chip.tsx
+++ b/frontend/src/lib/newComponents/Chip/chip.tsx
@@ -41,13 +41,15 @@ function ChipComponent(props: ChipProps, ref: React.ForwardedRef<HTMLElement>): 
         "wrapRemoveButton",
     ) as HTMLAttributes<HTMLElement>;
 
+    const isDisabled = props.disabled || props.selected;
+
     const removeButton = (
         <Button
             tabIndex={-1}
             iconOnly
             size="small"
             tone={props.tone}
-            disabled={props.disabled}
+            disabled={isDisabled}
             variant="ghost"
             layoutClassName={resolveClassNames("ml-3xs shrink-0 self-stretch border-l rounded-l-none", {
                 "border-warning": props.tone === "warning",
@@ -69,8 +71,8 @@ function ChipComponent(props: ChipProps, ref: React.ForwardedRef<HTMLElement>): 
             {...baseProps}
             ref={ref as any}
             data-tone={props.tone}
-            data-disabled={props.disabled ? "" : undefined}
-            aria-disabled={props.disabled}
+            data-disabled={isDisabled ? "" : undefined}
+            aria-disabled={isDisabled}
             className={resolveClassNames(
                 baseProps.className,
                 "relative rounded-sm",

--- a/frontend/src/lib/newComponents/Chip/chip.tsx
+++ b/frontend/src/lib/newComponents/Chip/chip.tsx
@@ -1,0 +1,94 @@
+import type { HTMLAttributes } from "react";
+import React from "react";
+
+import { Clear } from "@mui/icons-material";
+
+import { resolveClassNames } from "@lib/utils/resolveClassNames";
+
+import { resolveWrapperProps, type ComponentWrapperProps } from "../_shared/utils/wrapperProps";
+import { Button } from "../Button";
+
+export type ChipProps = {
+    as?: React.ElementType;
+    children?: React.ReactNode;
+    tone: "accent" | "neutral" | "danger" | "warning";
+    disabled?: boolean;
+    selected?: boolean;
+    startAdornment?: React.ReactNode;
+    onRemove?: () => void;
+
+    /**
+     * Utility function that allows you to wrap the button. Generally only relevant for rendering Base-UI function components, such as `Combobox.ChipRemove`
+     *
+     * @example ```tsx
+     *      <Chip {..args} wrapRemoveButton={(btn) => <Combobox.ChipRemove render={btn} />} />
+     * ```
+     */
+    wrapRemoveButton?: (button: React.ReactElement) => React.ReactNode;
+} & ComponentWrapperProps<HTMLAttributes<HTMLElement>>;
+
+function ChipComponent(props: ChipProps, ref: React.ForwardedRef<HTMLElement>): React.ReactNode {
+    const Component = props.as ?? "div";
+    const baseProps = resolveWrapperProps(
+        props,
+        "as",
+        "children",
+        "tone",
+        "disabled",
+        "startAdornment",
+        "selected",
+        "onRemove",
+        "wrapRemoveButton",
+    ) as HTMLAttributes<HTMLElement>;
+
+    const removeButton = (
+        <Button
+            tabIndex={-1}
+            iconOnly
+            size="small"
+            tone={props.tone}
+            disabled={props.disabled}
+            variant="ghost"
+            layoutClassName={resolveClassNames("ml-3xs self-stretch border-l rounded-l-none", {
+                "border-warning": props.tone === "warning",
+                "border-danger": props.tone === "danger",
+                "border-neutral": props.tone === "neutral",
+                "border-accent": props.tone === "accent",
+            })}
+            onClick={(e) => {
+                e.stopPropagation();
+                props.onRemove?.();
+            }}
+        >
+            <Clear />
+        </Button>
+    );
+
+    return (
+        <Component
+            {...baseProps}
+            ref={ref as any}
+            data-tone={props.tone}
+            data-disabled={props.disabled ? "" : undefined}
+            aria-disabled={props.disabled}
+            className={resolveClassNames(
+                baseProps.className,
+                "relative rounded-sm",
+                "gap-3xs flex items-center overflow-hidden",
+                "pl-2xs",
+                "data-disabled:opacity-75",
+                "text-neutral-strong data-[tone=warning]:text-warning-subtle data-[tone=danger]:text-danger-subtle",
+                "bg-neutral data-[tone=warning]:bg-warning data-[tone=danger]:bg-danger",
+            )}
+        >
+            {props.startAdornment}
+            {props.children}
+            {props.wrapRemoveButton?.(removeButton) ?? removeButton}
+            {props.selected && (
+                <div className="bg-accent-strong absolute top-0 left-0 z-10 block h-full w-full rounded-sm opacity-50" />
+            )}
+        </Component>
+    );
+}
+
+export const Chip = React.forwardRef(ChipComponent);

--- a/frontend/src/lib/newComponents/Chip/chip.tsx
+++ b/frontend/src/lib/newComponents/Chip/chip.tsx
@@ -82,7 +82,7 @@ function ChipComponent(props: ChipProps, ref: React.ForwardedRef<HTMLElement>): 
             )}
         >
             {props.startAdornment}
-            <div className="min-w-0 flex-1 overflow-hidden">{props.children}</div>
+            <div className="flex min-w-0 flex-1 items-center self-stretch overflow-x-hidden">{props.children}</div>
             {props.wrapRemoveButton?.(removeButton) ?? removeButton}
             {props.selected && (
                 <div className="bg-accent-strong absolute top-0 left-0 z-10 block h-full w-full rounded-sm opacity-50" />

--- a/frontend/src/lib/newComponents/Chip/index.tsx
+++ b/frontend/src/lib/newComponents/Chip/index.tsx
@@ -1,0 +1,3 @@
+export { Chip } from "./chip";
+
+export type { ChipProps } from "./chip";

--- a/frontend/src/lib/newComponents/Combobox/_components/inputVariants/valueChipsInput.tsx
+++ b/frontend/src/lib/newComponents/Combobox/_components/inputVariants/valueChipsInput.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import { Combobox as ComboboxBase } from "@base-ui/react";
 
-import { Chip } from "../../../Chip/chip";
+import { Chip } from "../../../Chip";
 
 import { ComboboxInput } from "./_input";
 
@@ -38,7 +38,7 @@ export function ComboboxValueChipsInputComponent<TValue>(
                                                 startAdornment={props.renderItemAdornment?.(item)}
                                                 wrapRemoveButton={(btn) => <ComboboxBase.ChipRemove render={btn} />}
                                             >
-                                                <span className="line-clamp-2">{label}</span>
+                                                <span className="line-clamp-2 min-w-0 flex-1">{label}</span>
                                             </Chip>
                                         )}
                                     />

--- a/frontend/src/lib/newComponents/Combobox/_components/inputVariants/valueChipsInput.tsx
+++ b/frontend/src/lib/newComponents/Combobox/_components/inputVariants/valueChipsInput.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 
 import { Combobox as ComboboxBase } from "@base-ui/react";
-import { Clear } from "@mui/icons-material";
+
+import { Chip } from "../../../Chip/chip";
 
 import { ComboboxInput } from "./_input";
 
@@ -29,21 +30,18 @@ export function ComboboxValueChipsInputComponent<TValue>(
                                     <ComboboxBase.Chip
                                         key={key}
                                         aria-label={label}
-                                        className="gap-x-3xs bg-neutral text-neutral-strong data-highlighted:bg-accent-hover data-highlighted:outline-focus not-data-highlighted:hover:outline-accent focus-within:bg-accent-hover flex items-center overflow-hidden rounded outline-2 outline-offset-1 outline-transparent"
-                                    >
-                                        {props.renderItemAdornment && (
-                                            <div className="pl-xs flex shrink-0 items-center">
-                                                {props.renderItemAdornment(item)}
-                                            </div>
+                                        render={(htmlProps, chipState) => (
+                                            <Chip
+                                                {...htmlProps}
+                                                tone="neutral"
+                                                disabled={chipState.disabled}
+                                                startAdornment={props.renderItemAdornment?.(item)}
+                                                wrapRemoveButton={(btn) => <ComboboxBase.ChipRemove render={btn} />}
+                                            >
+                                                <span className="line-clamp-2">{label}</span>
+                                            </Chip>
                                         )}
-                                        <span className="px-3xs py-3xs flex min-w-0 items-center">{label}</span>
-                                        <ComboboxBase.ChipRemove
-                                            aria-label={`Remove ${label}`}
-                                            className="selectable text-body-xs py-0"
-                                        >
-                                            <Clear />
-                                        </ComboboxBase.ChipRemove>
-                                    </ComboboxBase.Chip>
+                                    />
                                 );
                             })}
                         <ComboboxInput ref={ref} placeholder={value.length > 0 ? "" : props.placeholder} />

--- a/frontend/src/lib/newComponents/Combobox/_components/inputVariants/valueChipsInput.tsx
+++ b/frontend/src/lib/newComponents/Combobox/_components/inputVariants/valueChipsInput.tsx
@@ -18,7 +18,7 @@ export function ComboboxValueChipsInputComponent<TValue>(
     ref: React.ForwardedRef<HTMLInputElement>,
 ): React.ReactNode {
     return (
-        <ComboboxBase.Chips className="gap-x-3xs gap-y-3xs flex w-full grow flex-wrap items-center">
+        <ComboboxBase.Chips className="gap-x-3xs gap-y-3xs flex min-w-0 grow flex-wrap items-center">
             <ComboboxBase.Value>
                 {(value) => (
                     <>

--- a/frontend/src/lib/newComponents/Combobox/combobox.tsx
+++ b/frontend/src/lib/newComponents/Combobox/combobox.tsx
@@ -151,7 +151,6 @@ function ComboboxComponent<TValue, TMultiple extends boolean | undefined = false
                 <div className="gap-selectable -mr-3xs box-border flex h-full shrink-0 items-center justify-center empty:hidden">
                     {clearable && (
                         <ComboboxBase.Clear
-                            className="Clear selectable text-body-sm box-border flex items-center justify-center"
                             aria-label="Clear selection"
                             render={<Button tone="neutral" iconOnly variant="ghost" size="small" />}
                         >

--- a/frontend/src/lib/newComponents/Combobox/combobox.tsx
+++ b/frontend/src/lib/newComponents/Combobox/combobox.tsx
@@ -10,6 +10,7 @@ import { useComponentSize } from "../_shared/contexts/componentSizeContext";
 import type { SelectableSize } from "../_shared/utils/size";
 import { SELECTABLE_SIZES_CLASSNAMES } from "../_shared/utils/size";
 import { resolveWrapperProps, type ComponentWrapperProps } from "../_shared/utils/wrapperProps";
+import { Button } from "../Button";
 import { CircularProgress } from "../CircularProgress";
 
 import { ComboboxListGroup } from "./_components/group";
@@ -120,7 +121,7 @@ function ComboboxComponent<TValue, TMultiple extends boolean | undefined = false
         >
             <ComboboxBase.InputGroup
                 className={resolveClassNames(
-                    "form-element gap-x-sm pl-sm flex cursor-text items-center",
+                    "form-element gap-x-sm px-sm flex cursor-text items-center",
                     size !== "small" || (props.multiple && selectionMode === "chips") ? "py-xs" : undefined,
                     SELECTABLE_SIZES_CLASSNAMES[size],
                 )}
@@ -147,11 +148,12 @@ function ComboboxComponent<TValue, TMultiple extends boolean | undefined = false
                 )}
 
                 {/* --- Controls --- */}
-                <div className="pr-xs gap-selectable box-border flex h-full shrink-0 items-center justify-center">
+                <div className="gap-selectable -mr-3xs box-border flex h-full shrink-0 items-center justify-center empty:hidden">
                     {clearable && (
                         <ComboboxBase.Clear
-                            className="Clear selectable text-body-sm py-3xs! box-border flex items-center justify-center"
+                            className="Clear selectable text-body-sm box-border flex items-center justify-center"
                             aria-label="Clear selection"
+                            render={<Button tone="neutral" iconOnly variant="ghost" size="small" />}
                         >
                             <Clear fontSize="inherit" />
                         </ComboboxBase.Clear>


### PR DESCRIPTION
* Created a shared `Chip` component for Realization picker and combobox
* Made Combobox truncate chips to at most two lines
* Allowed EnsemblePicker chip's to break ensemble labels on underscores