### PR TITLE
Use new lightweight `cosmos-db` emulator from Microsoft

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,16 @@ with the following variable:
 
 ```
 WEBVIZ_CLIENT_SECRET=...
+WEBVIZ_ENTERPRISE_SUBSCRIPTION_KEY=0
+WEBVIZ_REDIS_AUTH_STORE_PASSWORD=0
+WEBVIZ_REDIS_CACHE_PASSWORD=0
+WEBVIZ_SESSION_STORE_FERNET_KEY=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+```
+
+If you want to test persistence features locally with Cosmos DB Emulator, use:
+
+```bash
+docker-compose -f docker-compose.yml -f docker-compose-cosmos-db.yml up
 ```
 
 ### Hot reload

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ You can then access
 - backend API documentation at `http://localhost:8080/api/docs`
 
 Before you start however you need to create a file `.env` at the root of the project
-with the following variable:
+with the following variables:
 
 ```
 WEBVIZ_CLIENT_SECRET=...

--- a/backend_py/primary/primary/config.py
+++ b/backend_py/primary/primary/config.py
@@ -39,3 +39,8 @@ if _is_on_radix_platform:
     COSMOS_DB_URL = os.getenv("WEBVIZ_COSMOS_DB_URL", "https://webviz-db.documents.azure.com:443/")
 else:
     COSMOS_DB_URL = os.getenv("WEBVIZ_COSMOS_DB_URL", "https://webviz-dev-db.documents.azure.com:443/")
+
+# When this is set (e.g. by the docker-compose-cosmos-db.yml override), the backend will use the
+# local Cosmos DB Emulator at the given endpoint instead of the cloud Cosmos DB. Leave it unset for
+# normal development and production, which connect to the cloud Cosmos DB using Azure credentials.
+COSMOS_DB_EMULATOR_HOST = os.getenv("WEBVIZ_COSMOS_DB_EMULATOR_HOST")

--- a/backend_py/primary/primary/config.py
+++ b/backend_py/primary/primary/config.py
@@ -40,7 +40,5 @@ if _is_on_radix_platform:
 else:
     COSMOS_DB_URL = os.getenv("WEBVIZ_COSMOS_DB_URL", "https://webviz-dev-db.documents.azure.com:443/")
 
-# When this is set (e.g. by the docker-compose-cosmos-db.yml override), the backend will use the
-# local Cosmos DB Emulator at the given endpoint instead of the cloud Cosmos DB. Leave it unset for
-# normal development and production, which connect to the cloud Cosmos DB using Azure credentials.
+# Backend will use local cosmos DB emulator when this env. variable is set:
 COSMOS_DB_EMULATOR_HOST = os.getenv("WEBVIZ_COSMOS_DB_EMULATOR_HOST")

--- a/backend_py/primary/primary/main.py
+++ b/backend_py/primary/primary/main.py
@@ -108,7 +108,9 @@ async def lifespan_handler_async(_fastapi_app: FastAPI) -> AsyncIterator[None]:
         LOGGER.info(
             f"Using credential for azure services to initialize PersistenceStoresSingleton with: {config.COSMOS_DB_URL}"
         )
-        await PersistenceStoresSingleton.initialize_with_credential_async(config.COSMOS_DB_URL, azure_services_credential)
+        await PersistenceStoresSingleton.initialize_with_credential_async(
+            config.COSMOS_DB_URL, azure_services_credential
+        )
 
     TaskMetaTrackerFactory.initialize(redis_url=config.REDIS_CACHE_URL)
     SumoFingerprinterFactory.initialize(redis_url=config.REDIS_CACHE_URL)

--- a/backend_py/primary/primary/main.py
+++ b/backend_py/primary/primary/main.py
@@ -93,20 +93,22 @@ async def lifespan_handler_async(_fastapi_app: FastAPI) -> AsyncIterator[None]:
     # The first part of this function, before the yield, will be executed before the FastPI application starts.
     HTTPX_ASYNC_CLIENT_WRAPPER.start()
 
-    client_secret_vars_for_dev = ClientSecretVars(
-        tenant_id=config.TENANT_ID,
-        client_id=config.CLIENT_ID,
-        client_secret=config.CLIENT_SECRET,
-    )
-    azure_services_credential = create_credential_for_azure_services(client_secret_vars_for_dev)
-
-    # For local development, you can use the Cosmos DB Emulator. The emulator does not require credentials,
-    # so we can initialize the PersistenceStoresSingleton with the emulator connection settings.
-    # PersistenceStoresSingleton.initialize_with_emulator()
-    LOGGER.info(
-        f"Using credential for azure services to initialize PersistenceStoresSingleton with: {config.COSMOS_DB_URL}"
-    )
-    await PersistenceStoresSingleton.initialize_with_credential_async(config.COSMOS_DB_URL, azure_services_credential)
+    if config.COSMOS_DB_EMULATOR_HOST:
+        LOGGER.info(
+            f"Using Cosmos DB Emulator at {config.COSMOS_DB_EMULATOR_HOST} to initialize PersistenceStoresSingleton"
+        )
+        PersistenceStoresSingleton.initialize_with_emulator(config.COSMOS_DB_EMULATOR_HOST)
+    else:
+        client_secret_vars_for_dev = ClientSecretVars(
+            tenant_id=config.TENANT_ID,
+            client_id=config.CLIENT_ID,
+            client_secret=config.CLIENT_SECRET,
+        )
+        azure_services_credential = create_credential_for_azure_services(client_secret_vars_for_dev)
+        LOGGER.info(
+            f"Using credential for azure services to initialize PersistenceStoresSingleton with: {config.COSMOS_DB_URL}"
+        )
+        await PersistenceStoresSingleton.initialize_with_credential_async(config.COSMOS_DB_URL, azure_services_credential)
 
     TaskMetaTrackerFactory.initialize(redis_url=config.REDIS_CACHE_URL)
     SumoFingerprinterFactory.initialize(redis_url=config.REDIS_CACHE_URL)
@@ -115,7 +117,8 @@ async def lifespan_handler_async(_fastapi_app: FastAPI) -> AsyncIterator[None]:
     yield
 
     await PersistenceStoresSingleton.shutdown_async()
-    await azure_services_credential.close()
+    if not config.COSMOS_DB_EMULATOR_HOST:
+        await azure_services_credential.close()
     await HTTPX_ASYNC_CLIENT_WRAPPER.stop_async()
 
 

--- a/backend_py/primary/primary/persistence/persistence_stores.py
+++ b/backend_py/primary/primary/persistence/persistence_stores.py
@@ -132,7 +132,9 @@ class PersistenceStoresSingleton:
 
         # Cosmos DB Emulator well-known default key
         key = "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw=="
-        cosmos_client = CosmosClient(uri, key)
+        # Disable endpoint discovery: the emulator advertises its location as 127.0.0.1, which the SDK
+        # would otherwise route to instead of the provided container-network URI (e.g. cosmos-db-emulator).
+        cosmos_client = CosmosClient(uri, key, enable_endpoint_discovery=False)
         maybe_setup_local_database(uri, key)
         cls._instance = PersistenceStores(cosmos_client)
 

--- a/backend_py/primary/primary/persistence/persistence_stores.py
+++ b/backend_py/primary/primary/persistence/persistence_stores.py
@@ -132,8 +132,7 @@ class PersistenceStoresSingleton:
 
         # Cosmos DB Emulator well-known default key
         key = "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw=="
-        # Disable endpoint discovery: the emulator advertises its location as 127.0.0.1, which the SDK
-        # would otherwise route to instead of the provided container-network URI (e.g. cosmos-db-emulator).
+
         cosmos_client = CosmosClient(uri, key, enable_endpoint_discovery=False)
         maybe_setup_local_database(uri, key)
         cls._instance = PersistenceStores(cosmos_client)

--- a/backend_py/primary/primary/persistence/persistence_stores.py
+++ b/backend_py/primary/primary/persistence/persistence_stores.py
@@ -126,14 +126,13 @@ class PersistenceStoresSingleton:
         cls._instance = PersistenceStores(cosmos_client)
 
     @classmethod
-    def initialize_with_emulator(cls) -> None:
+    def initialize_with_emulator(cls, uri: str) -> None:
         if cls._instance is not None:
             raise RuntimeError("PersistenceStoresSingleton is already initialized")
 
-        # Cosmos DB Emulator defaults
-        uri = "https://cosmos-db-emulator:8081"
+        # Cosmos DB Emulator well-known default key
         key = "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw=="
-        cosmos_client = CosmosClient(uri, key, connection_verify=False)
+        cosmos_client = CosmosClient(uri, key)
         maybe_setup_local_database(uri, key)
         cls._instance = PersistenceStores(cosmos_client)
 

--- a/backend_py/primary/primary/persistence/setup_local_database.py
+++ b/backend_py/primary/primary/persistence/setup_local_database.py
@@ -40,8 +40,6 @@ def create_database_with_retry(client: CosmosClient, db_def: Dict[str, Any], max
 
 
 def maybe_setup_local_database(uri: str, key: str) -> None:
-    # Disable endpoint discovery: the emulator advertises its location as 127.0.0.1, which the SDK
-    # would otherwise route to instead of the provided container-network URI (e.g. cosmos-db-emulator).
     client: CosmosClient = CosmosClient(uri, key, enable_endpoint_discovery=False)
 
     total_containers = 0

--- a/backend_py/primary/primary/persistence/setup_local_database.py
+++ b/backend_py/primary/primary/persistence/setup_local_database.py
@@ -5,9 +5,6 @@ This file is only used for setting up the local database for development and tes
 import logging
 import time
 from typing import List, Dict, Any
-import ssl
-import urllib.request
-from urllib.error import URLError
 
 from azure.cosmos import CosmosClient, PartitionKey, DatabaseProxy
 
@@ -27,29 +24,6 @@ COSMOS_SCHEMA: List[Dict[str, Any]] = [
 ]
 
 
-def wait_for_emulator(uri: str, key: str, retries: int = 50, delay: int = 10) -> CosmosClient:
-    probe_url = f"{uri.rstrip('/')}/_explorer/emulator.pem"
-    # pylint: disable=protected-access
-    # Disabling SSL certificate verification is safe here because this code is used exclusively
-    # with the local Cosmos DB Emulator for development and testing. Never use this in production.
-    context = ssl._create_unverified_context()  # nosec
-
-    for attempt in range(retries):
-        try:
-            with urllib.request.urlopen(probe_url, context=context) as response:  # nosec
-                if response.status == 200:
-                    LOGGER.info("✅ Emulator HTTPS endpoint is up. Proceeding to create CosmosClient.")
-                    break
-        except URLError as e:
-            LOGGER.warning("⏳ Emulator cert endpoint not ready (attempt %d): %s", attempt + 1, e.reason)
-        time.sleep(delay)
-    else:
-        raise RuntimeError("❌ Cosmos Emulator certificate endpoint not ready after timeout")
-
-    # Now that we know HTTPS works, create the CosmosClient
-    return CosmosClient(uri, key, connection_verify=False)
-
-
 def create_database_with_retry(client: CosmosClient, db_def: Dict[str, Any], max_attempts: int = 5) -> DatabaseProxy:
     db_name: str = db_def["database"]
     for attempt in range(1, max_attempts + 1):
@@ -66,7 +40,9 @@ def create_database_with_retry(client: CosmosClient, db_def: Dict[str, Any], max
 
 
 def maybe_setup_local_database(uri: str, key: str) -> None:
-    client: CosmosClient = wait_for_emulator(uri, key)
+    # Disable endpoint discovery: the emulator advertises its location as 127.0.0.1, which the SDK
+    # would otherwise route to instead of the provided container-network URI (e.g. cosmos-db-emulator).
+    client: CosmosClient = CosmosClient(uri, key, enable_endpoint_discovery=False)
 
     total_containers = 0
 

--- a/docker-compose-cosmos-db.yml
+++ b/docker-compose-cosmos-db.yml
@@ -1,0 +1,28 @@
+# Docker Compose override file for running with the Cosmos DB Emulator
+# Usage: docker-compose -f docker-compose.yml -f docker-compose-cosmos-db.yml up
+
+services:
+  backend-primary:
+    depends_on:
+      cosmos-db-emulator:
+        condition: service_healthy
+    environment:
+      - WEBVIZ_COSMOS_DB_EMULATOR_HOST=http://cosmos-db-emulator:8081
+
+  cosmos-db-emulator:
+    image: mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator:vnext-latest
+    platform: linux/amd64
+    tty: true
+    ports:
+      - 8081:8081
+    healthcheck:
+      test: curl -fsS http://127.0.0.1:8080/ready -o /dev/null || exit 1
+      interval: 10s
+      retries: 18 # 3 minutes
+      start_period: 20s
+      timeout: 5s
+    volumes:
+      - cosmosdrive:/data
+
+volumes:
+  cosmosdrive:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -103,35 +103,3 @@ services:
     user: "999:999"
     # https://redis.io/docs/latest/operate/oss_and_stack/management/config/#configuring-redis-as-a-cache
     command: ["--maxmemory", "1gb", "--maxmemory-policy", "allkeys-lru", "--loglevel", "notice"]
-
-
-# When using the Cosmos DB Emulator, make sure to uncomment the relevant parts in the backend-primary service as well,
-# to ensure it waits for the emulator to be healthy before starting.
-#
-# depends_on:
-#   cosmos-db-emulator:
-#     condition: service_healthy
-#
-# Also make sure to comment / uncomment the relevant parts in the backend_py code to use the emulator (main.py).
-#   cosmos-db-emulator:
-#     image: mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator:latest
-#     platform: linux/amd64
-#     tty: true
-#     mem_limit: 4GB
-#     ports:
-#       - "8081:8081" # HTTPS endpoint
-#       - "10250-10255:10250-10255" # Internal emulator ports (needed)
-#     environment:
-#       - AZURE_COSMOS_EMULATOR_PARTITION_COUNT=1
-#       - AZURE_COSMOS_EMULATOR_ENABLE_DATA_PERSISTENCE=true
-#     healthcheck:
-#       test: curl -k https://127.0.0.1:8081/_explorer/emulator.pem || exit 1
-#       interval: 10s
-#       retries: 12 # 2 minutes
-#       start_period: 30s
-#       timeout: 5s
-#     volumes:
-#       - cosmosdrive:/var/lib/cosmosdb/emulator
-
-# volumes:
-#   cosmosdrive:


### PR DESCRIPTION
- Use new cosmos db emulator from Microsoft (GA from now in June: https://devblogs.microsoft.com/cosmosdb/announcing-general-availability-of-the-azure-cosmos-db-vnext-emulator/ )
- Simplify way of using emulator (use docker compose override file instead of commenting in/out code/config).