### PR TITLE
Bugfix: Remove use of lodash-es `chain()` + fixed data error in well log curve fetch

### DIFF
--- a/backend_py/primary/primary/routers/well/router.py
+++ b/backend_py/primary/primary/routers/well/router.py
@@ -335,6 +335,9 @@ async def _get_headers_from_ssdl_well_log_async(
 async def _get_headers_from_smda_geology_async(
     authenticated_user: AuthenticatedUser, wellbore_uuid: str
 ) -> list[schemas.WellboreLogCurveHeader]:
+    if is_drogon_identifier(wellbore_uuid=wellbore_uuid):
+        return []
+
     geol_access = SmdaGeologyAccess(authenticated_user.get_smda_access_token())
 
     try:
@@ -348,6 +351,9 @@ async def _get_headers_from_smda_geology_async(
 async def _get_headers_from_smda_stratigraghpy_async(
     authenticated_user: AuthenticatedUser, wellbore_uuid: str
 ) -> list[schemas.WellboreLogCurveHeader]:
+    if is_drogon_identifier(wellbore_uuid=wellbore_uuid):
+        return []
+
     strat_access = SmdaAccess(authenticated_user.get_smda_access_token())
 
     try:
@@ -361,6 +367,9 @@ async def _get_headers_from_smda_stratigraghpy_async(
 async def _get_headers_from_smda_survey_async(
     authenticated_user: AuthenticatedUser, wellbore_uuid: str
 ) -> list[schemas.WellboreLogCurveHeader]:
+    if is_drogon_identifier(wellbore_uuid=wellbore_uuid):
+        return []
+
     survey_access = SmdaAccess(authenticated_user.get_smda_access_token())
 
     try:

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -55,8 +55,8 @@ export default eslintTypescript.config(
     },
     // Custom rules ---------------------------------------------------------------------
     {
+        // Lodash-es exposes the "chain" utility in its typing, but the function will fail due to tree-shaking in production. This rule config should flag any use of chain as an error
         rules: {
-            // Lodash-es exposes the "chain" utility in it's typing, but the function will fail due to tree-shaking in production. This rule config should flag these as
             "no-restricted-imports": [
                 "error",
                 {

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -56,6 +56,37 @@ export default eslintTypescript.config(
     // Custom rules ---------------------------------------------------------------------
     {
         rules: {
+            // Lodash-es exposes the "chain" utility in it's typing, but the function will fail due to tree-shaking in production. This rule config should flag these as
+            "no-restricted-imports": [
+                "error",
+                {
+                    paths: [
+                        {
+                            name: "lodash-es",
+                            importNames: ["chain"],
+                            message:
+                                "`lodash-es` is meant to be tree-shaken, therefore importing `chain` from lodash-es causes issues in production. Do not import `chain` from lodash-es",
+                        },
+                    ],
+                },
+            ],
+            "no-restricted-syntax": [
+                "error",
+                {
+                    selector: "MemberExpression[object.name='_'][property.name='chain']",
+                    message:
+                        "`lodash-es` is meant to be tree-shaken, therefore `_.chain` causes issues in production. Do not use `_.chain`",
+                },
+                {
+                    selector: "CallExpression[callee.name='_']",
+                    message:
+                        "`lodash-es` is meant to be tree-shaken, therefore `_(value)` is equivalent of using `_.chain` which causes issues in production. Do not use `_.chain`",
+                },
+            ],
+        },
+    },
+    {
+        rules: {
             "@typescript-eslint/no-unused-expressions": ["warn", { allowShortCircuit: true, allowTernary: true }], // Allow some useful "unused" expressions, such as `foo && foo()`
             "@typescript-eslint/consistent-type-imports": "warn",
             "@typescript-eslint/no-explicit-any": "off",

--- a/frontend/src/framework/components/RealizationPicker/_utils.ts
+++ b/frontend/src/framework/components/RealizationPicker/_utils.ts
@@ -1,4 +1,4 @@
-import { chain, inRange, range } from "lodash-es";
+import { inRange, range, sortBy, uniq } from "lodash-es";
 
 import { getNumbersAndRanges } from "@framework/utils/numberUtils";
 
@@ -62,7 +62,8 @@ export function textToRealizationSelection(pasteText: string, limits: Realizatio
     }
 
     // Sort them to keep the order, and remove possible duplicates
-    const sortedUniqueRealizationNumbers = chain(realizationNumbers).sortBy().uniq().value();
+    const sortedRealizationNumbers = sortBy(realizationNumbers);
+    const sortedUniqueRealizationNumbers = uniq(sortedRealizationNumbers);
     const numbersAndRanges = getNumbersAndRanges(sortedUniqueRealizationNumbers, skippedNumbers);
 
     const rangesAsValueStrings = numbersAndRanges.map((numberOrRange) => {

--- a/frontend/src/modules/WellLogViewer/utils/queryDataTransform.ts
+++ b/frontend/src/modules/WellLogViewer/utils/queryDataTransform.ts
@@ -9,7 +9,7 @@ import type {
     WellLogSet,
 } from "@webviz/well-log-viewer/dist/components/WellLogTypes";
 import type { WellPickProps } from "@webviz/well-log-viewer/dist/components/WellLogView";
-import { chain, clone, round, set } from "lodash-es";
+import { clone, entries, groupBy, round, set, sortBy, values } from "lodash-es";
 
 import { WellLogCurveSourceEnum_api } from "@api";
 import type { WellboreLogCurveData_api, WellborePick_api, WellboreTrajectory_api } from "@api";
@@ -46,52 +46,49 @@ export function createWellLogSets(
     // Adding a dedicated set for only the axes, so we always have a full set to show from.
     const axisOnlyLog = makeAxisOnlyLog(wellboreTrajectory, referenceSystem);
 
-    const wellLogsSets = chain(curveData)
-        // Initial map to handle some cornercases
-        .map((curveData) => {
-            curveData = clone(curveData);
+    // Initial map to handle some cornercases
+    const curveDataWithUniqueNames = curveData.map((curveData) => {
+        curveData = clone(curveData);
 
-            // Occasionally names are duplicated between logs. The log-viewer looks up
-            // curves by name only, and picks the first one when building it's graphs,
-            // must make it so all names are unique
-            curveData.name = getUniqueCurveNameForCurveData(curveData, nonUniqueCurveNames);
+        // Occasionally names are duplicated between logs. The log-viewer looks up
+        // curves by name only, and picks the first one when building it's graphs,
+        // must make it so all names are unique
+        curveData.name = getUniqueCurveNameForCurveData(curveData, nonUniqueCurveNames);
 
-            // These curves *will* have different sampling rates (as they only have
-            // entries when the value changes). To render these correctly in the viewer,
-            // we must ensure they have different log-names
-            if (curveData.source !== WellLogCurveSourceEnum_api.SSDL_WELL_LOG) {
-                // Names *should* be unique across logs
-                curveData.logName = `${curveData.logName}::${curveData.name}`;
-            }
+        // These curves *will* have different sampling rates (as they only have
+        // entries when the value changes). To render these correctly in the viewer,
+        // we must ensure they have different log-names
+        if (curveData.source !== WellLogCurveSourceEnum_api.SSDL_WELL_LOG) {
+            // Names *should* be unique across logs
+            curveData.logName = `${curveData.logName}::${curveData.name}`;
+        }
 
-            return curveData;
-        })
-        // According to the well-log JSON format, each log should have their own object
-        .groupBy("logName")
-        .entries()
-        .map(([logName, curveSet]) => {
-            let domain: [number, number] | undefined;
+        return curveData;
+    });
+    // According to the well-log JSON format, each log should have their own object
+    const curvesByLog = groupBy(curveDataWithUniqueNames, "logName");
+    const wellLogSets = entries(curvesByLog).map<WellLogSet>(([logName, curveSet]) => {
+        let domain: [number, number] | undefined;
 
-            if (padToTrajectoryLength) {
-                domain = [wellboreTrajectory.mdArr.at(0)!, wellboreTrajectory.mdArr.at(-1)!];
-            } else if (wellPickProps?.wellpick?.data?.length) {
-                // ! If pick data exists, it implies that start and end indices are set
-                // We add a little offset to make it easier to see the the picks
-                const picksStart = wellPickProps.wellpick.header.startIndex! - 10;
-                const picksEnd = wellPickProps.wellpick.header.endIndex! + 10;
+        if (padToTrajectoryLength) {
+            domain = [wellboreTrajectory.mdArr.at(0)!, wellboreTrajectory.mdArr.at(-1)!];
+        } else if (wellPickProps?.wellpick?.data?.length) {
+            // ! If pick data exists, it implies that start and end indices are set
+            // We add a little offset to make it easier to see the the picks
+            const picksStart = wellPickProps.wellpick.header.startIndex! - 10;
+            const picksEnd = wellPickProps.wellpick.header.endIndex! + 10;
 
-                domain = [picksStart, picksEnd];
-            }
+            domain = [picksStart, picksEnd];
+        }
 
-            const { curves, data, metadata_discrete } = createLogCurvesAndData(curveSet, referenceSystem, domain);
+        const { curves, data, metadata_discrete } = createLogCurvesAndData(curveSet, referenceSystem, domain);
 
-            const header = createLogHeader(logName, data, wellboreTrajectory);
+        const header = createLogHeader(logName, data, wellboreTrajectory);
 
-            return { header, curves, data, metadata_discrete };
-        })
-        .value();
+        return { header, curves, data, metadata_discrete };
+    });
 
-    return [axisOnlyLog, ...wellLogsSets];
+    return [axisOnlyLog, ...wellLogSets];
 }
 
 type SafeWellLogDataRow = [number, ...WellLogDataRow];
@@ -176,7 +173,7 @@ function createLogCurvesAndData(
     }
 
     return {
-        data: chain(rowAcc).values().sortBy("0").value(),
+        data: sortBy(values(rowAcc), "0"),
         // data: Object.values(rowAcc),
         metadata_discrete: metadataDiscrete,
         curves,
@@ -319,7 +316,7 @@ function mergeStackedPicks(wellborePicks: WellLogDataRow[]): WellLogDataRow[] {
         else mergedPicks[md] = mergePicks(mergedPicks[md], pick);
     });
 
-    return chain(mergedPicks).values().sortBy("0").value();
+    return sortBy(values(mergedPicks), "0");
 }
 
 function mergePicks(pick1: WellLogDataRow, pick2: WellLogDataRow): WellLogDataRow {

--- a/frontend/src/modules/WellLogViewer/view/components/ProviderVisualizationWrapper.tsx
+++ b/frontend/src/modules/WellLogViewer/view/components/ProviderVisualizationWrapper.tsx
@@ -110,7 +110,7 @@ function createWellLogJsonFromProduct(
 
     const accData = factoryProduct.accumulatedData;
     const curveData = accData[DATA_ACC_KEY] ?? [];
-    const duplicatedCurveNames = accData[DUPLICATE_NAMES_ACC_KEY] ?? [];
+    const duplicatedCurveNames = accData[DUPLICATE_NAMES_ACC_KEY] ?? new Set();
 
     return createWellLogSets(curveData, wellboreTrajectory, wellPickProps, duplicatedCurveNames, !limitDomainToData);
 }

--- a/frontend/src/modules/WellLogViewer/view/components/ProviderVisualizationWrapper.tsx
+++ b/frontend/src/modules/WellLogViewer/view/components/ProviderVisualizationWrapper.tsx
@@ -109,8 +109,8 @@ function createWellLogJsonFromProduct(
     if (!factoryProduct) return [];
 
     const accData = factoryProduct.accumulatedData;
-    const curveData = accData[DATA_ACC_KEY];
-    const duplicatedCurveNames = accData[DUPLICATE_NAMES_ACC_KEY];
+    const curveData = accData[DATA_ACC_KEY] ?? [];
+    const duplicatedCurveNames = accData[DUPLICATE_NAMES_ACC_KEY] ?? [];
 
     return createWellLogSets(curveData, wellboreTrajectory, wellPickProps, duplicatedCurveNames, !limitDomainToData);
 }

--- a/frontend/src/modules/WellLogViewer/view/components/ReadoutWrapper.tsx
+++ b/frontend/src/modules/WellLogViewer/view/components/ReadoutWrapper.tsx
@@ -1,7 +1,7 @@
 import type React from "react";
 
 import type { Info } from "@webviz/well-log-viewer/dist/components/InfoTypes";
-import { chain, maxBy } from "lodash-es";
+import { entries, groupBy, maxBy, sortBy } from "lodash-es";
 
 import type { InfoItem, ReadoutItem } from "@modules/_shared/components/ReadoutBox";
 import { ReadoutBox } from "@modules/_shared/components/ReadoutBox";
@@ -26,13 +26,11 @@ export function ReadoutWrapper(props: ReadoutWrapperProps): React.ReactNode {
 }
 
 function parseWellLogReadout(wellLogInfo: Info[], templateTracks: TemplateTrack[]): ReadoutItem[] {
-    return chain(wellLogInfo)
-        .filter(({ type }) => type !== "separator")
-        .groupBy("iTrack")
-        .entries()
-        .sortBy(0)
-        .map(([iTrack, infos]) => infoToReadoutItem(infos, Number(iTrack), templateTracks))
-        .value();
+    const nonSeparatorInfos = wellLogInfo.filter(({ type }) => type !== "separator");
+    const infosByTrack = groupBy(nonSeparatorInfos, "iTrack");
+    const sortedEntries = sortBy(entries(infosByTrack), 0);
+
+    return sortedEntries.map(([iTrack, infos]) => infoToReadoutItem(infos, Number(iTrack), templateTracks));
 }
 
 function infoToReadoutItem(infos: Info[], iTrack: number, templateTracks: TemplateTrack[]): ReadoutItem {

--- a/frontend/src/modules/WellLogViewer/view/components/ReadoutWrapper.tsx
+++ b/frontend/src/modules/WellLogViewer/view/components/ReadoutWrapper.tsx
@@ -28,7 +28,7 @@ export function ReadoutWrapper(props: ReadoutWrapperProps): React.ReactNode {
 function parseWellLogReadout(wellLogInfo: Info[], templateTracks: TemplateTrack[]): ReadoutItem[] {
     const nonSeparatorInfos = wellLogInfo.filter(({ type }) => type !== "separator");
     const infosByTrack = groupBy(nonSeparatorInfos, "iTrack");
-    const sortedEntries = sortBy(entries(infosByTrack), 0);
+    const sortedEntries = sortBy(entries(infosByTrack), ([iTrack]) => Number(iTrack));
 
     return sortedEntries.map(([iTrack, infos]) => infoToReadoutItem(infos, Number(iTrack), templateTracks));
 }

--- a/frontend/src/modules/_shared/DataProviderFramework/settings/implementations/LogCurveSetting.tsx
+++ b/frontend/src/modules/_shared/DataProviderFramework/settings/implementations/LogCurveSetting.tsx
@@ -1,6 +1,6 @@
 import type React from "react";
 
-import { chain, isEqual, sortBy } from "lodash-es";
+import { entries, groupBy, isEqual, sortBy } from "lodash-es";
 
 import type { WellboreLogCurveHeader_api } from "@api";
 import type { DropdownOption, DropdownOptionGroup } from "@lib/components/Dropdown";
@@ -19,9 +19,9 @@ type ValueConstraintsType = WellboreLogCurveHeader_api[];
 
 export class LogCurveSetting implements CustomSettingImplementation<ValueType, ValueType, ValueConstraintsType> {
     defaultValue: ValueType = null;
-    valueConstraintsIntersectionReducerDefinition = makeValueConstraintsIntersectionReducerDefinition<WellboreLogCurveHeader_api[]>(
-        (a, b) => isEqual(a, b),
-    );
+    valueConstraintsIntersectionReducerDefinition = makeValueConstraintsIntersectionReducerDefinition<
+        WellboreLogCurveHeader_api[]
+    >((a, b) => isEqual(a, b));
 
     mapInternalToExternalValue(internalValue: ValueType): ValueType {
         return internalValue;
@@ -84,12 +84,10 @@ export class LogCurveSetting implements CustomSettingImplementation<ValueType, V
             const selectedValue = makeSelectValueForCurveHeader(props.value);
             const availableValues = props.valueConstraints ?? [];
 
-            const curveOptions = chain(availableValues)
-                .groupBy("logName")
-                .entries()
-                .map(makeLogOptionGroup)
-                .sortBy([sortStatLogsToTop, "label"])
-                .value();
+            const valuesByLogName = groupBy(availableValues, "logName");
+            const valuesByLogNameEntries = entries(valuesByLogName);
+            const logOptionGroups = valuesByLogNameEntries.map(makeLogOptionGroup);
+            const sortedCurveOptions = sortBy(logOptionGroups, [sortStatLogsToTop, "label"]);
 
             function handleChange(selectedIdent: string) {
                 const selected = availableValues.find((v) => makeSelectValueForCurveHeader(v) === selectedIdent);
@@ -100,7 +98,7 @@ export class LogCurveSetting implements CustomSettingImplementation<ValueType, V
             return (
                 <Dropdown
                     filter
-                    options={curveOptions}
+                    options={sortedCurveOptions}
                     value={selectedValue}
                     onChange={handleChange}
                     disabled={props.isOverridden}
@@ -118,9 +116,12 @@ function makeCurveOption(curve: WellboreLogCurveHeader_api): DropdownOption {
 }
 
 function makeLogOptionGroup([logName, logCurves]: [string, WellboreLogCurveHeader_api[]]): DropdownOptionGroup {
+    const curveOptions = logCurves.map(makeCurveOption);
+    const sortedCurveOptions = sortBy(curveOptions, "label");
+
     return {
         label: logName,
-        options: chain(logCurves).map(makeCurveOption).sortBy("label").value(),
+        options: sortedCurveOptions,
     };
 }
 

--- a/frontend/src/modules/_shared/components/Readout/ReadoutList.tsx
+++ b/frontend/src/modules/_shared/components/Readout/ReadoutList.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { chain } from "lodash-es";
+import { entries, groupBy, map, sortBy, uniq } from "lodash-es";
 
 import type { CategoricalReadout, ReadoutProperty } from "./types";
 
@@ -15,14 +15,12 @@ export type ReadoutListProps = {
 
 export function ReadoutList(props: ReadoutListProps): React.ReactNode {
     let titleCount = 0;
-    const numGroups = chain(props.readouts).map("group").uniq().value().length;
+    const numGroups = uniq(map(props.readouts, "group")).length;
 
     const groupEntries = React.useMemo(() => {
-        return chain(props.readouts)
-            .groupBy((readout) => readout.group ?? "default")
-            .entries()
-            .sortBy(([group]) => (group === "default" ? 0 : 1)) // Default should always be first
-            .value();
+        const readoutsByGroup = groupBy(props.readouts, (readout) => readout.group ?? "default");
+        const readoutsByGroupEntries = entries(readoutsByGroup);
+        return sortBy(readoutsByGroupEntries, ([group]) => (group === "default" ? 0 : 1)); // Default should always be first
     }, [props.readouts]);
 
     function makeTitleAdornment() {


### PR DESCRIPTION

* Since `lodash-es` gets tree-shaken on build, the chain utility doesn't work, even though `@types/lodash-es` exposes it
  * Removed all uses uses of `chain()`
  * Added linter rule to avoid developers using it in the future
* Fixed an undefined data state in WellLogViewer
* Fixed a 400 error in causing a crash in log curve headers endpoint 