### PR TITLE
Fixed SeismicFenceMeshLayer crashing if properties contains NaN

### DIFF
--- a/frontend/src/modules/3DViewer/customDeckGlLayers/SeismicFenceMeshLayer/SeismicFenceMeshLayer.ts
+++ b/frontend/src/modules/3DViewer/customDeckGlLayers/SeismicFenceMeshLayer/SeismicFenceMeshLayer.ts
@@ -11,7 +11,7 @@ import type { ExtendedLayerProps } from "@webviz/subsurface-viewer";
 import type { ReportBoundingBoxAction } from "@webviz/subsurface-viewer/dist/layers/utils/layerTools";
 import type { BoundingBox3D } from "@webviz/subsurface-viewer/dist/utils";
 import { transfer, wrap } from "comlink";
-import { isEqual } from "lodash-es";
+import { isEqual, isNaN } from "lodash-es";
 
 import { assertNonNull } from "@lib/utils/assertNonNull";
 import type { Geometry as LoadingGeometry } from "@lib/utils/geometry";
@@ -293,6 +293,8 @@ export class SeismicFenceMeshLayer extends CompositeLayer<SeismicFenceMeshLayerP
         let minProperty = Number.MAX_VALUE;
         let maxProperty = -Number.MAX_VALUE;
         for (let i = 0; i < data.properties.length; i++) {
+            if (Number.isNaN(data.properties[i])) continue;
+
             minProperty = Math.min(minProperty, data.properties[i]);
             maxProperty = Math.max(maxProperty, data.properties[i]);
         }
@@ -305,7 +307,8 @@ export class SeismicFenceMeshLayer extends CompositeLayer<SeismicFenceMeshLayerP
 
         let colorIndex = 0;
         for (let i = 0; i < data.properties.length; i++) {
-            const property = data.properties[i];
+            const property = isNaN(data.properties[i]) ? 0 : data.properties[i];
+
             const [r, g, b, a] = colorMapFunction(property);
             colorsArray[colorIndex * 4 + 0] = r / 255;
             colorsArray[colorIndex * 4 + 1] = g / 255;

--- a/frontend/src/modules/3DViewer/customDeckGlLayers/SeismicFenceMeshLayer/SeismicFenceMeshLayer.ts
+++ b/frontend/src/modules/3DViewer/customDeckGlLayers/SeismicFenceMeshLayer/SeismicFenceMeshLayer.ts
@@ -299,6 +299,17 @@ export class SeismicFenceMeshLayer extends CompositeLayer<SeismicFenceMeshLayerP
             maxProperty = Math.max(maxProperty, data.properties[i]);
         }
 
+        if (minProperty === Number.MAX_VALUE && maxProperty === -Number.MAX_VALUE) {
+            minProperty = -1;
+            maxProperty = 1;
+        }
+
+        if (minProperty === maxProperty) {
+            // Avoid division by zero in encodePropertyToColor
+            minProperty -= 1;
+            maxProperty += 1;
+        }
+
         this.setState({
             ...this.state,
             minProperty,

--- a/frontend/src/modules/3DViewer/customDeckGlLayers/SeismicFenceMeshLayer/SeismicFenceMeshLayer.ts
+++ b/frontend/src/modules/3DViewer/customDeckGlLayers/SeismicFenceMeshLayer/SeismicFenceMeshLayer.ts
@@ -47,9 +47,11 @@ export interface SeismicFenceMeshLayerProps extends ExtendedLayerProps {
 }
 
 function encodePropertyToColor(property: number, min: number, max: number): [number, number, number] {
+    if (isNaN(property)) return [1, 0, 0]; // Allow NaN values to be explicitly picked
+
     const normalized = (property - min) / (max - min);
     const safeNormalized = Math.max(1 / 16777215, normalized); // avoid zero
-    const colorIndex = Math.floor(safeNormalized * 16777215);
+    const colorIndex = Math.floor(safeNormalized * 16777215) + 1; // Add 1 to separate from
     const r = (colorIndex >> 16) & 255;
     const g = (colorIndex >> 8) & 255;
     const b = colorIndex & 255;
@@ -57,7 +59,9 @@ function encodePropertyToColor(property: number, min: number, max: number): [num
 }
 
 function decodeColorToProperty(r: number, g: number, b: number, min: number, max: number): number {
-    const colorIndex = r * 256 * 256 + g * 256 + b;
+    if (isEqual([r, g, b], [1, 0, 0])) return NaN;
+
+    const colorIndex = r * 256 * 256 + g * 256 + b - 1;
     const normalized = colorIndex / 16777215;
     return normalized * (max - min) + min;
 }
@@ -318,7 +322,8 @@ export class SeismicFenceMeshLayer extends CompositeLayer<SeismicFenceMeshLayerP
 
         let colorIndex = 0;
         for (let i = 0; i < data.properties.length; i++) {
-            const property = isNaN(data.properties[i]) ? 0 : data.properties[i];
+            const trueProperty = data.properties[i];
+            const property = isNaN(trueProperty) ? 0 : trueProperty;
 
             const [r, g, b, a] = colorMapFunction(property);
             colorsArray[colorIndex * 4 + 0] = r / 255;
@@ -326,7 +331,7 @@ export class SeismicFenceMeshLayer extends CompositeLayer<SeismicFenceMeshLayerP
             colorsArray[colorIndex * 4 + 2] = b / 255;
             colorsArray[colorIndex * 4 + 3] = a / 255;
 
-            const [r2, g2, b2] = encodePropertyToColor(property, minProperty, maxProperty);
+            const [r2, g2, b2] = encodePropertyToColor(trueProperty, minProperty, maxProperty);
             pickingColorsArray[i * 3 + 0] = r2;
             pickingColorsArray[i * 3 + 1] = g2;
             pickingColorsArray[i * 3 + 2] = b2;

--- a/frontend/src/modules/Intersection/DataProviderFramework/visualization/createSeismicLayerItemsMaker.ts
+++ b/frontend/src/modules/Intersection/DataProviderFramework/visualization/createSeismicLayerItemsMaker.ts
@@ -68,7 +68,7 @@ export function createSeismicLayerItemsMaker({
 
     const seismicFenceSectionLengths = getStoredData("seismicFencePolylineWithSectionLengths")?.actualSectionLengths;
 
-    if (!fenceData || !seismicFenceSectionLengths || !colorScale || isLoading || !valueRange) {
+    if (!fenceData || !seismicFenceSectionLengths || !colorScale || isLoading) {
         return null;
     }
 
@@ -87,7 +87,7 @@ export function createSeismicLayerItemsMaker({
 
     const adjustedColorScale = colorScale.clone();
     if (!useCustomColorScaleBoundaries) {
-        const { min, max, mid } = createSeismicColorScaleValues(valueRange);
+        const { min, max, mid } = createSeismicColorScaleValues(valueRange ?? [-1, 1]);
         adjustedColorScale.setRangeAndMidPoint(min, max, mid);
     }
 

--- a/frontend/src/modules/_shared/DataProviderFramework/dataProviders/implementations/seismicProviders/IntersectionSeismicProvider.ts
+++ b/frontend/src/modules/_shared/DataProviderFramework/dataProviders/implementations/seismicProviders/IntersectionSeismicProvider.ts
@@ -115,6 +115,11 @@ export class IntersectionSeismicProvider implements CustomDataProviderImplementa
             .filter((value) => !Number.isNaN(value))
             .reduce((acc, value) => Math.max(acc, value), -Infinity);
 
+        // Discard infinite scales
+        if (minValue === Infinity || maxValue === -Infinity) {
+            return null;
+        }
+
         return [minValue, maxValue];
     }
 
@@ -141,7 +146,6 @@ export class IntersectionSeismicProvider implements CustomDataProviderImplementa
         queryClient,
         workbenchSession,
     }: SetupBindingsContext<IntersectionSeismicSettings, IntersectionSeismicStoredData>): void {
-
         setting(Setting.REALIZATION).bindAttributes({
             read(read) {
                 return {


### PR DESCRIPTION
When a wellbore fence gets extended far enough values in the properties array might become NaN. This was observed on drogon_horizontal, with an extension length of 1500. _I assume it just happens because the fence goes outside of the simulated area?_