### PR TITLE
[HoverService] Synced hover between Polylines, seismic fence layer and intersection modules

### DIFF
--- a/frontend/src/framework/HoverService.ts
+++ b/frontend/src/framework/HoverService.ts
@@ -16,6 +16,7 @@ export enum HoverTopic {
     FACIES = "hover.facies",
     WORLD_POS_UTM = "hover.world_pos_utm",
     POLYLINE_LENGTH_ALONG = "hover.polyline_length_along",
+    SEISMIC_FENCE = "hover.seismic_fence",
 }
 
 export type HoverData = {
@@ -28,6 +29,7 @@ export type HoverData = {
     [HoverTopic.FACIES]: string | null;
     [HoverTopic.WORLD_POS_UTM]: { x?: number; y?: number; z?: number } | null;
     [HoverTopic.POLYLINE_LENGTH_ALONG]: { polylineId: string; lengthAlong: number } | null;
+    [HoverTopic.SEISMIC_FENCE]: { sourceId: string; lengthAlong: number; depth: number } | null;
 };
 
 type ThrottledPublishFunc = _.DebouncedFunc<<T extends keyof HoverData>(topic: T, newValue: HoverData[T]) => void>;
@@ -172,6 +174,8 @@ export function usePublishHoverValue<T extends keyof HoverData>(
 ): (v: HoverData[T]) => void {
     return React.useCallback(
         function updateHoverValue(newValue: HoverData[T]) {
+            console.debug(`[HoverService] ${moduleInstanceId} published to ${topic}`, newValue);
+
             hoverService.updateHoverValue(topic, newValue, moduleInstanceId);
         },
         [hoverService, moduleInstanceId, topic],

--- a/frontend/src/framework/HoverService.ts
+++ b/frontend/src/framework/HoverService.ts
@@ -15,8 +15,7 @@ export enum HoverTopic {
     REGION = "hover.region",
     FACIES = "hover.facies",
     WORLD_POS_UTM = "hover.world_pos_utm",
-    POLYLINE_LENGTH_ALONG = "hover.polyline_length_along",
-    SEISMIC_FENCE = "hover.seismic_fence",
+    FENCE = "hover.fence",
 }
 
 export type HoverData = {
@@ -28,8 +27,7 @@ export type HoverData = {
     [HoverTopic.REGION]: string | null;
     [HoverTopic.FACIES]: string | null;
     [HoverTopic.WORLD_POS_UTM]: { x?: number; y?: number; z?: number } | null;
-    [HoverTopic.POLYLINE_LENGTH_ALONG]: { polylineId: string; lengthAlong: number } | null;
-    [HoverTopic.SEISMIC_FENCE]: { sourceId: string; lengthAlong: number; depth: number } | null;
+    [HoverTopic.FENCE]: { fenceId: string; lengthAlong: number; depth: number | null } | null;
 };
 
 type ThrottledPublishFunc = _.DebouncedFunc<<T extends keyof HoverData>(topic: T, newValue: HoverData[T]) => void>;
@@ -171,12 +169,26 @@ export function usePublishHoverValue<T extends keyof HoverData>(
     topic: T,
     hoverService: HoverService,
     moduleInstanceId: string,
-): (v: HoverData[T]) => void {
+): (v: HoverData[T], caller?: string) => void {
+    // In some cases, a publisher can have separate system that wants to emit hover data. This can
+    // sometimes cause conflicts when one system emits an object while the other does not. To
+    // we only want to emit "null" when none of our potential systems see a hover value.
+    const callerPayloadsRef = React.useRef<Record<string, HoverData[T]>>({});
+
     return React.useCallback(
-        function updateHoverValue(newValue: HoverData[T]) {
+        function updateHoverValue(newValue: HoverData[T], caller = "generic") {
             console.debug(`[HoverService] ${moduleInstanceId} published to ${topic}`, newValue);
 
-            hoverService.updateHoverValue(topic, newValue, moduleInstanceId);
+            callerPayloadsRef.current[caller] = newValue;
+
+            if (newValue === null) {
+                // Only emit a null value if all sources are null
+                if (Object.values(callerPayloadsRef.current).every((v) => v === null)) {
+                    hoverService.updateHoverValue(topic, newValue, moduleInstanceId);
+                }
+            } else {
+                hoverService.updateHoverValue(topic, newValue, moduleInstanceId);
+            }
         },
         [hoverService, moduleInstanceId, topic],
     );

--- a/frontend/src/framework/HoverService.ts
+++ b/frontend/src/framework/HoverService.ts
@@ -177,7 +177,9 @@ export function usePublishHoverValue<T extends keyof HoverData>(
 
     return React.useCallback(
         function updateHoverValue(newValue: HoverData[T], caller = "generic") {
-            console.debug(`[HoverService] ${moduleInstanceId} published to ${topic}`, newValue);
+            if (import.meta.env.DEV) {
+                console.debug(`[HoverService] ${moduleInstanceId} published to ${topic}`, newValue);
+            }
 
             callerPayloadsRef.current[caller] = newValue;
 

--- a/frontend/src/framework/utils/deckgl.ts
+++ b/frontend/src/framework/utils/deckgl.ts
@@ -1,0 +1,27 @@
+import type { Layer, PickingInfo } from "@deck.gl/core";
+/**
+ * Subsurface uses the modelMatrix prop to enable vertical scaling on layers, which causes the coordinates to no longer match the real world
+ * coordinates (aka "normal" space). Built-in subsurface-comp layers will revert this when picking, but our custom layers do not. Use this
+ * utility in getPickingInfo functions to ensure un-scaled coordinates are being used
+ * layers
+ * @param pick A PickingInfo object from a deck.gl layer
+ * @param layerInstance The layer instance that the PickingInfo was generated from
+ * @returns A copy of the picking info with the pick-coordinate reverted to normal-space
+ */
+export function transformPickToNormalSpace<TPickingInfo extends PickingInfo<any, object>>(
+    pick: TPickingInfo,
+    layerInstance: Layer,
+): TPickingInfo {
+    if (pick.coordinate && pick.coordinate.length === 3) {
+        const modelMatrix = layerInstance.props.modelMatrix;
+        const zScale = modelMatrix?.[10] ?? 1;
+        const revertedZCoord = pick.coordinate[2] / zScale;
+
+        return {
+            ...pick,
+            coordinate: pick.coordinate.toSpliced(-1, 1, revertedZCoord),
+        };
+    }
+
+    return pick;
+}

--- a/frontend/src/modules/3DViewer/DataProviderFramework/visualization/makeIntersectionSeismicHoverVisualizationFunction.ts
+++ b/frontend/src/modules/3DViewer/DataProviderFramework/visualization/makeIntersectionSeismicHoverVisualizationFunction.ts
@@ -1,0 +1,111 @@
+import type { Color, Position } from "@deck.gl/core";
+import type { ColumnLayerProps } from "@deck.gl/layers";
+import { LineLayer, ColumnLayer } from "@deck.gl/layers";
+import { chunk } from "lodash-es";
+
+import { HoverTopic } from "@framework/HoverService";
+import { IntersectionType } from "@framework/types/intersection";
+import type {
+    IntersectionSeismicData,
+    IntersectionSeismicSettings,
+    IntersectionSeismicStoredData,
+} from "@modules/_shared/DataProviderFramework/dataProviders/implementations/seismicProviders/IntersectionSeismicProvider";
+import { Setting } from "@modules/_shared/DataProviderFramework/settings/settingsDefinitions";
+import type {
+    HoverVisualizationFunctions,
+    TransformerArgs,
+    VisualizationTarget,
+} from "@modules/_shared/DataProviderFramework/visualization/VisualizationAssembler";
+import { makeSeismicFenceSourceId } from "@modules/_shared/Intersection/seismicIntersectionUtils";
+import { positionAtLengthAlong } from "@modules/_shared/utils/polylineHoverUtils";
+
+const HIGHLIGHT_COLOR = [255, 0, 0, 180] as Color;
+const FENCE_HIGHLIGHT_LAYER_PROPS: Partial<ColumnLayerProps> = {
+    diskResolution: 20,
+    radiusUnits: "pixels",
+
+    flatShading: true,
+    elevationScale: 1,
+    extruded: true,
+    getFillColor: HIGHLIGHT_COLOR,
+    pickable: false,
+    autoHighlight: false,
+};
+
+export function makeIntersectionSeismicHoverVisualizationFunction(
+    args: TransformerArgs<IntersectionSeismicSettings, IntersectionSeismicData, IntersectionSeismicStoredData>,
+): HoverVisualizationFunctions<VisualizationTarget.DECK_GL> {
+    const { id, getData, getSetting, getStoredData } = args;
+    const seismicIntersection = getData();
+    const intersectionSetting = getSetting(Setting.INTERSECTION);
+    const fenceData = getData();
+    const sourcePolylineWithSectionLengths = getStoredData("sourcePolylineWithSectionLengths");
+
+    return {
+        [HoverTopic.SEISMIC_FENCE]: (hoverInfo) => {
+            if (!seismicIntersection) return [];
+            if (!fenceData) return [];
+            if (!hoverInfo) return [];
+            if (!intersectionSetting) return [];
+            if (!sourcePolylineWithSectionLengths) return [];
+            if (hoverInfo.sourceId !== makeSeismicFenceSourceId(intersectionSetting)) return [];
+
+            const data = [];
+
+            // For well-bores, the path-along get's offset by the extension length
+            let lengthAlong = hoverInfo.lengthAlong;
+            if (intersectionSetting.type === IntersectionType.WELLBORE) {
+                lengthAlong += intersectionSetting.extensionLength;
+            }
+
+            const hoverPos = positionAtLengthAlong(
+                chunk(sourcePolylineWithSectionLengths.polylineUtmXy, 2),
+                lengthAlong,
+            );
+            if (!hoverPos) throw new Error("Expected valid path position for hover length along polyline");
+
+            data.push(hoverPos.toSpliced(-1, 1, -hoverInfo.depth));
+
+            return [
+                new ColumnLayer({
+                    ...FENCE_HIGHLIGHT_LAYER_PROPS,
+                    id: `${id}-hovered-fence-column-depth`,
+                    data: data,
+                    radius: 46,
+                    getPosition: (d) => d,
+                    getElevation: 1,
+                }),
+
+                new ColumnLayer({
+                    ...FENCE_HIGHLIGHT_LAYER_PROPS,
+                    id: `${id}-hovered-fence-pos-along`,
+                    data: data,
+                    radius: 16,
+
+                    // The column should go along the entire fence, forming a line through it
+                    getPosition: (d) => d.toSpliced(-1, 1, -fenceData.max_fence_depth) as Position,
+                    getElevation: Math.abs(fenceData.max_fence_depth - fenceData.min_fence_depth),
+                }),
+
+                // On large zoom levels, the column gets hard to see (there is no "min-radius"). This line layer is
+                // obscured by the position column when zoomed in, but as we zoom out, the line layer remains visible
+                // thanks to the min-pixels, making it appear as if the column keeps a min-radius
+                // ! Note that the ordering matters. By having the line layer last, the column layer hides it fully
+                new LineLayer({
+                    id: `${id}-hovered-fence-line-along`,
+                    data: data,
+                    getSourcePosition: (d: number[]) => d.toSpliced(-1, 1, -fenceData.min_fence_depth) as Position,
+                    getTargetPosition: (d: number[]) => d.toSpliced(-1, 1, -fenceData.max_fence_depth) as Position,
+                    getColor: HIGHLIGHT_COLOR,
+
+                    getWidth: 1,
+                    widthMinPixels: 3,
+                    widthMaxPixels: 3,
+
+                    billboard: true,
+                    pickable: false,
+                }),
+            ];
+        },
+    };
+}

--- a/frontend/src/modules/3DViewer/DataProviderFramework/visualization/makeIntersectionSeismicHoverVisualizationFunction.ts
+++ b/frontend/src/modules/3DViewer/DataProviderFramework/visualization/makeIntersectionSeismicHoverVisualizationFunction.ts
@@ -68,6 +68,10 @@ export function makeIntersectionSeismicHoverVisualizationFunction(
 
             data.push(hoverPos.toSpliced(-1, 1, -fenceDepthPos));
 
+            const depthMarkerVisible =
+                hoverInfo.depth !== null &&
+                inBounds(hoverInfo.depth, fenceData.min_fence_depth, fenceData.max_fence_depth);
+
             return [
                 new ColumnLayer({
                     ...FENCE_HIGHLIGHT_LAYER_PROPS,
@@ -76,7 +80,7 @@ export function makeIntersectionSeismicHoverVisualizationFunction(
                     radius: 46,
                     getPosition: (d) => d,
                     getElevation: 1,
-                    visible: hoverInfo.depth !== null,
+                    visible: depthMarkerVisible,
                 }),
 
                 new ColumnLayer({
@@ -111,4 +115,9 @@ export function makeIntersectionSeismicHoverVisualizationFunction(
             ];
         },
     };
+}
+
+/** Similar to lodash's inRange, but with inclusive max  */
+function inBounds(n: number, min: number, max: number) {
+    return n >= min && n <= max;
 }

--- a/frontend/src/modules/3DViewer/DataProviderFramework/visualization/makeIntersectionSeismicHoverVisualizationFunction.ts
+++ b/frontend/src/modules/3DViewer/DataProviderFramework/visualization/makeIntersectionSeismicHoverVisualizationFunction.ts
@@ -23,7 +23,6 @@ const HIGHLIGHT_COLOR = [255, 0, 0, 180] as Color;
 const FENCE_HIGHLIGHT_LAYER_PROPS: Partial<ColumnLayerProps> = {
     diskResolution: 20,
     radiusUnits: "pixels",
-
     flatShading: true,
     elevationScale: 1,
     extruded: true,
@@ -64,7 +63,10 @@ export function makeIntersectionSeismicHoverVisualizationFunction(
                 lengthAlong,
             );
 
-            if (!hoverPos) throw new Error("Expected valid path position for hover length along polyline");
+            // This case should never fire, as a valid hover payload implies the position exists
+            if (!hoverPos) {
+                throw new Error("Expected valid path position for hover length along polyline");
+            }
 
             data.push(hoverPos.toSpliced(-1, 1, -fenceDepthPos));
 

--- a/frontend/src/modules/3DViewer/DataProviderFramework/visualization/makeIntersectionSeismicHoverVisualizationFunction.ts
+++ b/frontend/src/modules/3DViewer/DataProviderFramework/visualization/makeIntersectionSeismicHoverVisualizationFunction.ts
@@ -16,7 +16,7 @@ import type {
     TransformerArgs,
     VisualizationTarget,
 } from "@modules/_shared/DataProviderFramework/visualization/VisualizationAssembler";
-import { makeSeismicFenceSourceId } from "@modules/_shared/Intersection/seismicIntersectionUtils";
+import { makeFenceSourceId } from "@modules/_shared/utils/fence";
 import { positionAtLengthAlong } from "@modules/_shared/utils/polylineHoverUtils";
 
 const HIGHLIGHT_COLOR = [255, 0, 0, 180] as Color;
@@ -42,13 +42,13 @@ export function makeIntersectionSeismicHoverVisualizationFunction(
     const sourcePolylineWithSectionLengths = getStoredData("sourcePolylineWithSectionLengths");
 
     return {
-        [HoverTopic.SEISMIC_FENCE]: (hoverInfo) => {
+        [HoverTopic.FENCE]: (hoverInfo) => {
             if (!seismicIntersection) return [];
             if (!fenceData) return [];
             if (!hoverInfo) return [];
             if (!intersectionSetting) return [];
             if (!sourcePolylineWithSectionLengths) return [];
-            if (hoverInfo.sourceId !== makeSeismicFenceSourceId(intersectionSetting)) return [];
+            if (hoverInfo.fenceId !== makeFenceSourceId(intersectionSetting)) return [];
 
             const data = [];
 
@@ -58,13 +58,15 @@ export function makeIntersectionSeismicHoverVisualizationFunction(
                 lengthAlong += intersectionSetting.extensionLength;
             }
 
+            const fenceDepthPos = hoverInfo.depth ?? 0;
             const hoverPos = positionAtLengthAlong(
                 chunk(sourcePolylineWithSectionLengths.polylineUtmXy, 2),
                 lengthAlong,
             );
+
             if (!hoverPos) throw new Error("Expected valid path position for hover length along polyline");
 
-            data.push(hoverPos.toSpliced(-1, 1, -hoverInfo.depth));
+            data.push(hoverPos.toSpliced(-1, 1, -fenceDepthPos));
 
             return [
                 new ColumnLayer({
@@ -74,6 +76,7 @@ export function makeIntersectionSeismicHoverVisualizationFunction(
                     radius: 46,
                     getPosition: (d) => d,
                     getElevation: 1,
+                    visible: hoverInfo.depth !== null,
                 }),
 
                 new ColumnLayer({

--- a/frontend/src/modules/3DViewer/DataProviderFramework/visualization/makeSeismicIntersectionMeshLayer.ts
+++ b/frontend/src/modules/3DViewer/DataProviderFramework/visualization/makeSeismicIntersectionMeshLayer.ts
@@ -1,5 +1,6 @@
 import type { Layer } from "@deck.gl/core";
 
+import { IntersectionType } from "@framework/types/intersection";
 import {
     SeismicFenceMeshLayer,
     type SeismicFence,
@@ -12,6 +13,7 @@ import type {
 import { Setting } from "@modules/_shared/DataProviderFramework/settings/settingsDefinitions";
 import { makeColorMapFunctionFromColorScale } from "@modules/_shared/DataProviderFramework/visualization/utils/colors";
 import type { TransformerArgs } from "@modules/_shared/DataProviderFramework/visualization/VisualizationAssembler";
+import { makeFenceSourceId } from "@modules/_shared/utils/fence";
 
 function makeTraceXYZPointsArrayFromPolyline(polylineUtmXy: number[], z: number): Float32Array {
     if (polylineUtmXy.length % 2 !== 0) {
@@ -36,8 +38,10 @@ export function makeSeismicIntersectionMeshLayer(
     const opacityPercent = (getSetting(Setting.OPACITY_PERCENT) ?? 100) / 100;
     const valueRange = getDataValueRange();
     const polyline = getStoredData("seismicFencePolylineWithSectionLengths");
+    const sourcePolyline = getStoredData("sourcePolylineWithSectionLengths");
+    const intersectionSetting = getSetting(Setting.INTERSECTION);
 
-    if (!fenceData || !polyline) {
+    if (!fenceData || !polyline || !sourcePolyline || !intersectionSetting) {
         return null;
     }
 
@@ -55,6 +59,11 @@ export function makeSeismicIntersectionMeshLayer(
         vVector: [0, 0, fenceData.max_fence_depth - fenceData.min_fence_depth],
         numSamples: fenceData.num_samples_per_trace,
         properties: fenceData.fenceTracesFloat32Arr,
+        sourceFence: {
+            id: makeFenceSourceId(intersectionSetting),
+            utmXY: sourcePolyline.polylineUtmXy,
+            offset: intersectionSetting?.type === IntersectionType.WELLBORE ? intersectionSetting.extensionLength : 0,
+        },
     };
 
     return new SeismicFenceMeshLayer({

--- a/frontend/src/modules/3DViewer/customDeckGlLayers/SeismicFenceMeshLayer/SeismicFenceMeshLayer.ts
+++ b/frontend/src/modules/3DViewer/customDeckGlLayers/SeismicFenceMeshLayer/SeismicFenceMeshLayer.ts
@@ -385,6 +385,8 @@ export class SeismicFenceMeshLayer extends CompositeLayer<SeismicFenceMeshLayerP
         }
 
         return {
+            // Note that we return the original info without the normal space transform, later
+            // layer picks should always assume non-translated data
             ...info,
             ...extraInfo,
             properties,

--- a/frontend/src/modules/3DViewer/customDeckGlLayers/SeismicFenceMeshLayer/SeismicFenceMeshLayer.ts
+++ b/frontend/src/modules/3DViewer/customDeckGlLayers/SeismicFenceMeshLayer/SeismicFenceMeshLayer.ts
@@ -11,10 +11,12 @@ import type { ExtendedLayerProps } from "@webviz/subsurface-viewer";
 import type { ReportBoundingBoxAction } from "@webviz/subsurface-viewer/dist/layers/utils/layerTools";
 import type { BoundingBox3D } from "@webviz/subsurface-viewer/dist/utils";
 import { transfer, wrap } from "comlink";
-import { isEqual } from "lodash-es";
+import { chunk, isEqual } from "lodash-es";
 
+import { transformPickToNormalSpace } from "@framework/utils/deckgl";
 import { assertNonNull } from "@lib/utils/assertNonNull";
 import type { Geometry as LoadingGeometry } from "@lib/utils/geometry";
+import { lengthAlongAtXyPosition } from "@modules/_shared/utils/polylineHoverUtils";
 
 import { PreviewLayer } from "../PreviewLayer/PreviewLayer";
 
@@ -24,6 +26,9 @@ import MeshWorker from "./_private/webworker/makeMesh.worker?worker";
 import { type WebWorkerParameters, type WebworkerResult } from "./_private/webworker/types";
 
 export type SeismicFenceMeshLayerPickingInfo = {
+    sourceFence?: SeismicFence["sourceFence"];
+    lengthAlongFence?: number;
+    fenceDepth?: number;
     properties?: { name: string; value: number }[];
 } & PickingInfo;
 
@@ -32,6 +37,11 @@ export type SeismicFence = {
     properties: Float32Array;
     traceXYZPointsArray: Float32Array;
     vVector: [number, number, number];
+    sourceFence?: {
+        id: string;
+        utmXY: number[];
+        offset: number;
+    };
 };
 
 export interface SeismicFenceMeshLayerProps extends ExtendedLayerProps {
@@ -325,18 +335,39 @@ export class SeismicFenceMeshLayer extends CompositeLayer<SeismicFenceMeshLayerP
 
         const [r, g, b] = info.color; // Convert from [0, 1] to [0, 255]
         const { minProperty, maxProperty } = this.state;
+        const sourceFence = this.props.data.sourceFence;
 
         const property = decodeColorToProperty(r, g, b, minProperty, maxProperty);
 
         const properties: { name: string; value: number }[] = [{ name: "Property", value: property }];
+        const extraInfo: Partial<SeismicFenceMeshLayerPickingInfo> = {};
 
-        if (info.coordinate?.length === 3) {
-            const depth = (this.props.zIncreaseDownwards ? -1 : 1) * info.coordinate[2];
+        const normalSpaceCoord = transformPickToNormalSpace(info, this).coordinate;
+
+        if (normalSpaceCoord?.length === 3) {
+            const depth = (this.props.zIncreaseDownwards ? -1 : 1) * normalSpaceCoord[2];
+            extraInfo.fenceDepth = depth;
             properties.push({ name: "Depth", value: depth });
+        }
+
+        if (sourceFence && normalSpaceCoord) {
+            const sourceFenceOffset = sourceFence.offset;
+
+            const lengthAlong = lengthAlongAtXyPosition(
+                chunk(sourceFence.utmXY, 2),
+                normalSpaceCoord[0],
+                normalSpaceCoord[1],
+            );
+
+            extraInfo.sourceFence = this.props.data.sourceFence;
+            extraInfo.lengthAlongFence = lengthAlong - sourceFenceOffset;
+
+            properties.push({ name: "Length along", value: lengthAlong - sourceFenceOffset });
         }
 
         return {
             ...info,
+            ...extraInfo,
             properties,
         };
     }

--- a/frontend/src/modules/3DViewer/view/components/VisualizationAssemblerWrapper.tsx
+++ b/frontend/src/modules/3DViewer/view/components/VisualizationAssemblerWrapper.tsx
@@ -12,6 +12,7 @@ import { CustomDataProviderType } from "@modules/3DViewer/DataProviderFramework/
 import { makeDrilledWellTrajectoriesHoverVisualizationFunctions } from "@modules/3DViewer/DataProviderFramework/visualization/makeDrilledWellTrajectoriesHoverVisualizationFunctions";
 import { makeDrilledWellTrajectoriesLayer } from "@modules/3DViewer/DataProviderFramework/visualization/makeDrilledWellTrajectoriesLayer";
 import { makeIntersectionRealizationGridLayer } from "@modules/3DViewer/DataProviderFramework/visualization/makeIntersectionRealizationGridLayer";
+import { makeIntersectionSeismicHoverVisualizationFunction } from "@modules/3DViewer/DataProviderFramework/visualization/makeIntersectionSeismicHoverVisualizationFunction";
 import { makeSeismicIntersectionMeshLayer } from "@modules/3DViewer/DataProviderFramework/visualization/makeSeismicIntersectionMeshLayer";
 import { makeSeismicSlicesLayer } from "@modules/3DViewer/DataProviderFramework/visualization/makeSeismicSlicesLayer";
 import {
@@ -126,6 +127,7 @@ VISUALIZATION_ASSEMBLER.registerDataProviderTransformers(
         transformToVisualization: makeSeismicIntersectionMeshLayer,
         transformToAnnotations: makeColorScaleAnnotation,
         transformToBoundingBox: makeIntersectionSeismicBoundingBox,
+        transformToHoverVisualization: makeIntersectionSeismicHoverVisualizationFunction,
     },
 );
 

--- a/frontend/src/modules/Intersection/DataProviderFramework/visualization/createSeismicLayerItemsMaker.ts
+++ b/frontend/src/modules/Intersection/DataProviderFramework/visualization/createSeismicLayerItemsMaker.ts
@@ -99,6 +99,7 @@ export function createSeismicLayerItemsMaker({
                     {
                         order,
                         data: {
+                            source: fenceData.source,
                             propertyName: attribute ?? "",
                             propertyUnit: "",
                             minFenceDepth: fenceData.min_fence_depth,

--- a/frontend/src/modules/Intersection/view/components/ReadoutWrapper.tsx
+++ b/frontend/src/modules/Intersection/view/components/ReadoutWrapper.tsx
@@ -20,6 +20,8 @@ import type { IntersectionSettingValue } from "@modules/_shared/DataProviderFram
 import { makeFenceSourceId } from "@modules/_shared/utils/fence";
 import type { Interfaces } from "@modules/Intersection/interfaces";
 
+import { inBounds } from "../utils/boundsUtils";
+
 const AXES_LABELS = { xLabel: "Length along", yLabel: "Depth" };
 
 // Needs extra distance for the left side; this avoids overlapping with legend elements.
@@ -37,6 +39,7 @@ export type ReadoutWrapperProps = {
     layerIdToNameMap: Record<string, string>;
     viewport?: Viewport;
     bounds: Bounds;
+    focusBounds: Bounds | null;
     verticalScale: number;
     hoverService: HoverService;
     viewContext: ViewContext<Interfaces>;
@@ -163,16 +166,28 @@ export function ReadoutWrapper(props: ReadoutWrapperProps): React.ReactNode {
     // External hover on fence
     // - vertical red line at the length-along position
     if (fenceSourceId && !isLocallyHoveringRef.current && hoveredFence?.fenceId === fenceSourceId) {
-        const yExtension = Math.abs(props.bounds.y[1] - props.bounds.y[0]) * 0.1;
+        const bounds = props.focusBounds ?? props.bounds;
+
+        const yExtension = Math.abs(bounds.y[1] - bounds.y[0]) * 0.01;
+
         highlightItems.push({
             shape: HighlightItemShape.LINE,
             line: [
-                [hoveredFence.lengthAlong, props.bounds.y[0] - yExtension],
-                [hoveredFence.lengthAlong, props.bounds.y[1] + yExtension],
+                [hoveredFence.lengthAlong, bounds.y[0] - yExtension],
+                [hoveredFence.lengthAlong, bounds.y[1] + yExtension],
             ],
             color: "red",
             paintOrder: 5,
         });
+
+        if (hoveredFence.depth && inBounds([hoveredFence.lengthAlong, hoveredFence.depth], bounds)) {
+            highlightItems.push({
+                shape: HighlightItemShape.CROSS,
+                center: [hoveredFence.lengthAlong, hoveredFence.depth],
+                color: "red",
+                paintOrder: 5,
+            });
+        }
     }
 
     return (

--- a/frontend/src/modules/Intersection/view/components/ReadoutWrapper.tsx
+++ b/frontend/src/modules/Intersection/view/components/ReadoutWrapper.tsx
@@ -11,13 +11,13 @@ import type { EsvIntersectionReadoutEvent, EsvLayer, Bounds } from "@modules/_sh
 import { EsvIntersection } from "@modules/_shared/components/EsvIntersection";
 import type { ReadoutItem as EsvReadoutItem, HighlightItem } from "@modules/_shared/components/EsvIntersection/types";
 import { HighlightItemShape } from "@modules/_shared/components/EsvIntersection/types";
-import { isSeismicLayer, isWellborepathLayer } from "@modules/_shared/components/EsvIntersection/utils/layers";
+import { isWellborepathLayer } from "@modules/_shared/components/EsvIntersection/utils/layers";
 import { esvReadoutToGenericReadout } from "@modules/_shared/components/EsvIntersection/utils/readoutItemUtils";
 import { PositionReadout, type PositionCoordinates } from "@modules/_shared/components/PositionReadout";
 import type { ReadoutItem } from "@modules/_shared/components/ReadoutBox";
 import { ReadoutBox } from "@modules/_shared/components/ReadoutBox";
 import type { IntersectionSettingValue } from "@modules/_shared/DataProviderFramework/settings/implementations/IntersectionSetting";
-import { makeSeismicFenceSourceId } from "@modules/_shared/Intersection/seismicIntersectionUtils";
+import { makeFenceSourceId } from "@modules/_shared/utils/fence";
 import type { Interfaces } from "@modules/Intersection/interfaces";
 
 const AXES_LABELS = { xLabel: "Length along", yLabel: "Depth" };
@@ -53,27 +53,15 @@ export function ReadoutWrapper(props: ReadoutWrapperProps): React.ReactNode {
 
     // Hover synchronization
     const [hoveredMd, setHoveredMd] = useHover(HoverTopic.WELLBORE_MD, props.hoverService, moduleInstanceId);
+    const [hoveredFence, setHoveredFence] = useHover(HoverTopic.FENCE, props.hoverService, moduleInstanceId);
 
     const setHoveredWellbore = usePublishHoverValue(HoverTopic.WELLBORE, props.hoverService, moduleInstanceId);
-    const [polylineHoverData, setPolylineHoverData] = useHover(
-        HoverTopic.POLYLINE_LENGTH_ALONG,
-        props.hoverService,
-        moduleInstanceId,
-    );
 
-    const [hoveredSeismicFence, setHoveredSeismicFence] = useHover(
-        HoverTopic.SEISMIC_FENCE,
-        props.hoverService,
-        moduleInstanceId,
-    );
-
-    // Extract wellbore and polyline id
+    // Extract wellbore and fence id
     const wellboreUuid =
         props.intersectionSource?.type === IntersectionType.WELLBORE ? props.intersectionSource.uuid : null;
-    const polylineId =
-        props.intersectionSource?.type === IntersectionType.CUSTOM_POLYLINE ? props.intersectionSource.uuid : null;
 
-    const fenceSourceId = props.intersectionSource ? makeSeismicFenceSourceId(props.intersectionSource) : "";
+    const fenceSourceId = props.intersectionSource ? makeFenceSourceId(props.intersectionSource) : null;
 
     const formatEsvLayout = React.useCallback(
         function formatEsvLayout(item: EsvReadoutItem, index: number): ReadoutItem {
@@ -113,9 +101,11 @@ export function ReadoutWrapper(props: ReadoutWrapperProps): React.ReactNode {
                 position.y >= props.bounds.y[0] - depthThreshold &&
                 position.y <= props.bounds.y[1] + depthThreshold;
 
-            if (polylineId) {
-                const polylineHoverData = isValidCursorPosition ? { polylineId, lengthAlong: position.x } : null;
-                setPolylineHoverData(polylineHoverData);
+            if (fenceSourceId) {
+                const fenceHoverData = isValidCursorPosition
+                    ? { fenceId: fenceSourceId, lengthAlong: position.x, depth: position.y }
+                    : null;
+                setHoveredFence(fenceHoverData);
             }
 
             if (!isValidCursorPosition || !props.referenceSystem || !position) {
@@ -128,13 +118,13 @@ export function ReadoutWrapper(props: ReadoutWrapperProps): React.ReactNode {
             setMouseCursorUtmCoordinate({ x: utmPos[0], y: utmPos[1], z: position.y });
         },
         [
-            polylineId,
-            props.bounds,
-            props.verticalScale,
             props.viewport,
+            props.verticalScale,
+            props.bounds.y,
+            props.bounds.x,
             props.referenceSystem,
-            setPolylineHoverData,
-            setMouseCursorUtmCoordinate,
+            fenceSourceId,
+            setHoveredFence,
         ],
     );
 
@@ -143,24 +133,12 @@ export function ReadoutWrapper(props: ReadoutWrapperProps): React.ReactNode {
             const items = event.readoutItems;
 
             const wellboreReadoutItem = items.find((item) => isWellborepathLayer(item.layer));
-            const seismicReadoutItem = items.find((item) => isSeismicLayer(item.layer));
-
-            if (seismicReadoutItem && fenceSourceId) {
-                const [lengthAlong, depth] = seismicReadoutItem.point;
-                setHoveredSeismicFence({
-                    depth,
-                    lengthAlong,
-                    sourceId: fenceSourceId,
-                });
-            } else {
-                setHoveredSeismicFence(null);
-            }
 
             publishWellboreHoverEvent(wellboreReadoutItem?.md ?? null);
 
             setReadoutItems(items.map(formatEsvLayout));
         },
-        [fenceSourceId, formatEsvLayout, publishWellboreHoverEvent, setHoveredSeismicFence],
+        [formatEsvLayout, publishWellboreHoverEvent],
     );
 
     const highlightItems: HighlightItem[] = [];
@@ -182,15 +160,15 @@ export function ReadoutWrapper(props: ReadoutWrapperProps): React.ReactNode {
         });
     }
 
-    // External hover on polyline
+    // External hover on fence
     // - vertical red line at the length-along position
-    if (polylineId && !isLocallyHoveringRef.current && polylineHoverData?.polylineId === polylineId) {
+    if (fenceSourceId && !isLocallyHoveringRef.current && hoveredFence?.fenceId === fenceSourceId) {
         const yExtension = Math.abs(props.bounds.y[1] - props.bounds.y[0]) * 0.1;
         highlightItems.push({
             shape: HighlightItemShape.LINE,
             line: [
-                [polylineHoverData.lengthAlong, props.bounds.y[0] - yExtension],
-                [polylineHoverData.lengthAlong, props.bounds.y[1] + yExtension],
+                [hoveredFence.lengthAlong, props.bounds.y[0] - yExtension],
+                [hoveredFence.lengthAlong, props.bounds.y[1] + yExtension],
             ],
             color: "red",
             paintOrder: 5,

--- a/frontend/src/modules/Intersection/view/components/ReadoutWrapper.tsx
+++ b/frontend/src/modules/Intersection/view/components/ReadoutWrapper.tsx
@@ -11,12 +11,13 @@ import type { EsvIntersectionReadoutEvent, EsvLayer, Bounds } from "@modules/_sh
 import { EsvIntersection } from "@modules/_shared/components/EsvIntersection";
 import type { ReadoutItem as EsvReadoutItem, HighlightItem } from "@modules/_shared/components/EsvIntersection/types";
 import { HighlightItemShape } from "@modules/_shared/components/EsvIntersection/types";
-import { isWellborepathLayer } from "@modules/_shared/components/EsvIntersection/utils/layers";
+import { isSeismicLayer, isWellborepathLayer } from "@modules/_shared/components/EsvIntersection/utils/layers";
 import { esvReadoutToGenericReadout } from "@modules/_shared/components/EsvIntersection/utils/readoutItemUtils";
 import { PositionReadout, type PositionCoordinates } from "@modules/_shared/components/PositionReadout";
 import type { ReadoutItem } from "@modules/_shared/components/ReadoutBox";
 import { ReadoutBox } from "@modules/_shared/components/ReadoutBox";
 import type { IntersectionSettingValue } from "@modules/_shared/DataProviderFramework/settings/implementations/IntersectionSetting";
+import { makeSeismicFenceSourceId } from "@modules/_shared/Intersection/seismicIntersectionUtils";
 import type { Interfaces } from "@modules/Intersection/interfaces";
 
 const AXES_LABELS = { xLabel: "Length along", yLabel: "Depth" };
@@ -52,9 +53,16 @@ export function ReadoutWrapper(props: ReadoutWrapperProps): React.ReactNode {
 
     // Hover synchronization
     const [hoveredMd, setHoveredMd] = useHover(HoverTopic.WELLBORE_MD, props.hoverService, moduleInstanceId);
+
     const setHoveredWellbore = usePublishHoverValue(HoverTopic.WELLBORE, props.hoverService, moduleInstanceId);
     const [polylineHoverData, setPolylineHoverData] = useHover(
         HoverTopic.POLYLINE_LENGTH_ALONG,
+        props.hoverService,
+        moduleInstanceId,
+    );
+
+    const [hoveredSeismicFence, setHoveredSeismicFence] = useHover(
+        HoverTopic.SEISMIC_FENCE,
         props.hoverService,
         moduleInstanceId,
     );
@@ -64,6 +72,8 @@ export function ReadoutWrapper(props: ReadoutWrapperProps): React.ReactNode {
         props.intersectionSource?.type === IntersectionType.WELLBORE ? props.intersectionSource.uuid : null;
     const polylineId =
         props.intersectionSource?.type === IntersectionType.CUSTOM_POLYLINE ? props.intersectionSource.uuid : null;
+
+    const fenceSourceId = props.intersectionSource ? makeSeismicFenceSourceId(props.intersectionSource) : "";
 
     const formatEsvLayout = React.useCallback(
         function formatEsvLayout(item: EsvReadoutItem, index: number): ReadoutItem {
@@ -131,13 +141,26 @@ export function ReadoutWrapper(props: ReadoutWrapperProps): React.ReactNode {
     const handleReadoutItemsChange = React.useCallback(
         function handleReadoutItemsChange(event: EsvIntersectionReadoutEvent): void {
             const items = event.readoutItems;
+
             const wellboreReadoutItem = items.find((item) => isWellborepathLayer(item.layer));
+            const seismicReadoutItem = items.find((item) => isSeismicLayer(item.layer));
+
+            if (seismicReadoutItem && fenceSourceId) {
+                const [lengthAlong, depth] = seismicReadoutItem.point;
+                setHoveredSeismicFence({
+                    depth,
+                    lengthAlong,
+                    sourceId: fenceSourceId,
+                });
+            } else {
+                setHoveredSeismicFence(null);
+            }
 
             publishWellboreHoverEvent(wellboreReadoutItem?.md ?? null);
 
             setReadoutItems(items.map(formatEsvLayout));
         },
-        [formatEsvLayout, publishWellboreHoverEvent],
+        [fenceSourceId, formatEsvLayout, publishWellboreHoverEvent, setHoveredSeismicFence],
     );
 
     const highlightItems: HighlightItem[] = [];

--- a/frontend/src/modules/Intersection/view/components/ViewportWrapper.tsx
+++ b/frontend/src/modules/Intersection/view/components/ViewportWrapper.tsx
@@ -62,17 +62,24 @@ export function ViewportWrapper(props: ViewportWrapperProps): React.ReactNode {
     );
 
     // Viewport, bounds, vertical scale, and all related handlers
-    const { viewport, verticalScale, effectiveLayerItemsBounds, updateViewport, updateVerticalScale, handleFitInView } =
-        useViewportState({
-            viewId,
-            viewLinkResult,
-            autofit: autoFitView,
-            layerItemsBounds: props.layerItemsBounds,
-            focusBounds: props.focusBounds,
-            containerSize: mainDivSize,
-            workbenchServices: props.workbenchServices,
-            viewContext: props.viewContext,
-        });
+    const {
+        viewport,
+        verticalScale,
+        effectiveLayerItemsBounds,
+        effectiveFocusBounds,
+        updateViewport,
+        updateVerticalScale,
+        handleFitInView,
+    } = useViewportState({
+        viewId,
+        viewLinkResult,
+        autofit: autoFitView,
+        layerItemsBounds: props.layerItemsBounds,
+        focusBounds: props.focusBounds,
+        containerSize: mainDivSize,
+        workbenchServices: props.workbenchServices,
+        viewContext: props.viewContext,
+    });
 
     const handleViewportChange = React.useCallback(
         function handleViewportChange(newViewport: Viewport) {
@@ -140,6 +147,7 @@ export function ViewportWrapper(props: ViewportWrapperProps): React.ReactNode {
                     layers={props.layerItems}
                     layerIdToNameMap={props.layerItemIdToNameMap}
                     bounds={effectiveLayerItemsBounds}
+                    focusBounds={effectiveFocusBounds}
                     viewport={viewport ?? undefined}
                     hoverService={props.hoverService}
                     viewContext={props.viewContext}

--- a/frontend/src/modules/Intersection/view/hooks/useViewportState.ts
+++ b/frontend/src/modules/Intersection/view/hooks/useViewportState.ts
@@ -40,6 +40,7 @@ export type ViewportState = {
     viewport: Viewport | null;
     verticalScale: number;
     effectiveLayerItemsBounds: Bounds;
+    effectiveFocusBounds: Bounds | null;
     updateViewport: (newViewport: Viewport) => void;
     updateVerticalScale: (newScale: number) => void;
     handleFitInView: () => void;
@@ -285,6 +286,7 @@ export function useViewportState(props: UseViewportStateProps): ViewportState {
         viewport,
         verticalScale,
         effectiveLayerItemsBounds,
+        effectiveFocusBounds,
         updateViewport,
         updateVerticalScale,
         handleFitInView,

--- a/frontend/src/modules/Intersection/view/utils/boundsUtils.ts
+++ b/frontend/src/modules/Intersection/view/utils/boundsUtils.ts
@@ -52,3 +52,9 @@ export function createBoundsForIntersectionView(
 
     return cloneDeep(DEFAULT_INTERSECTION_VIEW_BOUNDS);
 }
+
+export function inBounds(point: [number, number], bounds: Bounds) {
+    const [x, y] = point;
+
+    return x >= bounds.x[0] && x <= bounds.x[1] && y >= bounds.y[0] && y <= bounds.y[1];
+}

--- a/frontend/src/modules/_shared/DataProviderFramework/dataProviders/implementations/seismicProviders/IntersectionSeismicProvider.ts
+++ b/frontend/src/modules/_shared/DataProviderFramework/dataProviders/implementations/seismicProviders/IntersectionSeismicProvider.ts
@@ -11,7 +11,10 @@ import type { PolylineWithSectionLengths } from "@modules/_shared/Intersection/i
 import { createSectionWiseResampledPolylineWithSectionLengths } from "@modules/_shared/Intersection/intersectionPolylineUtils";
 import type { SeismicFenceData_trans } from "@modules/_shared/Intersection/seismicIntersectionTransform";
 import { transformSeismicFenceData } from "@modules/_shared/Intersection/seismicIntersectionTransform";
-import { createSeismicFencePolylineFromPolylineXy } from "@modules/_shared/Intersection/seismicIntersectionUtils";
+import {
+    createSeismicFencePolylineFromPolylineXy,
+    makeSeismicFenceSourceId,
+} from "@modules/_shared/Intersection/seismicIntersectionUtils";
 
 import type {
     CustomDataProviderImplementation,
@@ -52,7 +55,7 @@ export type IntersectionSeismicStoredData = {
     seismicFencePolylineWithSectionLengths: PolylineWithSectionLengths;
 };
 
-export type IntersectionSeismicData = SeismicFenceData_trans;
+export type IntersectionSeismicData = SeismicFenceData_trans & { source: { id: string; name: string } };
 
 export class IntersectionSeismicProvider implements CustomDataProviderImplementation<
     IntersectionSeismicSettings,
@@ -141,7 +144,6 @@ export class IntersectionSeismicProvider implements CustomDataProviderImplementa
         queryClient,
         workbenchSession,
     }: SetupBindingsContext<IntersectionSeismicSettings, IntersectionSeismicStoredData>): void {
-
         setting(Setting.REALIZATION).bindAttributes({
             read(read) {
                 return {
@@ -386,6 +388,8 @@ export class IntersectionSeismicProvider implements CustomDataProviderImplementa
         IntersectionSeismicData,
         IntersectionSeismicStoredData
     >): Promise<IntersectionSeismicData> {
+        const sourceIntersection = assertNonNull(getSetting(Setting.INTERSECTION), "No intersection selected");
+
         const ensembleIdent = assertNonNull(getSetting(Setting.ENSEMBLE), "No ensemble selected");
         const realization = assertNonNull(getSetting(Setting.REALIZATION), "No realization number selected");
         const attribute = assertNonNull(getSetting(Setting.ATTRIBUTE), "No attribute selected");
@@ -399,6 +403,11 @@ export class IntersectionSeismicProvider implements CustomDataProviderImplementa
         if (seismicFencePolylineUtmXy.length < 4) {
             throw new Error("Invalid seismic fence polyline in stored data. Must contain at least two (x,y)-points");
         }
+
+        const source = {
+            id: makeSeismicFenceSourceId(sourceIntersection),
+            name: sourceIntersection.name,
+        };
 
         const apiSeismicFencePolyline = createSeismicFencePolylineFromPolylineXy(seismicFencePolylineUtmXy);
         const queryOptions = postGetSeismicFenceOptions({
@@ -415,7 +424,10 @@ export class IntersectionSeismicProvider implements CustomDataProviderImplementa
             },
         });
 
-        const seismicFenceDataPromise = fetchQuery(queryOptions).then(transformSeismicFenceData);
+        const seismicFenceDataPromise = fetchQuery(queryOptions).then((data) => ({
+            ...transformSeismicFenceData(data),
+            source,
+        }));
 
         return seismicFenceDataPromise;
     }

--- a/frontend/src/modules/_shared/DataProviderFramework/dataProviders/implementations/seismicProviders/IntersectionSeismicProvider.ts
+++ b/frontend/src/modules/_shared/DataProviderFramework/dataProviders/implementations/seismicProviders/IntersectionSeismicProvider.ts
@@ -11,10 +11,8 @@ import type { PolylineWithSectionLengths } from "@modules/_shared/Intersection/i
 import { createSectionWiseResampledPolylineWithSectionLengths } from "@modules/_shared/Intersection/intersectionPolylineUtils";
 import type { SeismicFenceData_trans } from "@modules/_shared/Intersection/seismicIntersectionTransform";
 import { transformSeismicFenceData } from "@modules/_shared/Intersection/seismicIntersectionTransform";
-import {
-    createSeismicFencePolylineFromPolylineXy,
-    makeSeismicFenceSourceId,
-} from "@modules/_shared/Intersection/seismicIntersectionUtils";
+import { createSeismicFencePolylineFromPolylineXy } from "@modules/_shared/Intersection/seismicIntersectionUtils";
+import { makeFenceSourceId } from "@modules/_shared/utils/fence";
 
 import type {
     CustomDataProviderImplementation,
@@ -405,7 +403,7 @@ export class IntersectionSeismicProvider implements CustomDataProviderImplementa
         }
 
         const source = {
-            id: makeSeismicFenceSourceId(sourceIntersection),
+            id: makeFenceSourceId(sourceIntersection),
             name: sourceIntersection.name,
         };
 

--- a/frontend/src/modules/_shared/Intersection/seismicIntersectionUtils.ts
+++ b/frontend/src/modules/_shared/Intersection/seismicIntersectionUtils.ts
@@ -1,10 +1,4 @@
 import type { SeismicFencePolyline_api } from "@api";
-import { IntersectionType } from "@framework/types/intersection";
-
-import type {
-    PolylineIntersectionSettingValue,
-    WellboreIntersectionSettingValue,
-} from "../DataProviderFramework/settings/implementations/IntersectionSetting";
 
 /**
  * Create seismic fence polyline object from polyline XY coordinates.
@@ -77,16 +71,4 @@ export function createSeismicSliceImageYAxisValuesArrayForFence(
         yAxisValues.push(minFenceDepth + ((maxFenceDepth - minFenceDepth) / numSamplesPerTrace) * i);
     }
     return yAxisValues;
-}
-
-export function makeSeismicFenceSourceId(
-    sourceSetting: PolylineIntersectionSettingValue | WellboreIntersectionSettingValue,
-): string {
-    switch (sourceSetting.type) {
-        case IntersectionType.WELLBORE:
-            // ! Extension-length is included, since positionAlong would be dependent on length
-            return `wellbore::${sourceSetting.uuid}::${sourceSetting.extensionLength}`;
-        case IntersectionType.CUSTOM_POLYLINE:
-            return `polyline::${sourceSetting.uuid}`;
-    }
 }

--- a/frontend/src/modules/_shared/Intersection/seismicIntersectionUtils.ts
+++ b/frontend/src/modules/_shared/Intersection/seismicIntersectionUtils.ts
@@ -1,4 +1,10 @@
 import type { SeismicFencePolyline_api } from "@api";
+import { IntersectionType } from "@framework/types/intersection";
+
+import type {
+    PolylineIntersectionSettingValue,
+    WellboreIntersectionSettingValue,
+} from "../DataProviderFramework/settings/implementations/IntersectionSetting";
 
 /**
  * Create seismic fence polyline object from polyline XY coordinates.
@@ -71,4 +77,16 @@ export function createSeismicSliceImageYAxisValuesArrayForFence(
         yAxisValues.push(minFenceDepth + ((maxFenceDepth - minFenceDepth) / numSamplesPerTrace) * i);
     }
     return yAxisValues;
+}
+
+export function makeSeismicFenceSourceId(
+    sourceSetting: PolylineIntersectionSettingValue | WellboreIntersectionSettingValue,
+): string {
+    switch (sourceSetting.type) {
+        case IntersectionType.WELLBORE:
+            // ! Extension-length is included, since positionAlong would be dependent on length
+            return `wellbore::${sourceSetting.uuid}::${sourceSetting.extensionLength}`;
+        case IntersectionType.CUSTOM_POLYLINE:
+            return `polyline::${sourceSetting.uuid}`;
+    }
 }

--- a/frontend/src/modules/_shared/components/EsvIntersection/layers/SeismicLayer.ts
+++ b/frontend/src/modules/_shared/components/EsvIntersection/layers/SeismicLayer.ts
@@ -28,6 +28,7 @@ export type SeismicSliceImageOptions = {
 // Note: This type does not extend SeismicCanvasData because we want to generate the image and seismic info
 // inside this render due to async seismic slice image generation
 export type SeismicLayerData = {
+    source: { id: string; name: string };
     minFenceDepth: number;
     maxFenceDepth: number;
     numTraces: number;

--- a/frontend/src/modules/_shared/components/SubsurfaceViewer/_components/HoverVisualizationWrapper.tsx
+++ b/frontend/src/modules/_shared/components/SubsurfaceViewer/_components/HoverVisualizationWrapper.tsx
@@ -7,14 +7,15 @@ import type { BoundingBox2D, MapMouseEvent, ViewportType } from "@webviz/subsurf
 import { CrosshairLayer } from "@webviz/subsurface-viewer/dist/layers";
 import { inRange } from "lodash-es";
 
-import type { HoverService } from "@framework/HoverService";
+import type { HoverData, HoverService } from "@framework/HoverService";
 import { HoverTopic, useHoverValue, usePublishHoverValue } from "@framework/HoverService";
 import { usePublishSubscribeTopicValue } from "@lib/utils/PublishSubscribeDelegate";
 import { PickingRayLayer } from "@modules/_shared/customDeckGlLayers/PickingRayLayer";
 import { useSubscribedProviderHoverVisualizations } from "@modules/_shared/DataProviderFramework/visualization/hooks/useSubscribedProviderHoverVisualizations";
 import type { VisualizationTarget } from "@modules/_shared/DataProviderFramework/visualization/VisualizationAssembler";
 import type { ViewsTypeExtended } from "@modules/_shared/types/deckgl";
-import { positionAtLengthAlong } from "@modules/_shared/utils/polylineHoverUtils";
+import { getPolylineIdFromFenceId, makeFenceSourceIdForPolyLine } from "@modules/_shared/utils/fence";
+import { lengthAlongAtXyPosition, positionAtLengthAlong } from "@modules/_shared/utils/polylineHoverUtils";
 import type { DeckGlInstanceManager } from "@modules/_shared/utils/subsurfaceViewer/DeckGlInstanceManager";
 import type { PolylinesPlugin } from "@modules/_shared/utils/subsurfaceViewer/PolylinesPlugin";
 import { PolylineEditingMode, PolylinesPluginTopic } from "@modules/_shared/utils/subsurfaceViewer/PolylinesPlugin";
@@ -50,11 +51,7 @@ export function HoverVisualizationWrapper(props: HoverVisualizationWrapperProps)
     );
     const publishHoveredWellbore = usePublishHoverValue(HoverTopic.WELLBORE, ctx.hoverService, ctx.moduleInstanceId);
     const publishHoveredMd = usePublishHoverValue(HoverTopic.WELLBORE_MD, ctx.hoverService, ctx.moduleInstanceId);
-    const publishHoveredPolylineLengthAlong = usePublishHoverValue(
-        HoverTopic.POLYLINE_LENGTH_ALONG,
-        ctx.hoverService,
-        ctx.moduleInstanceId,
-    );
+    const publishHoveredFence = usePublishHoverValue(HoverTopic.FENCE, ctx.hoverService, ctx.moduleInstanceId);
 
     const crossHairLayer = useCrosshairLayer(ctx.bounds, ctx.hoverService, ctx.moduleInstanceId);
     const pickingRayLayers = usePickingRayLayers(unscaledCoordinatesPerView, false);
@@ -70,15 +67,37 @@ export function HoverVisualizationWrapper(props: HoverVisualizationWrapperProps)
         ctx.moduleInstanceId,
     );
 
-    const publishHoveredPolylineLengthAlongRef = React.useRef(publishHoveredPolylineLengthAlong);
-    publishHoveredPolylineLengthAlongRef.current = publishHoveredPolylineLengthAlong;
+    const publishHoveredFenceRef = React.useRef(publishHoveredFence);
+    publishHoveredFenceRef.current = publishHoveredFence;
 
     React.useEffect(
         function subscribeToPolylineHover() {
             return props.polylinesPlugin
                 .getPublishSubscribeDelegate()
                 .makeSubscriberFunction(PolylinesPluginTopic.POLYLINE_HOVER)(() => {
-                publishHoveredPolylineLengthAlongRef.current(props.polylinesPlugin.getPolylineHoverData());
+                const polylineData = props.polylinesPlugin.getPolylineHoverData();
+
+                let payload: HoverData[HoverTopic.FENCE] = null;
+
+                if (polylineData) {
+                    const fenceLengthAlong = convertPolylineLengthAlongToFenceLengthAlong(
+                        polylineData.path,
+                        polylineData.lengthAlong,
+                    );
+
+                    if (fenceLengthAlong) {
+                        // Also grab the polyline's 3D position as the depth
+                        const polylinePosition = positionAtLengthAlong(polylineData.path, polylineData.lengthAlong);
+                        const polylineDepth = -polylinePosition![2];
+
+                        payload = {
+                            fenceId: makeFenceSourceIdForPolyLine(polylineData.polylineId),
+                            lengthAlong: fenceLengthAlong,
+                            depth: polylineDepth,
+                        };
+                    }
+                }
+                publishHoveredFenceRef.current(payload, "polyline-plugin");
             });
         },
         [props.polylinesPlugin],
@@ -128,13 +147,15 @@ export function HoverVisualizationWrapper(props: HoverVisualizationWrapperProps)
                 HoverTopic.WELLBORE_MD,
                 HoverTopic.WELLBORE,
                 HoverTopic.WORLD_POS_UTM,
+                HoverTopic.FENCE,
             );
 
             publishHoveredWorldPos(hoverData[HoverTopic.WORLD_POS_UTM]);
             publishHoveredWellbore(hoverData[HoverTopic.WELLBORE]);
             publishHoveredMd(hoverData[HoverTopic.WELLBORE_MD]);
+            publishHoveredFence(hoverData[HoverTopic.FENCE], "provider-layers");
         },
-        [publishHoveredMd, publishHoveredWellbore, publishHoveredWorldPos],
+        [publishHoveredMd, publishHoveredFence, publishHoveredWellbore, publishHoveredWorldPos],
     );
 
     const handleViewportHover = React.useCallback(function handleViewportHover(viewport: ViewportType | null) {
@@ -198,14 +219,27 @@ function usePolylineHoverMarkerLayer(
     hoverService: HoverService,
     instanceId: string,
 ): ScatterplotLayer {
-    const hovered = useHoverValue(HoverTopic.POLYLINE_LENGTH_ALONG, hoverService, instanceId);
+    const hovered = useHoverValue(HoverTopic.FENCE, hoverService, instanceId);
     const polylineEditingMode = usePublishSubscribeTopicValue(polylinesPlugin, PolylinesPluginTopic.EDITING_MODE);
     const availablePolylines = usePublishSubscribeTopicValue(polylinesPlugin, PolylinesPluginTopic.POLYLINES);
 
     let position: [number, number, number] | null = null;
+
     if (polylineEditingMode !== PolylineEditingMode.DISABLED && hovered) {
-        const polyline = availablePolylines.find((p) => p.id === hovered.polylineId);
-        position = polyline ? positionAtLengthAlong(polyline.path, hovered.lengthAlong) : null;
+        const hoveredPolylineId = getPolylineIdFromFenceId(hovered.fenceId);
+
+        const polyline = availablePolylines.find((p) => p.id === hoveredPolylineId);
+
+        if (polyline) {
+            // The fence payload will be the length along a XY line following the polyline. The polyline
+            // might have 3D positions, so we need to convert to a length in 3D space.
+            const polylineLengthAlong = convertFenceLengthAlongToPolylineLengthAlong(
+                polyline.path,
+                hovered.lengthAlong,
+            );
+
+            position = polylineLengthAlong ? positionAtLengthAlong(polyline.path, polylineLengthAlong) : null;
+        }
     }
 
     return new ScatterplotLayer({
@@ -246,4 +280,40 @@ function usePickingRayLayers(
     }
 
     return pickingRayLayers;
+}
+
+function convertPolylineLengthAlongToFenceLengthAlong(
+    polylinePath: number[][],
+    polylineLengthAlong: number,
+): number | null {
+    // This is arguably a sub-optimal approach, but polyline paths are expected to only be a few segments,
+    // so this should be fine for now...
+    // Get the position for this point along the 3D-space poly-line
+    const polylinePos = positionAtLengthAlong(polylinePath, polylineLengthAlong);
+
+    if (!polylinePos) return null;
+
+    // The fence only cares about XY positions, but otherwise matches the polyline.
+    const fenceLengthAlongConverted = lengthAlongAtXyPosition(
+        polylinePath.map((v) => [v[0], v[1]]),
+        polylinePos[0],
+        polylinePos[1],
+    );
+
+    return fenceLengthAlongConverted;
+}
+
+function convertFenceLengthAlongToPolylineLengthAlong(polylinePath: number[][], lengthAlong: number): number | null {
+    // Get the position for this length-along in the XY-plane
+    const fencePos = positionAtLengthAlong(
+        polylinePath.map((v) => [v[0], v[1]]),
+        lengthAlong,
+    );
+
+    if (!fencePos) {
+        return null;
+    }
+
+    const polylineLengthAlong = lengthAlongAtXyPosition(polylinePath, fencePos[0], fencePos[1]);
+    return polylineLengthAlong;
 }

--- a/frontend/src/modules/_shared/components/SubsurfaceViewer/_components/HoverVisualizationWrapper.tsx
+++ b/frontend/src/modules/_shared/components/SubsurfaceViewer/_components/HoverVisualizationWrapper.tsx
@@ -17,7 +17,11 @@ import type { ViewsTypeExtended } from "@modules/_shared/types/deckgl";
 import { getPolylineIdFromFenceId, makeFenceSourceIdForPolyLine } from "@modules/_shared/utils/fence";
 import { lengthAlongAtXyPosition, positionAtLengthAlong } from "@modules/_shared/utils/polylineHoverUtils";
 import type { DeckGlInstanceManager } from "@modules/_shared/utils/subsurfaceViewer/DeckGlInstanceManager";
-import type { PolylinesPlugin } from "@modules/_shared/utils/subsurfaceViewer/PolylinesPlugin";
+import type {
+    Polyline,
+    PolylineHoverData,
+    PolylinesPlugin,
+} from "@modules/_shared/utils/subsurfaceViewer/PolylinesPlugin";
 import { PolylineEditingMode, PolylinesPluginTopic } from "@modules/_shared/utils/subsurfaceViewer/PolylinesPlugin";
 import { getHoverDataInPicks } from "@modules/_shared/utils/subsurfaceViewerLayers";
 
@@ -76,27 +80,8 @@ export function HoverVisualizationWrapper(props: HoverVisualizationWrapperProps)
                 .getPublishSubscribeDelegate()
                 .makeSubscriberFunction(PolylinesPluginTopic.POLYLINE_HOVER)(() => {
                 const polylineData = props.polylinesPlugin.getPolylineHoverData();
+                const payload = makeFenceHoverPayloadFromPolylineHoverData(polylineData);
 
-                let payload: HoverData[HoverTopic.FENCE] = null;
-
-                if (polylineData) {
-                    const fenceLengthAlong = convertPolylineLengthAlongToFenceLengthAlong(
-                        polylineData.path,
-                        polylineData.lengthAlong,
-                    );
-
-                    if (fenceLengthAlong) {
-                        // Also grab the polyline's 3D position as the depth
-                        const polylinePosition = positionAtLengthAlong(polylineData.path, polylineData.lengthAlong);
-                        const polylineDepth = -polylinePosition![2];
-
-                        payload = {
-                            fenceId: makeFenceSourceIdForPolyLine(polylineData.polylineId),
-                            lengthAlong: fenceLengthAlong,
-                            depth: polylineDepth,
-                        };
-                    }
-                }
                 publishHoveredFenceRef.current(payload, "polyline-plugin");
             });
         },
@@ -226,20 +211,7 @@ function usePolylineHoverMarkerLayer(
     let position: [number, number, number] | null = null;
 
     if (polylineEditingMode !== PolylineEditingMode.DISABLED && hovered) {
-        const hoveredPolylineId = getPolylineIdFromFenceId(hovered.fenceId);
-
-        const polyline = availablePolylines.find((p) => p.id === hoveredPolylineId);
-
-        if (polyline) {
-            // The fence payload will be the length along a XY line following the polyline. The polyline
-            // might have 3D positions, so we need to convert to a length in 3D space.
-            const polylineLengthAlong = convertFenceLengthAlongToPolylineLengthAlong(
-                polyline.path,
-                hovered.lengthAlong,
-            );
-
-            position = polylineLengthAlong ? positionAtLengthAlong(polyline.path, polylineLengthAlong) : null;
-        }
+        position = getPolylinePositionFromFenceLenghtAlong(hovered, availablePolylines);
     }
 
     return new ScatterplotLayer({
@@ -282,12 +254,16 @@ function usePickingRayLayers(
     return pickingRayLayers;
 }
 
-function convertPolylineLengthAlongToFenceLengthAlong(
-    polylinePath: number[][],
-    polylineLengthAlong: number,
-): number | null {
-    // This is arguably a sub-optimal approach, but polyline paths are expected to only be a few segments,
-    // so this should be fine for now...
+function makeFenceHoverPayloadFromPolylineHoverData(
+    polylineHoverData: PolylineHoverData | null,
+): HoverData[HoverTopic.FENCE] | null {
+    if (!polylineHoverData) return null;
+    // Iterating the path multiple-times is arguably a sub-optimal approach, but polyline
+    // paths are expected to only be a few segments, so this should be fine for now...
+    const polylineFenceId = makeFenceSourceIdForPolyLine(polylineHoverData.polylineId);
+    const polylinePath = polylineHoverData.path;
+    const polylineLengthAlong = polylineHoverData.lengthAlong;
+
     // Get the position for this point along the 3D-space poly-line
     const polylinePos = positionAtLengthAlong(polylinePath, polylineLengthAlong);
 
@@ -300,20 +276,41 @@ function convertPolylineLengthAlongToFenceLengthAlong(
         polylinePos[1],
     );
 
-    return fenceLengthAlongConverted;
+    return {
+        fenceId: polylineFenceId,
+        lengthAlong: fenceLengthAlongConverted,
+        // The hovered position's z-coordinate is a
+        depth: -polylinePos[2],
+    };
 }
 
-function convertFenceLengthAlongToPolylineLengthAlong(polylinePath: number[][], lengthAlong: number): number | null {
-    // Get the position for this length-along in the XY-plane
-    const fencePos = positionAtLengthAlong(
-        polylinePath.map((v) => [v[0], v[1]]),
-        lengthAlong,
-    );
+function getPolylinePositionFromFenceLenghtAlong(
+    fenceHoverData: HoverData[HoverTopic.FENCE],
+    availablePolylines: Polyline[],
+) {
+    if (!fenceHoverData) return null;
 
-    if (!fencePos) {
+    const hoveredFenceId = getPolylineIdFromFenceId(fenceHoverData.fenceId);
+    const hoveredPolyline = availablePolylines.find((p) => p.id === hoveredFenceId);
+
+    if (!hoveredPolyline) {
         return null;
     }
 
-    const polylineLengthAlong = lengthAlongAtXyPosition(polylinePath, fencePos[0], fencePos[1]);
-    return polylineLengthAlong;
+    // Get the position for this length-along in the XY-plane
+    const fencePos = positionAtLengthAlong(
+        hoveredPolyline.path.map((v) => [v[0], v[1]]),
+        fenceHoverData.lengthAlong,
+    )!;
+
+    if (!fencePos) {
+        // This case should technically never occur, since hover triggering implies a valid fence pos
+        console.warn("Unable to find position on polyline");
+        return null;
+    }
+
+    const [hoverX, hoverY] = fencePos;
+    const polylineLengthAlong = lengthAlongAtXyPosition(hoveredPolyline.path, hoverX, hoverY);
+
+    return positionAtLengthAlong(hoveredPolyline.path, polylineLengthAlong);
 }

--- a/frontend/src/modules/_shared/utils/fence.ts
+++ b/frontend/src/modules/_shared/utils/fence.ts
@@ -1,0 +1,39 @@
+import { IntersectionType } from "@framework/types/intersection";
+
+export type FenceSource = {
+    type: IntersectionType;
+    uuid: string;
+};
+
+export type PolylineFenceSource = FenceSource & {
+    type: IntersectionType.CUSTOM_POLYLINE;
+};
+
+export type WellboreFenceSource = FenceSource & {
+    type: IntersectionType.WELLBORE;
+    extensionLength: number;
+};
+
+export function makeFenceSourceId(sourceSetting: PolylineFenceSource | WellboreFenceSource): string {
+    switch (sourceSetting.type) {
+        case IntersectionType.WELLBORE:
+            return makeFenceSourceIdForWellbore(sourceSetting.uuid, sourceSetting.extensionLength);
+        case IntersectionType.CUSTOM_POLYLINE:
+            return makeFenceSourceIdForPolyLine(sourceSetting.uuid);
+    }
+}
+
+export function makeFenceSourceIdForWellbore(wellboreId: string, extensionLength: number) {
+    // ! Extension-length is included since positionAlong would be dependent on length
+    return `wellbore::${wellboreId}::${extensionLength}`;
+}
+
+export function makeFenceSourceIdForPolyLine(polylineId: string) {
+    return `polyline::${polylineId}`;
+}
+
+export function getPolylineIdFromFenceId(fenceId: string): string | undefined {
+    const [type, id] = fenceId.split("::");
+
+    return type === "polyline" ? id : undefined;
+}

--- a/frontend/src/modules/_shared/utils/subsurfaceViewer/PolylinesPlugin.tsx
+++ b/frontend/src/modules/_shared/utils/subsurfaceViewer/PolylinesPlugin.tsx
@@ -42,11 +42,13 @@ export enum PolylinesPluginTopic {
     POLYLINE_HOVER = "polyline_hover",
 }
 
+export type PolylineHoverData = { polylineId: string; lengthAlong: number; path: number[][] };
+
 export type PolylinesPluginTopicPayloads = {
     [PolylinesPluginTopic.EDITING_MODE]: PolylineEditingMode;
     [PolylinesPluginTopic.EDITING_POLYLINE_ID]: string | null;
     [PolylinesPluginTopic.POLYLINES]: Polyline[];
-    [PolylinesPluginTopic.POLYLINE_HOVER]: { polylineId: string; lengthAlong: number } | null;
+    [PolylinesPluginTopic.POLYLINE_HOVER]: PolylineHoverData | null;
 };
 
 enum AppendToPathLocation {
@@ -80,7 +82,7 @@ export class PolylinesPlugin extends DeckGlPlugin implements PublishSubscribe<Po
     private _appendToPathLocation: AppendToPathLocation = AppendToPathLocation.END;
     private _selectedPolylineId: string | null = null;
     private _hoverPoint: number[] | null = null;
-    private _polylineHoverData: { polylineId: string; lengthAlong: number } | null = null;
+    private _polylineHoverData: PolylineHoverData | null = null;
     private _visiblePolylineIds: string[] = [];
     private _colorGenerator: Generator<[number, number, number]>;
 
@@ -165,7 +167,7 @@ export class PolylinesPlugin extends DeckGlPlugin implements PublishSubscribe<Po
         return this._editingMode;
     }
 
-    getPolylineHoverData(): { polylineId: string; lengthAlong: number } | null {
+    getPolylineHoverData(): PolylineHoverData | null {
         return this._polylineHoverData;
     }
 
@@ -345,7 +347,7 @@ export class PolylinesPlugin extends DeckGlPlugin implements PublishSubscribe<Po
 
             const [x, y] = pickingInfo.coordinate;
             const lengthAlong = lengthAlongAtXyPosition(polyline.path, x, y);
-            const newHoverData = { polylineId: polyline.id, lengthAlong };
+            const newHoverData = { polylineId: polyline.id, lengthAlong, path: polyline.path };
             if (!isEqual(this._polylineHoverData, newHoverData)) {
                 this._polylineHoverData = newHoverData;
                 this._publishSubscribeDelegate.notifySubscribers(PolylinesPluginTopic.POLYLINE_HOVER);

--- a/frontend/src/modules/_shared/utils/subsurfaceViewerLayers.ts
+++ b/frontend/src/modules/_shared/utils/subsurfaceViewerLayers.ts
@@ -14,6 +14,8 @@ import { HoverTopic } from "@framework/HoverService";
 import type { HoverData } from "@framework/HoverService";
 import type { FlowDataColors } from "@framework/types/wellbore";
 import { InjectionPhase, ProductionPhase } from "@framework/types/wellbore";
+import type { SeismicFenceMeshLayerPickingInfo } from "@modules/3DViewer/customDeckGlLayers/SeismicFenceMeshLayer/SeismicFenceMeshLayer";
+import { SeismicFenceMeshLayer } from "@modules/3DViewer/customDeckGlLayers/SeismicFenceMeshLayer/SeismicFenceMeshLayer";
 
 import type { CategoricalReadout, ReadoutProperty } from "../components/Readout/types";
 import { AdjustedWellsLayer } from "../customDeckGlLayers/AdjustedWellsLayer";
@@ -126,6 +128,29 @@ function getTopicHoverDataFromPicks<TTopic extends keyof HoverData>(
 
             return { x, y, z: zValue } as HoverData[TTopic];
         }
+
+        case HoverTopic.FENCE: {
+            const fencePick = getInfoPickForLayer<SeismicFenceMeshLayerPickingInfo>(
+                pickingInfos,
+                SeismicFenceMeshLayer,
+            );
+
+            const fenceId = fencePick?.sourceFence?.id;
+            const lengthAlong = fencePick?.lengthAlongFence;
+
+            if (fenceId && lengthAlong) {
+                const payload: HoverData[HoverTopic.FENCE] = {
+                    fenceId: fenceId,
+                    lengthAlong,
+                    depth: fencePick.fenceDepth ?? null,
+                };
+
+                return payload as HoverData[TTopic];
+            }
+
+            return null;
+        }
+
         default:
             console.warn("Unsupported hover topic", topic);
             return null;


### PR DESCRIPTION
Adds a "position along fence" hover topic to the hover service, replacing the existing "position along polyline" topic.

This topic is now used to show synchronized position hover on:
* The Intersection module
* The 3D-viewer's SeismicFence layer
* Polylines overview

Polylines were the odd one out, so I made the hover payload only worry about the XY plane, and the polyline layer is responsible for converting the fence's position-along to it's own explicit length.