### PR TITLE
[Modules]: Ensure consistent loading experience

### DIFF
--- a/frontend/src/modules/FlowNetwork/settings/atoms/persistableFixableAtoms.ts
+++ b/frontend/src/modules/FlowNetwork/settings/atoms/persistableFixableAtoms.ts
@@ -133,5 +133,5 @@ function computeFlowNetworkQueryResultDependenciesState({
     if (flowNetworkQueryResult.isFetching) {
         return "loading";
     }
-    return !flowNetworkQueryResult.data ? "error" : "loaded";
+    return "loaded";
 }

--- a/frontend/src/modules/Vfp/settings/atoms/persistableFixableAtoms.ts
+++ b/frontend/src/modules/Vfp/settings/atoms/persistableFixableAtoms.ts
@@ -210,5 +210,5 @@ function computeVfpTableQueryDependenciesState({ get }: { get: (atom: any) => an
     if (vfpTableQuery.isFetching) {
         return "loading";
     }
-    return !vfpTableQuery.data ? "error" : "loaded";
+    return "loaded";
 }

--- a/frontend/src/modules/Vfp/settings/atoms/persistableFixableAtoms.ts
+++ b/frontend/src/modules/Vfp/settings/atoms/persistableFixableAtoms.ts
@@ -55,7 +55,7 @@ export const selectedVfpTableNameAtom = persistableFixableAtom<string | null>({
             return "loading";
         }
 
-        return !vfpTableNamesQuery.data ? "error" : "loaded";
+        return "loaded";
     },
     isValidFunction: ({ get, value }) => {
         const availableVfpTableNames = get(availableVfpTableNamesAtom);

--- a/frontend/src/modules/WellLogViewer/interfaces.ts
+++ b/frontend/src/modules/WellLogViewer/interfaces.ts
@@ -4,17 +4,22 @@ import type { DataProviderManager } from "@modules/_shared/DataProviderFramework
 
 import { horizontalLayoutAtom, limitDomainToDataAtom, dataProviderManagerAtom } from "./settings/atoms/baseAtoms";
 import { selectedWellboreHeaderAtom } from "./settings/atoms/derivedAtoms";
-import { selectedFieldIdentAtom } from "./settings/atoms/persistableFixableAtoms";
+import { selectedFieldIdentAtom, selectedWellboreUuidAtom } from "./settings/atoms/persistableFixableAtoms";
 
 export type InterfaceTypes = {
     settingsToView: SettingsToViewInterface;
+};
+
+export type WellboreHeaderStatus = {
+    header: WellboreHeader_api | null;
+    isLoading: boolean;
 };
 
 export type SettingsToViewInterface = {
     providerManager: DataProviderManager | null;
 
     selectedField: string | null;
-    wellboreHeader: WellboreHeader_api | null;
+    wellboreHeaderStatus: WellboreHeaderStatus;
     horizontalLayout: boolean;
     limitDomainToData: boolean;
 };
@@ -22,7 +27,10 @@ export type SettingsToViewInterface = {
 export const settingsToViewInterfaceInitialization: InterfaceInitialization<SettingsToViewInterface> = {
     providerManager: (get) => get(dataProviderManagerAtom),
     selectedField: (get) => get(selectedFieldIdentAtom).value,
-    wellboreHeader: (get) => get(selectedWellboreHeaderAtom),
+    wellboreHeaderStatus: (get) => ({
+        header: get(selectedWellboreHeaderAtom),
+        isLoading: get(selectedWellboreUuidAtom).isLoading,
+    }),
     horizontalLayout: (get) => get(horizontalLayoutAtom),
     limitDomainToData: (get) => get(limitDomainToDataAtom),
 };

--- a/frontend/src/modules/WellLogViewer/view/atoms/interfaceEffects.ts
+++ b/frontend/src/modules/WellLogViewer/view/atoms/interfaceEffects.ts
@@ -5,10 +5,10 @@ import { selectedFieldIdentAtom, wellboreHeaderAtom } from "./baseAtoms";
 
 export const settingsToViewInterfaceEffects: InterfaceEffects<SettingsToViewInterface> = [
     (getInterfaceValue, setAtomValue) => {
-        const wellboreUuid = getInterfaceValue("wellboreHeader");
+        const wellboreHeader = getInterfaceValue("wellboreHeaderStatus").header;
         const selectedField = getInterfaceValue("selectedField");
 
         setAtomValue(selectedFieldIdentAtom, selectedField);
-        setAtomValue(wellboreHeaderAtom, wellboreUuid);
+        setAtomValue(wellboreHeaderAtom, wellboreHeader);
     },
 ];

--- a/frontend/src/modules/WellLogViewer/view/view.tsx
+++ b/frontend/src/modules/WellLogViewer/view/view.tsx
@@ -24,7 +24,14 @@ export function View(props: ModuleViewProps<InterfaceTypes>) {
 
     const propagatedErrorMessage = usePropagateQueryErrorToStatusWriter(wellboreTrajectoryDataQuery, statusWriter);
 
-    statusWriter.setLoading(isLoadingWellboreHeaders || wellboreTrajectoryDataQuery.isFetching);
+    // Only treat the trajectory query's pending state as "loading" once a wellbore is actually
+    // selected; while nothing is selected the query is intentionally disabled and stays pending forever.
+    const isLoading =
+        !providerManager ||
+        isLoadingWellboreHeaders ||
+        (Boolean(selectedWellboreHeader) && wellboreTrajectoryDataQuery.isPending);
+
+    statusWriter.setLoading(isLoading);
 
     React.useEffect(
         function setModuleName() {
@@ -40,13 +47,6 @@ export function View(props: ModuleViewProps<InterfaceTypes>) {
         },
         [props.viewContext, selectedWellboreHeader?.uniqueWellboreIdentifier],
     );
-
-    // Only treat the trajectory query's pending state as "loading" once a wellbore is actually
-    // selected; while nothing is selected the query is intentionally disabled and stays pending forever.
-    const isLoading =
-        !providerManager ||
-        isLoadingWellboreHeaders ||
-        (Boolean(selectedWellboreHeader) && wellboreTrajectoryDataQuery.isPending);
 
     let infoMessage: string | undefined;
     let errorMessage: string | undefined;

--- a/frontend/src/modules/WellLogViewer/view/view.tsx
+++ b/frontend/src/modules/WellLogViewer/view/view.tsx
@@ -1,10 +1,10 @@
 import React from "react";
 
-import { CircularProgress } from "@mui/material";
 import { useAtomValue } from "jotai";
 
 import type { ModuleViewProps } from "@framework/Module";
 import { useViewStatusWriter } from "@framework/StatusWriter";
+import { StatusWrapper } from "@lib/components/StatusWrapper";
 import { usePropagateQueryErrorToStatusWriter } from "@modules/_shared/hooks/usePropagateApiErrorToStatusWriter";
 
 import type { InterfaceTypes } from "../interfaces";
@@ -15,13 +15,16 @@ import { ProviderVisualizationWrapper } from "./components/ProviderVisualization
 export function View(props: ModuleViewProps<InterfaceTypes>) {
     const statusWriter = useViewStatusWriter(props.viewContext);
     const providerManager = props.viewContext.useSettingsToViewInterfaceValue("providerManager");
-    const selectedWellboreHeader = props.viewContext.useSettingsToViewInterfaceValue("wellboreHeader");
+    const { header: selectedWellboreHeader, isLoading: isLoadingWellboreHeaders } =
+        props.viewContext.useSettingsToViewInterfaceValue("wellboreHeaderStatus");
     const horizontalLayout = props.viewContext.useSettingsToViewInterfaceValue("horizontalLayout");
     const limitDomainToData = props.viewContext.useSettingsToViewInterfaceValue("limitDomainToData");
 
     const wellboreTrajectoryDataQuery = useAtomValue(wellboreTrajectoryQueryAtom);
 
-    usePropagateQueryErrorToStatusWriter(wellboreTrajectoryDataQuery, statusWriter);
+    const propagatedErrorMessage = usePropagateQueryErrorToStatusWriter(wellboreTrajectoryDataQuery, statusWriter);
+
+    statusWriter.setLoading(isLoadingWellboreHeaders || wellboreTrajectoryDataQuery.isFetching);
 
     React.useEffect(
         function setModuleName() {
@@ -38,22 +41,37 @@ export function View(props: ModuleViewProps<InterfaceTypes>) {
         [props.viewContext, selectedWellboreHeader?.uniqueWellboreIdentifier],
     );
 
-    if (!providerManager || !wellboreTrajectoryDataQuery.data) {
-        return (
-            <div className="absolute w-full h-full z-10 bg-white opacity-50 flex items-center justify-center">
-                <CircularProgress />
-            </div>
-        );
+    // Only treat the trajectory query's pending state as "loading" once a wellbore is actually
+    // selected; while nothing is selected the query is intentionally disabled and stays pending forever.
+    const isLoading =
+        !providerManager ||
+        isLoadingWellboreHeaders ||
+        (Boolean(selectedWellboreHeader) && wellboreTrajectoryDataQuery.isPending);
+
+    let infoMessage: string | undefined;
+    let errorMessage: string | undefined;
+    if (!isLoading) {
+        if (!selectedWellboreHeader) {
+            infoMessage = "No wellbore selected.";
+        } else if (wellboreTrajectoryDataQuery.isError) {
+            errorMessage = propagatedErrorMessage ?? "Could not load wellbore trajectory data.";
+        } else if (!wellboreTrajectoryDataQuery.data) {
+            infoMessage = "No wellbore trajectory data found.";
+        }
     }
 
     return (
-        <ProviderVisualizationWrapper
-            providerManager={providerManager}
-            wellboreHeader={selectedWellboreHeader}
-            trajectoryData={wellboreTrajectoryDataQuery.data}
-            horizontal={horizontalLayout}
-            limitDomainToData={limitDomainToData}
-            moduleProps={props}
-        />
+        <StatusWrapper className="h-full" isPending={isLoading} infoMessage={infoMessage} errorMessage={errorMessage}>
+            {providerManager && selectedWellboreHeader && wellboreTrajectoryDataQuery.data && (
+                <ProviderVisualizationWrapper
+                    providerManager={providerManager}
+                    wellboreHeader={selectedWellboreHeader}
+                    trajectoryData={wellboreTrajectoryDataQuery.data}
+                    horizontal={horizontalLayout}
+                    limitDomainToData={limitDomainToData}
+                    moduleProps={props}
+                />
+            )}
+        </StatusWrapper>
     );
 }


### PR DESCRIPTION
## Summary
Several modules were conflating "data is not available yet" (still loading, or not yet applicable) with "data is unavailable" (a real error) when deciding what to show. Because a react-query result's `data` field is equally `undefined` while fetching, while disabled, and after an error, code that used `!data` as its only signal beyond `isFetching`/`isError` mislabeled the "not yet applicable" case.

## Changes
- `WellLogViewer`: the view rendered its content overlay based on whether trajectory data was present, so a disabled or failed query showed a permanent loading spinner instead of resolving to a "no wellbore selected" or error message. Fixed by driving the overlay off explicit `isPending`/`isLoading` state instead, routed through `StatusWrapper` for a consistent loading/error/info presentation. This also surfaced a related issue: the resolved wellbore header was `null` both when nothing was selected and while the wellbore list was still loading, causing a "No wellbore selected" flash on mount — the settings→view interface now carries the loading state alongside the resolved value so the view can tell the two apart.
- `FlowNetwork` , `Vfp`: the settings-side `computeDependenciesState` helpers checked `isFetching`/`isError` correctly but fell back to `!data ? "error" : "loaded"` for everything else. Since a disabled query (ensemble/realization not yet selected) also has no data, this showed a persistent, false "Error loading..." banner in the settings panel whenever nothing was selected yet, rather than clearing once loading/error are ruled out. All affected atoms in both modules (including `selectedVfpTableNameAtom`) now return `"loaded"` unconditionally once loading/error are ruled out.

---

Closes #1824.