### PR TITLE
Subsurface-viewer: Fixed incorrect controller prop when toggling panning

### DIFF
--- a/frontend/src/modules/_shared/utils/subsurfaceViewer/DeckGlInstanceManager.ts
+++ b/frontend/src/modules/_shared/utils/subsurfaceViewer/DeckGlInstanceManager.ts
@@ -99,6 +99,8 @@ export class DeckGlInstanceManager implements PublishSubscribe<DeckGlInstanceMan
     private _contextMenu: ContextMenu | null = null;
     private _verticalScale: number = 1;
 
+    private _panEnabled: boolean = true;
+
     private _hiddenViews: View[] = []; // plugin registered
     private _hiddenViewStatePatch: Record<string, any> = {};
     private _layerFilterWrappers: ((prev?: any) => any)[] = [];
@@ -150,29 +152,13 @@ export class DeckGlInstanceManager implements PublishSubscribe<DeckGlInstanceMan
     }
 
     disablePanning() {
-        if (!this._ref) {
-            return;
-        }
-
-        this._ref.deck?.setProps({
-            controller: {
-                dragPan: false,
-                dragRotate: false,
-            },
-        });
+        this._panEnabled = false;
+        this.redraw();
     }
 
     enablePanning() {
-        if (!this._ref) {
-            return;
-        }
-
-        this._ref.deck?.setProps({
-            controller: {
-                dragRotate: true,
-                dragPan: true,
-            },
-        });
+        this._panEnabled = true;
+        this.redraw();
     }
 
     getDeck() {
@@ -383,6 +369,10 @@ export class DeckGlInstanceManager implements PublishSubscribe<DeckGlInstanceMan
                 viewports: (props.views?.viewports ?? []).map((viewport) => ({
                     ...viewport,
                     layerIds: [...(viewport.layerIds ?? []), ...pluginLayerIds],
+                    controller: {
+                        dragRotate: this._panEnabled,
+                        dragPan: this._panEnabled,
+                    },
                 })),
                 layout: props.views?.layout ?? [1, 1],
             },

--- a/frontend/src/modules/_shared/utils/subsurfaceViewer/DeckGlInstanceManager.ts
+++ b/frontend/src/modules/_shared/utils/subsurfaceViewer/DeckGlInstanceManager.ts
@@ -34,11 +34,11 @@ export class DeckGlPlugin {
     }
 
     protected requestDisablePanning() {
-        this._manager.disablePanning();
+        this._manager.disableDragInteraction();
     }
 
     protected requestEnablePanning() {
-        this._manager.enablePanning();
+        this._manager.enableDragInteraction();
     }
 
     protected getFirstLayerUnderCursorInfo(x: number, y: number): PickingInfo | undefined {
@@ -99,7 +99,7 @@ export class DeckGlInstanceManager implements PublishSubscribe<DeckGlInstanceMan
     private _contextMenu: ContextMenu | null = null;
     private _verticalScale: number = 1;
 
-    private _panEnabled: boolean = true;
+    private _dragInteractionEnabled: boolean = true;
 
     private _hiddenViews: View[] = []; // plugin registered
     private _hiddenViewStatePatch: Record<string, any> = {};
@@ -151,13 +151,17 @@ export class DeckGlInstanceManager implements PublishSubscribe<DeckGlInstanceMan
         this._publishSubscribeDelegate.notifySubscribers(DeckGlInstanceManagerTopic.REDRAW);
     }
 
-    disablePanning() {
-        this._panEnabled = false;
+    disableDragInteraction() {
+        if (!this._dragInteractionEnabled) return;
+
+        this._dragInteractionEnabled = false;
         this.redraw();
     }
 
-    enablePanning() {
-        this._panEnabled = true;
+    enableDragInteraction() {
+        if (this._dragInteractionEnabled) return;
+
+        this._dragInteractionEnabled = true;
         this.redraw();
     }
 
@@ -370,8 +374,9 @@ export class DeckGlInstanceManager implements PublishSubscribe<DeckGlInstanceMan
                     ...viewport,
                     layerIds: [...(viewport.layerIds ?? []), ...pluginLayerIds],
                     controller: {
-                        dragRotate: this._panEnabled,
-                        dragPan: this._panEnabled,
+                        ...viewport.controller,
+                        dragRotate: this._dragInteractionEnabled,
+                        dragPan: this._dragInteractionEnabled,
                     },
                 })),
                 layout: props.views?.layout ?? [1, 1],
@@ -380,7 +385,7 @@ export class DeckGlInstanceManager implements PublishSubscribe<DeckGlInstanceMan
     }
 
     beforeDestroy() {
-        this.enablePanning();
+        this.enableDragInteraction();
         this.maybeRemoveKeyboardEventListeners();
     }
 }


### PR DESCRIPTION
Resolves #1836 

When toggling pan via the `DeckGlInstanceManager`, we applied the changes direction to the `deck.controller` prop, this prop is just intended as a shorthand when using a default deck.gl view; so it only applies to the *first* view. Subsurface also doesn't account for this prop, meaning the double-click zoom was forced to `true`

This PR correctly applies the panning-option to each view via `DeckGlInstanceManager.makeDeckGlComponentProps()`