### PR TITLE
Hide subsurface-viewer render progress indicator

### DIFF
--- a/frontend/src/modules/_shared/components/SubsurfaceViewer/_components/ReadoutWrapper.tsx
+++ b/frontend/src/modules/_shared/components/SubsurfaceViewer/_components/ReadoutWrapper.tsx
@@ -466,6 +466,7 @@ export function ReadoutWrapper(props: ReadoutWrapperProps): React.ReactNode {
                 views={storedDeckGlViews}
                 getCameraPosition={ctx.onViewStateChange}
                 initialCameraPosition={ctx.viewState}
+                onRenderingProgress={() => {}} // No-op; only here to suppress the render progress indicator
             >
                 {props.views.viewports.map((viewport) => (
                     // @ts-expect-error -- This class is marked as abstract, but seems to just work as is


### PR DESCRIPTION
Added no-op `onRenderProgress`callback to avoid the render progress indicator being shown